### PR TITLE
drop python 3.5 support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,6 @@ environment:
 
     # See: https://www.appveyor.com/docs/windows-images-software/#python
 
-    - NOX_SESSION: "unit-3.5"
     - NOX_SESSION: "unit-3.6"
     - NOX_SESSION: "unit-3.7"
     - NOX_SESSION: "docs"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,6 @@ jobs:
           name: Update to latest `nox`
           command: python3.7 -m pip install --upgrade nox
       - run:
-          name: Unit tests in Python 3.5
-          command: python3.7 -m nox -s unit-3.5
-      - run:
           name: Unit tests in Python 3.6
           command: python3.7 -m nox -s unit-3.6
       - run:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -9,19 +9,19 @@ Contributing
 
 .. _Faster Pull Request Reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
 
-.. contents:: Here are some guidelines for hacking on ``google-cloud-python``.
+.. contents:: Here are some guidelines for hacking on ``python-ndb``.
 
 ***************
 Adding Features
 ***************
 
-In order to add a feature to ``google-cloud-python``:
+In order to add a feature to ``python-ndb``:
 
 - The feature must be documented in both the API and narrative
   documentation (in ``docs/``).
 
-- The feature must work fully on the following CPython versions:  2.7,
-  3.4, 3.5, and 3.6 on both UNIX and Windows.
+- The feature must work fully on the following CPython versions:  3.6 and 3.7
+  on both UNIX and Windows.
 
 - The feature must not add unnecessary dependencies (where
   "unnecessary" is of course subjective, but new dependencies should
@@ -32,24 +32,24 @@ Using a Development Checkout
 ****************************
 
 You'll have to create a development environment to hack on
-``google-cloud-python``, using a Git checkout:
+``python-ndb``, using a Git checkout:
 
 - While logged into your GitHub account, navigate to the
-  ``google-cloud-python`` `repo`_ on GitHub.
+  ``python-ndb`` `repo`_ on GitHub.
 
-- Fork and clone the ``google-cloud-python`` repository to your GitHub account by
+- Fork and clone the ``python-ndb`` repository to your GitHub account by
   clicking the "Fork" button.
 
-- Clone your fork of ``google-cloud-python`` from your GitHub account to your local
+- Clone your fork of ``python-ndb`` from your GitHub account to your local
   computer, substituting your account username and specifying the destination
-  as ``hack-on-google-cloud-python``.  E.g.::
+  as ``hack-on-python-ndb``.  E.g.::
 
    $ cd ${HOME}
-   $ git clone git@github.com:USERNAME/google-cloud-python.git hack-on-google-cloud-python
-   $ cd hack-on-google-cloud-python
-   # Configure remotes such that you can pull changes from the google-cloud-python
+   $ git clone git@github.com:USERNAME/python-ndb.git hack-on-python-ndb
+   $ cd hack-on-python-ndb
+   # Configure remotes such that you can pull changes from the python-ndb
    # repository into your local repository.
-   $ git remote add upstream git@github.com:GoogleCloudPlatform/google-cloud-python.git
+   $ git remote add upstream git@github.com:googleapis/python-ndb.git
    # fetch and merge changes from upstream into master
    $ git fetch upstream
    $ git merge upstream/master
@@ -60,7 +60,7 @@ repo, from which you can submit a pull request.
 To work on the codebase and run the tests, we recommend using ``nox``,
 but you can also use a ``virtualenv`` of your own creation.
 
-.. _repo: https://github.com/GoogleCloudPlatform/google-cloud-python
+.. _repo: https://github.com/googleapis/python-ndb
 
 Using ``nox``
 =============
@@ -69,23 +69,9 @@ We use `nox <https://nox.readthedocs.io/en/latest/>`__ to instrument our tests.
 
 - To test your changes, run unit tests with ``nox``::
 
-    $ nox -f datastore/noxfile.py -s unit-2.7
-    $ nox -f datastore/noxfile.py -s unit-3.6
+    $ nox -s unit-3.7
+    $ nox -s unit-3.6
     $ ...
-
-  .. note::
-
-    The unit tests and system tests are contained in the individual
-    ``nox.py`` files in each directory; substitute ``datastore`` in the
-    example above with the package of your choice.
-
-
-  Alternatively, you can just navigate directly to the package you are
-  currently developing and run tests there::
-
-    $ export GIT_ROOT=$(pwd)
-    $ cd ${GIT_ROOT}/datastore/
-    $ nox -s "unit(py='3.6')"
 
 .. nox: https://pypi.org/project/nox-automation/
 
@@ -103,7 +89,7 @@ Note on Editable Installs / Develop Mode
   package.
 
 .. _namespace packages: https://www.python.org/dev/peps/pep-0420/
-.. _Issue #2316: https://github.com/GoogleCloudPlatform/google-cloud-python/issues/2316
+.. _Issue #2316: https://github.com/googleapis/google-cloud-python/issues/2316
 .. _PyPA issue: https://github.com/pypa/packaging-problems/issues/12
 .. _develop mode: https://setuptools.readthedocs.io/en/latest/setuptools.html#development-mode
 .. _editable install: https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs
@@ -135,8 +121,8 @@ Coding Style
    export GOOGLE_CLOUD_TESTING_BRANCH="master"
 
   By doing this, you are specifying the location of the most up-to-date
-  version of ``google-cloud-python``. The the suggested remote name ``upstream``
-  should point to the official ``GoogleCloudPlatform`` checkout and the
+  version of ``python-ndb``. The the suggested remote name ``upstream``
+  should point to the official ``googleapis`` checkout and the
   the branch should be the main branch on that remote (``master``).
 
 Exceptions to PEP8:
@@ -151,14 +137,12 @@ Running System Tests
 
 - To run system tests for a given package, you can execute::
 
-   $ nox -f datastore/noxfile.py -s system-3.6
-   $ nox -f datastore/noxfile.py -s system-2.7
+   $ nox -e system
 
   .. note::
 
-      System tests are only configured to run under Python 2.7 and
-      Python 3.6. For expediency, we do not run them in older versions
-      of Python 3.
+      System tests are only configured to run under Python 3.7. For
+      expediency, we do not run them in older versions of Python 3.
 
   This alone will not run the tests. You'll need to change some local
   auth settings and change some configuration in your project to
@@ -231,22 +215,22 @@ changed to reflect the bug fix, ideally in the same commit that fixes the bug
 or adds the feature.
 
 To build and review docs (where ``${VENV}`` refers to the virtualenv you're
-using to develop ``google-cloud-python``):
+using to develop ``python-ndb``):
 
 #. After following the steps above in "Using a Development Checkout", install
    Sphinx and all development requirements in your virtualenv::
 
