### PR TITLE
Store strings as strings in Datastore.

### DIFF
--- a/MIGRATION_NOTES.md
+++ b/MIGRATION_NOTES.md
@@ -125,6 +125,11 @@ The primary differences come from:
   This method shouldn't generally be called by user code, anyway.
 - `Future.state` is omitted as it is redundant. Call `Future.done()` or
   `Future.running()` to get the state of a future.
+- `StringProperty` properties were previously stored as blobs
+  (entity_pb2.Value.blob_value) in Datastore. They are now properly stored as 
+  strings (entity_pb2.Value.string_value). At read time, a `StringProperty`
+  will accept either a string or blob value, so compatibility is maintained
+  with legacy databases.
 
 ## Privatization
 

--- a/src/google/cloud/ndb/model.py
+++ b/src/google/cloud/ndb/model.py
@@ -2074,7 +2074,7 @@ class BlobProperty(Property):
         raise exceptions.NoLongerImplementedError()
 
 
-class TextProperty(BlobProperty):
+class TextProperty(Property):
     """An unindexed property that contains UTF-8 encoded text values.
 
     A :class:`TextProperty` is intended for values of unlimited length, hence
@@ -2172,12 +2172,12 @@ class TextProperty(BlobProperty):
             value (Union[bytes, str]): The value to be converted.
 
         Returns:
-            Optional[bytes]: The converted value. If ``value`` is a
-            :class:`str`, this will return the UTF-8 encoded bytes for it.
+            Optional[str]: The converted value. If ``value`` is a
+            :class:`bytes`, this will return the UTF-8 decoded ``str`` for it.
             Otherwise, it will return :data:`None`.
         """
-        if isinstance(value, str):
-            return value.encode("utf-8")
+        if isinstance(value, bytes):
+            return value.decode("utf-8")
 
     def _from_base_type(self, value):
         """Convert a value from the "base" value type for this property.

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -51,17 +51,19 @@ def client_context():
 @pytest.mark.usefixtures("client_context")
 def test_retrieve_entity(ds_entity):
     entity_id = test_utils.system.unique_resource_id()
-    ds_entity("SomeKind", entity_id, foo=42, bar="none")
+    ds_entity("SomeKind", entity_id, foo=42, bar="none", baz=b"night")
 
     class SomeKind(ndb.Model):
         foo = ndb.IntegerProperty()
         bar = ndb.StringProperty()
+        baz = ndb.StringProperty()
 
     key = ndb.Key("SomeKind", entity_id)
     entity = key.get()
     assert isinstance(entity, SomeKind)
     assert entity.foo == 42
     assert entity.bar == "none"
+    assert entity.baz == "night"
 
 
 @pytest.mark.usefixtures("client_context")
@@ -136,6 +138,11 @@ def test_insert_entity():
     retrieved = key.get()
     assert retrieved.foo == 42
     assert retrieved.bar == "none"
+
+    # Make sure strings are stored as strings in datastore
+    ds_client = datastore.Client()
+    ds_entity = ds_client.get(key._key)
+    assert ds_entity["bar"] == "none"
 
 
 @pytest.mark.usefixtures("client_context")

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -1741,13 +1741,13 @@ class TestTextProperty:
     @staticmethod
     def test__to_base_type():
         prop = model.TextProperty(name="text")
-        assert prop._to_base_type(b"abc") is None
+        assert prop._to_base_type("abc") is None
 
     @staticmethod
     def test__to_base_type_converted():
         prop = model.TextProperty(name="text")
         value = "\N{snowman}"
-        assert prop._to_base_type(value) == b"\xe2\x98\x83"
+        assert prop._to_base_type(b"\xe2\x98\x83") == value
 
     @staticmethod
     def test__from_base_type():
@@ -3001,9 +3001,9 @@ class Test_entity_to_protobuf:
         assert entity_pb.properties["b"].null_value == 0
         assert pickle.loads(entity_pb.properties["c"].blob_value) == gherkin
         d_values = entity_pb.properties["d"].array_value.values
-        assert d_values[0].blob_value == b"foo"
-        assert d_values[1].blob_value == b"bar"
-        assert d_values[2].blob_value == b"baz"
+        assert d_values[0].string_value == "foo"
+        assert d_values[1].string_value == "bar"
+        assert d_values[2].string_value == "baz"
         e_values = entity_pb.properties["e"].array_value.values
         assert pickle.loads(e_values[0].blob_value) == gherkin
         assert pickle.loads(e_values[1].blob_value) == dill
@@ -3018,7 +3018,7 @@ class Test_entity_to_protobuf:
         entity = ThisKind(key="not the key", _key=key)
 
         entity_pb = model._entity_to_protobuf(entity)
-        assert entity_pb.properties["key"].blob_value == b"not the key"
+        assert entity_pb.properties["key"].string_value == "not the key"
         assert entity_pb.key.path[0].kind == "ThisKind"
         assert entity_pb.key.path[0].id == 123
 
@@ -3053,9 +3053,9 @@ class Test_entity_to_protobuf:
         assert entity_pb.properties["b"].null_value == 0
         assert pickle.loads(entity_pb.properties["c"].blob_value) == gherkin
         d_values = entity_pb.properties["d"].array_value.values
-        assert d_values[0].blob_value == b"foo"
-        assert d_values[1].blob_value == b"bar"
-        assert d_values[2].blob_value == b"baz"
+        assert d_values[0].string_value == "foo"
+        assert d_values[1].string_value == "bar"
+        assert d_values[2].string_value == "baz"
         e_values = entity_pb.properties["e"].array_value.values
         assert pickle.loads(e_values[0].blob_value) == gherkin
         assert pickle.loads(e_values[1].blob_value) == dill

--- a/tests/unit/test_polymodel.py
+++ b/tests/unit/test_polymodel.py
@@ -96,7 +96,7 @@ class TestPolyModel:
 
         assert Animal._default_filters() == ()
         assert Cat._default_filters() == (
-            query.FilterNode("class", "=", b"Cat"),
+            query.FilterNode("class", "=", "Cat"),
         )
 
     @staticmethod


### PR DESCRIPTION
Fixes issue #32.

Note that strings were not being stored as base64.
That's just how the Google Console represents binary data in the UI.
Strings were being stored as binary data, however, and that has been
fixed. Strings were also being stored as binary data in legacy NDB.
Legacy databases with strings stored as binary will still work with this
version of NDB as we can handle getting ``bytes`` or ``str`` from
``google.cloud.datastore``.