### PR TITLE
Base type for TextProperty should not be converted to bytes

### DIFF
--- a/src/google/cloud/ndb/model.py
+++ b/src/google/cloud/ndb/model.py
@@ -1997,9 +1997,9 @@ class BlobProperty(Property):
             .BadValueError: If the current property is indexed but the value
                 exceeds the maximum length (1500 bytes).
         """
-        if not isinstance(value, bytes):
+        if not isinstance(value, (str, bytes)):
             raise exceptions.BadValueError(
-                "Expected bytes, got {!r}".format(value)
+                "Expected str or bytes, got {!r}".format(value)
             )
 
         if self._indexed and len(value) > _MAX_STRING_LENGTH:
@@ -2171,11 +2171,14 @@ class TextProperty(BlobProperty):
 
         Returns:
             Optional[bytes]: The converted value. If ``value`` is a
-            :class:`str`, this will return the UTF-8 encoded bytes for it.
+            :class:`bytes`, this will return utf-8 decoded unicode string.
             Otherwise, it will return :data:`None`.
         """
-        if isinstance(value, str):
-            return value.encode("utf-8")
+        if isinstance(value, bytes):
+            try:
+                return value.decode("utf-8")
+            except UnicodeError:
+                pass
 
     def _from_base_type(self, value):
         """Convert a value from the "base" value type for this property.

--- a/src/google/cloud/ndb/model.py
+++ b/src/google/cloud/ndb/model.py
@@ -2170,15 +2170,12 @@ class TextProperty(BlobProperty):
             value (Union[bytes, str]): The value to be converted.
 
         Returns:
-            Optional[bytes]: The converted value. If ``value`` is a
-            :class:`bytes`, this will return utf-8 decoded unicode string.
-            Otherwise, it will return :data:`None`.
+            Optional[bytes]: The converted value. No conversion is required
+            here as TextProperty and StringProperty can accept both string
+            and bytes. However, this method needs to exist because of how
+            validation is done.
         """
-        if isinstance(value, bytes):
-            try:
-                return value.decode("utf-8")
-            except UnicodeError:
-                pass
+        return value
 
     def _from_base_type(self, value):
         """Convert a value from the "base" value type for this property.


### PR DESCRIPTION
* For TextProperty, just return str or bytes as is
* Fix BlobProperty._validate to accept str type so that StringProperty and TextProperty can validate during composable validation