-     $ cd ${HOME}/hack-on-google-cloud-python
+     $ cd ${HOME}/hack-on-python-ndb
      $ ${VENV}/bin/pip install Sphinx
 
-#. Change into the ``docs`` directory within your ``google-cloud-python`` checkout and
+#. Change into the ``docs`` directory within your ``python-ndb`` checkout and
    execute the ``make`` command with some flags::
 
-     $ cd ${HOME}/hack-on-google-cloud-python/google-cloud-python/docs
+     $ cd ${HOME}/hack-on-python-ndb/docs
      $ make clean html SPHINXBUILD=${VENV}/bin/sphinx-build
 
    The ``SPHINXBUILD=...`` argument tells Sphinx to use the virtualenv Python,
-   which will have both Sphinx and ``google-cloud-python`` (for API documentation
+   which will have both Sphinx and ``python-ndb`` (for API documentation
    generation) installed.
 
 #. Open the ``docs/_build/html/index.html`` file to see the resulting HTML
@@ -265,7 +249,7 @@ The `description on PyPI`_ for the project comes directly from the
 ``README``. Due to the reStructuredText (``rst``) parser used by
 PyPI, relative links which will work on GitHub (e.g. ``CONTRIBUTING.rst``
 instead of
-``https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/CONTRIBUTING.rst``)
+``https://github.com/googleapis/python-ndb/blob/master/CONTRIBUTING.rst``)
 may cause problems creating links or rendering the description.
 
 .. _description on PyPI: https://pypi.org/project/google-cloud/
@@ -286,43 +270,17 @@ Supported Python Versions
 
 We support:
 
--  `Python 3.4`_
--  `Python 3.5`_
 -  `Python 3.6`_
+-  `Python 3.7`_
 
-.. _Python 3.4: https://docs.python.org/3.4/
-.. _Python 3.5: https://docs.python.org/3.5/
 .. _Python 3.6: https://docs.python.org/3.6/
+.. _Python 3.7: https://docs.python.org/3.7/
 
 
 Supported versions can be found in our ``noxfile.py`` `config`_.
 
-.. _config: https://github.com/googleapis/google-cloud-python/blob/master/noxfile.py
+.. _config: https://github.com/googleapis/python-ndb/blob/master/noxfile.py
 
-We explicitly decided not to support `Python 2.5`_ due to `decreased usage`_
-and lack of continuous integration `support`_.
-
-.. _Python 2.5: https://docs.python.org/2.5/
-.. _decreased usage: https://caremad.io/2013/10/a-look-at-pypi-downloads/
-.. _support: https://blog.travis-ci.com/2013-11-18-upcoming-build-environment-updates/
-
-We have `dropped 2.6`_ as a supported version as well since Python 2.6 is no
-longer supported by the core development team.
-
-Python 2.7 support is deprecated. All code changes should maintain Python 2.7 compatibility until January 1, 2020.
-
-We also explicitly decided to support Python 3 beginning with version
-3.4. Reasons for this include:
-
--  Encouraging use of newest versions of Python 3
--  Taking the lead of `prominent`_ open-source `projects`_
--  `Unicode literal support`_ which allows for a cleaner codebase that
-   works in both Python 2 and Python 3
-
-.. _prominent: https://docs.djangoproject.com/en/1.9/faq/install/#what-python-version-can-i-use-with-django
-.. _projects: http://flask.pocoo.org/docs/0.10/python3/
-.. _Unicode literal support: https://www.python.org/dev/peps/pep-0414/
-.. _dropped 2.6: https://github.com/googleapis/google-cloud-python/issues/995
 
 **********
 Versioning

--- a/noxfile.py
+++ b/noxfile.py
@@ -25,7 +25,7 @@ LOCAL_DEPS = ("google-cloud-core", "google-api-core")
 NOX_DIR = os.path.abspath(os.path.dirname(__file__))
 DEFAULT_INTERPRETER = "3.7"
 PYPY = "pypy3"
-ALL_INTERPRETERS = ("3.5", "3.6", "3.7", PYPY)
+ALL_INTERPRETERS = ("3.6", "3.7", PYPY)
 
 
 def get_path(*names):

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ def main():
             "License :: OSI Approved :: Apache Software License",
             "Programming Language :: Python",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.5",
             "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Operating System :: OS Independent",


### PR DESCRIPTION
As discussed in PR #24, drop Python 3.5 support to make it easier to use newer language features.