### PR TITLE
Wire up queries to Datastore.

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -45,7 +45,7 @@ def unit(session):
         run_args.extend(
             [
                 "--cov=google.cloud.ndb",
-                "--cov=tests",
+                "--cov=tests.unit",
                 "--cov-config",
                 get_path(".coveragerc"),
                 "--cov-report=",

--- a/src/google/cloud/ndb/_datastore_query.py
+++ b/src/google/cloud/ndb/_datastore_query.py
@@ -92,7 +92,7 @@ def _query_to_protobuf(query):
     """
     query_args = {}
     if query.kind:
-        query_args['kind'] = [query_pb2.KindExpression(name=query.kind)]
+        query_args["kind"] = [query_pb2.KindExpression(name=query.kind)]
 
     return query_pb2.Query(**query_args)
 

--- a/src/google/cloud/ndb/_datastore_query.py
+++ b/src/google/cloud/ndb/_datastore_query.py
@@ -90,10 +90,11 @@ def _query_to_protobuf(query):
     Returns:
         query_pb2.Query: The protocol buffer representation of the query.
     """
-    query_pb = query_pb2.Query(
-        kind=[query_pb2.KindExpression(name=query.kind)]
-    )
-    return query_pb
+    query_args = {}
+    if query.kind:
+        query_args['kind'] = [query_pb2.KindExpression(name=query.kind)]
+
+    return query_pb2.Query(**query_args)
 
 
 @tasklets.tasklet

--- a/src/google/cloud/ndb/_datastore_query.py
+++ b/src/google/cloud/ndb/_datastore_query.py
@@ -1,0 +1,119 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Translate NDB queries to Datastore calls."""
+
+from google.cloud.datastore_v1.proto import datastore_pb2
+from google.cloud.datastore_v1.proto import query_pb2
+
+from google.cloud.ndb import context as context_module
+from google.cloud.ndb import _datastore_api
+from google.cloud.ndb import model
+from google.cloud.ndb import tasklets
+
+MoreResultsType = query_pb2.QueryResultBatch.MoreResultsType
+MORE_RESULTS_TYPE_NOT_FINISHED = MoreResultsType.Value("NOT_FINISHED")
+ResultType = query_pb2.EntityResult.ResultType
+RESULT_TYPE_FULL = ResultType.Value("FULL")
+
+
+@tasklets.tasklet
+def fetch(query):
+    """Fetch query results.
+
+    Args:
+        query.Query: The query.
+
+    Returns:
+        tasklets.Future: Result is List[model.Model]. The query results.
+    """
+    for name in (
+        "ancestor",
+        "filters",
+        "orders",
+        "app",
+        "namespace",
+        "default_options",
+        "projection",
+        "group_by",
+    ):
+        if getattr(query, name, None):
+            raise NotImplementedError(
+                "{} is not yet implemented for queries.".format(name))
+
+    query_pb = _query_to_protobuf(query)
+    results = yield _run_query(query_pb)
+    return [_process_result(result_type, result)
+            for result_type, result in results]
+
+
+def _process_result(result_type, result):
+    """Process a single entity result."""
+    if result_type == RESULT_TYPE_FULL:
+        return model._entity_from_protobuf(result.entity)
+
+    raise NotImplementedError(
+        "Processing for projection and key only entity results is not yet "
+        "implemented for queries.")
+
+
+def _query_to_protobuf(query):
+    """Convert an NDB query to a Datastore protocol buffer.
+
+    Args:
+        query (query.Query): The query.
+
+    Returns:
+        query_pb2.Query: The protocol buffer representation of the query.
+    """
+    query_pb = query_pb2.Query(
+        kind=[query_pb2.KindExpression(name=query.kind)],
+    )
+    return query_pb
+
+
+@tasklets.tasklet
+def _run_query(query_pb):
+    """Run a query in Datastore.
+
+    Will potentially repeat the query to get all results.
+
+    Args:
+        query_pb (query_pb2.Query): The query protocol buffer representation.
+    Returns:
+        tasklets.Future: List[Tuple[query_pb2.EntityResult.ResultType,
+            query_pb2.EntityResult]]
+    """
+    client = context_module.get_context().client
+    results = []
+
+    while True:
+        # See what results we get from the backend
+        request = datastore_pb2.RunQueryRequest(
+            project_id=client.project,
+            query=query_pb,
+        )
+        response = yield _datastore_api.make_call("RunQuery", request)
+        batch = response.batch
+        results.extend(((batch.entity_result_type, result) for result in
+                        batch.entity_results))
+
+        # Did we get all of them?
+        if batch.more_results != MORE_RESULTS_TYPE_NOT_FINISHED:
+            break
+
+        # Still some results left to fetch. Update cursors and try again.
+        query_pb.start_cursor = batch.end_cursor
+
+    return results

--- a/src/google/cloud/ndb/query.py
+++ b/src/google/cloud/ndb/query.py
@@ -1069,11 +1069,13 @@ class Query:
         """
         if limit:
             raise NotImplementedError(
-                "'limit' is not implemented yet for queries")
+                "'limit' is not implemented yet for queries"
+            )
 
         if options:
             raise NotImplementedError(
-                "'options' are not implemented yet for queries")
+                "'options' are not implemented yet for queries"
+            )
 
         return _datastore_query.fetch(self)
 

--- a/src/google/cloud/ndb/query.py
+++ b/src/google/cloud/ndb/query.py
@@ -14,6 +14,7 @@
 
 """High-level wrapper for datastore queries."""
 
+from google.cloud.ndb import _datastore_query
 from google.cloud.ndb import exceptions
 from google.cloud.ndb import model
 
@@ -1040,6 +1041,41 @@ class Query:
         modelclass = model.Model._kind_map.get(self.kind)
         if modelclass is not None:
             modelclass._check_properties(fixed, **kwargs)
+
+    def fetch(self, limit=None, **options):
+        """Run a query, fetching results.
+
+        Args:
+            limit (int): Maximum number of results to fetch. data:`None`
+                or data:`0` indicates no limit.
+            options (Dict[str, Any]): TBD.
+
+        Returns:
+            List([model.Model]): The query results.
+        """
+        return self.fetch_async(limit, **options).result()
+
+    def fetch_async(self, limit=None, **options):
+        """Run a query, asynchronously fetching the results.
+
+        Args:
+            limit (int): Maximum number of results to fetch. data:`None`
+                or data:`0` indicates no limit.
+            options (Dict[str, Any]): TBD.
+
+        Returns:
+            tasklets.Future: Eventual result will be a List[model.Model] of the
+                results.
+        """
+        if limit:
+            raise NotImplementedError(
+                "'limit' is not implemented yet for queries")
+
+        if options:
+            raise NotImplementedError(
+                "'options' are not implemented yet for queries")
+
+        return _datastore_query.fetch(self)
 
 
 def gql(*args, **kwargs):

--- a/tests/system/__init__.py
+++ b/tests/system/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+KIND = "SomeKind"

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -1,0 +1,65 @@
+import pytest
+
+from google.cloud import datastore
+from google.cloud import ndb
+
+from . import KIND
+
+
+@pytest.fixture(scope="module", autouse=True)
+def initial_clean():
+    # Make sure database is in clean state at beginning of test run
+    client = datastore.Client()
+    query = client.query(kind=KIND)
+    for entity in query.fetch():
+        client.delete(entity.key)
+
+
+@pytest.fixture
+def ds_client():
+    client = datastore.Client()
+
+    # Make sure we're leaving database as clean as we found it after each test
+    query = client.query(kind=KIND)
+    results = list(query.fetch())
+    assert not results
+
+    yield client
+
+    results = list(query.fetch())
+    assert not results
+
+
+@pytest.fixture
+def ds_entity(ds_client, dispose_of):
+    def make_entity(*key_args, **entity_kwargs):
+        key = ds_client.key(*key_args)
+        assert ds_client.get(key) is None
+        entity = datastore.Entity(key=key)
+        entity.update(entity_kwargs)
+        ds_client.put(entity)
+        dispose_of(key)
+
+        return entity
+
+    yield make_entity
+
+
+@pytest.fixture
+def dispose_of(ds_client):
+    ds_keys = []
+
+    def delete_entity(ds_key):
+        ds_keys.append(ds_key)
+
+    yield delete_entity
+
+    for ds_key in ds_keys:
+        ds_client.delete(ds_key)
+
+
+@pytest.fixture
+def client_context():
+    client = ndb.Client()
+    with client.context():
+        yield

--- a/tests/system/test_crud.py
+++ b/tests/system/test_crud.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+System tests for Create, Update, Delete. (CRUD)
+"""
+
 import pytest
 
 import test_utils.system
@@ -19,67 +23,7 @@ import test_utils.system
 from google.cloud import datastore
 from google.cloud import ndb
 
-
-KIND = "SomeKind"
-
-
-@pytest.fixture(scope="module", autouse=True)
-def initial_clean():
-    # Make sure database is in clean state at beginning of test run
-    client = datastore.Client()
-    query = client.query(kind=KIND)
-    for entity in query.fetch():
-        client.delete(entity.key)
-
-
-@pytest.fixture
-def ds_client():
-    client = datastore.Client()
-
-    # Make sure we're leaving database as clean as we found it after each test
-    query = client.query(kind=KIND)
-    results = list(query.fetch())
-    assert not results
-
-    yield client
-
-    results = list(query.fetch())
-    assert not results
-
-
-@pytest.fixture
-def ds_entity(ds_client, dispose_of):
-    def make_entity(*key_args, **entity_kwargs):
-        key = ds_client.key(*key_args)
-        assert ds_client.get(key) is None
-        entity = datastore.Entity(key=key)
-        entity.update(entity_kwargs)
-        ds_client.put(entity)
-        dispose_of(key)
-
-        return entity
-
-    yield make_entity
-
-
-@pytest.fixture
-def dispose_of(ds_client):
-    ds_keys = []
-
-    def delete_entity(ds_key):
-        ds_keys.append(ds_key)
-
-    yield delete_entity
-
-    for ds_key in ds_keys:
-        ds_client.delete(ds_key)
-
-
-@pytest.fixture
-def client_context():
-    client = ndb.Client()
-    with client.context():
-        yield
+from . import KIND
 
 
 @pytest.mark.usefixtures("client_context")

--- a/tests/system/test_query.py
+++ b/tests/system/test_query.py
@@ -1,0 +1,71 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+System tests for queries.
+"""
+
+import operator
+
+import pytest
+
+import test_utils.system
+
+from google.cloud import ndb
+
+from . import KIND
+
+
+@pytest.mark.usefixtures("client_context")
+def test_fetch_all_of_a_kind(ds_entity):
+    for i in range(5):
+        entity_id = test_utils.system.unique_resource_id()
+        ds_entity(KIND, entity_id, foo=i)
+
+    class SomeKind(ndb.Model):
+        foo = ndb.IntegerProperty()
+
+    #query = SomeKind.query()  # Not implemented yet
+    query = ndb.Query(kind=KIND)
+    results = query.fetch()
+    assert len(results) == 5
+
+    results = sorted(results, key=operator.attrgetter("foo"))
+    assert [entity.foo for entity in results] == [0, 1, 2, 3, 4]
+
+
+@pytest.mark.skip(reason="Exercises retreiving multiple batches, but is slow.")
+@pytest.mark.usefixtures("client_context")
+def test_fetch_lots_of_a_kind(dispose_of):
+    n_entities = 500
+
+    class SomeKind(ndb.Model):
+        foo = ndb.IntegerProperty()
+
+    @ndb.tasklet
+    def make_entities():
+        entities = [SomeKind(foo=i) for i in range(n_entities)]
+        keys = yield [entity.put_async() for entity in entities]
+        return keys
+
+    for key in make_entities().result():
+        dispose_of(key._key)
+
+    #query = SomeKind.query()  # Not implemented yet
+    query = ndb.Query(kind=KIND)
+    results = query.fetch()
+    assert len(results) == n_entities
+
+    results = sorted(results, key=operator.attrgetter("foo"))
+    assert [entity.foo for entity in results][:5] == [0, 1, 2, 3, 4]

--- a/tests/system/test_query.py
+++ b/tests/system/test_query.py
@@ -36,7 +36,7 @@ def test_fetch_all_of_a_kind(ds_entity):
     class SomeKind(ndb.Model):
         foo = ndb.IntegerProperty()
 
-    #query = SomeKind.query()  # Not implemented yet
+    # query = SomeKind.query()  # Not implemented yet
     query = ndb.Query(kind=KIND)
     results = query.fetch()
     assert len(results) == 5
@@ -62,7 +62,7 @@ def test_fetch_lots_of_a_kind(dispose_of):
     for key in make_entities().result():
         dispose_of(key._key)
 
-    #query = SomeKind.query()  # Not implemented yet
+    # query = SomeKind.query()  # Not implemented yet
     query = ndb.Query(kind=KIND)
     results = query.fetch()
     assert len(results) == n_entities

--- a/tests/unit/test__datastore_query.py
+++ b/tests/unit/test__datastore_query.py
@@ -1,0 +1,156 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+import pytest
+
+from google.cloud.datastore_v1.proto import query_pb2
+
+from google.cloud.ndb import _datastore_query
+from google.cloud.ndb import query as query_module
+from google.cloud.ndb import tasklets
+
+
+@pytest.mark.usefixtures("in_context")
+class Test_fetch:
+    @staticmethod
+    def test_unsupported_option():
+        query = mock.Mock(ancestor="foo")
+        tasklet = _datastore_query.fetch(query)
+        with pytest.raises(NotImplementedError):
+            tasklet.result()
+
+    @staticmethod
+    @mock.patch("google.cloud.ndb._datastore_query._process_result",
+                str.__add__)
+    @mock.patch("google.cloud.ndb._datastore_query._run_query")
+    @mock.patch("google.cloud.ndb._datastore_query._query_to_protobuf")
+    def test_success(_query_to_protobuf, _run_query):
+        query = object()
+        query_pb = _query_to_protobuf.return_value
+
+        _run_query_future = tasklets.Future()
+        _run_query.return_value = _run_query_future
+
+        tasklet = _datastore_query.fetch(query)
+        _run_query_future.set_result([("a", "b"), ("c", "d"), ("e", "f")])
+        assert tasklet.result() == ["ab", "cd", "ef"]
+
+        assert _query_to_protobuf.called_once_with(query)
+        assert _run_query.called_once_with(query_pb)
+
+
+class Test__process_result:
+    @staticmethod
+    def test_unsupported_result_type():
+        with pytest.raises(NotImplementedError):
+            _datastore_query._process_result("foo", "bar")
+
+    @staticmethod
+    @mock.patch("google.cloud.ndb._datastore_query.model")
+    def test_full_entity(model):
+        model._entity_from_protobuf.return_value = "bar"
+        result = mock.Mock(entity="foo", spec=("entity",))
+        assert _datastore_query._process_result(
+            _datastore_query.RESULT_TYPE_FULL,
+            result) == "bar"
+
+        model._entity_from_protobuf.assert_called_once_with("foo")
+
+
+class Test__query_to_protobuf:
+    @staticmethod
+    def test_kind_only():
+        query = query_module.Query(kind="Foo")
+        assert _datastore_query._query_to_protobuf(query) == query_pb2.Query(
+            kind=[query_pb2.KindExpression(name="Foo")],
+        )
+
+
+@pytest.mark.usefixtures("in_context")
+class Test__run_query:
+    @staticmethod
+    @mock.patch("google.cloud.ndb._datastore_query.datastore_pb2")
+    @mock.patch("google.cloud.ndb._datastore_query._datastore_api")
+    def test_single_batch(_datastore_api, datastore_pb2):
+        request = datastore_pb2.RunQueryRequest.return_value
+        query_pb = object()
+
+        make_call_future = tasklets.Future("RunQuery")
+        _datastore_api.make_call.return_value = make_call_future
+
+        batch = mock.Mock(
+            more_results="nope",
+            entity_result_type="this type",
+            entity_results=["foo", "bar", "baz"],
+            spec=("more_results", "entity_result_type", "entity_results"),
+        )
+
+        tasklet = _datastore_query._run_query(query_pb)
+        make_call_future.set_result(mock.Mock(batch=batch, spec=("batch",)))
+
+        assert tasklet.result() == [
+            ("this type", "foo"),
+            ("this type", "bar"),
+            ("this type", "baz"),
+        ]
+
+        datastore_pb2.RunQueryRequest.assert_called_once_with(
+            project_id="testing",
+            query=query_pb,
+        )
+        _datastore_api.make_call.assert_called_once_with("RunQuery", request)
+
+    @staticmethod
+    @mock.patch("google.cloud.ndb._datastore_query.datastore_pb2")
+    @mock.patch("google.cloud.ndb._datastore_query._datastore_api")
+    def test_double_batch(_datastore_api, datastore_pb2):
+        query_pb = mock.Mock(
+            spec=("start_cursor",),
+        )
+
+        make_call_future1 = tasklets.Future("RunQuery")
+        make_call_future2 = tasklets.Future("RunQuery")
+        _datastore_api.make_call.side_effect = (make_call_future1,
+                                                make_call_future2)
+
+        batch1 = mock.Mock(
+            more_results=_datastore_query.MORE_RESULTS_TYPE_NOT_FINISHED,
+            entity_result_type="this type",
+            entity_results=["foo"],
+            end_cursor=b"end",
+            spec=("more_results", "entity_result_type", "entity_results",
+                  "end_cursor"),
+        )
+        batch2 = mock.Mock(
+            more_results="nope",
+            entity_result_type="that type",
+            entity_results=["bar", "baz"],
+            spec=("more_results", "entity_result_type", "entity_results"),
+        )
+
+        tasklet = _datastore_query._run_query(query_pb)
+        make_call_future1.set_result(mock.Mock(batch=batch1, spec=("batch",)))
+        make_call_future2.set_result(mock.Mock(batch=batch2, spec=("batch",)))
+
+        assert tasklet.result() == [
+            ("this type", "foo"),
+            ("that type", "bar"),
+            ("that type", "baz"),
+        ]
+
+        assert datastore_pb2.RunQueryRequest.call_count == 2
+        assert _datastore_api.make_call.call_count == 2
+        assert query_pb.start_cursor == b"end"

--- a/tests/unit/test__datastore_query.py
+++ b/tests/unit/test__datastore_query.py
@@ -76,7 +76,12 @@ class Test__process_result:
 
 class Test__query_to_protobuf:
     @staticmethod
-    def test_kind_only():
+    def test_no_args():
+        query = query_module.Query()
+        assert _datastore_query._query_to_protobuf(query) == query_pb2.Query()
+
+    @staticmethod
+    def test_kind():
         query = query_module.Query(kind="Foo")
         assert _datastore_query._query_to_protobuf(query) == query_pb2.Query(
             kind=[query_pb2.KindExpression(name="Foo")]

--- a/tests/unit/test__datastore_query.py
+++ b/tests/unit/test__datastore_query.py
@@ -33,8 +33,9 @@ class Test_fetch:
             tasklet.result()
 
     @staticmethod
-    @mock.patch("google.cloud.ndb._datastore_query._process_result",
-                str.__add__)
+    @mock.patch(
+        "google.cloud.ndb._datastore_query._process_result", str.__add__
+    )
     @mock.patch("google.cloud.ndb._datastore_query._run_query")
     @mock.patch("google.cloud.ndb._datastore_query._query_to_protobuf")
     def test_success(_query_to_protobuf, _run_query):
@@ -63,9 +64,12 @@ class Test__process_result:
     def test_full_entity(model):
         model._entity_from_protobuf.return_value = "bar"
         result = mock.Mock(entity="foo", spec=("entity",))
-        assert _datastore_query._process_result(
-            _datastore_query.RESULT_TYPE_FULL,
-            result) == "bar"
+        assert (
+            _datastore_query._process_result(
+                _datastore_query.RESULT_TYPE_FULL, result
+            )
+            == "bar"
+        )
 
         model._entity_from_protobuf.assert_called_once_with("foo")
 
@@ -75,7 +79,7 @@ class Test__query_to_protobuf:
     def test_kind_only():
         query = query_module.Query(kind="Foo")
         assert _datastore_query._query_to_protobuf(query) == query_pb2.Query(
-            kind=[query_pb2.KindExpression(name="Foo")],
+            kind=[query_pb2.KindExpression(name="Foo")]
         )
 
 
@@ -108,8 +112,7 @@ class Test__run_query:
         ]
 
         datastore_pb2.RunQueryRequest.assert_called_once_with(
-            project_id="testing",
-            query=query_pb,
+            project_id="testing", query=query_pb
         )
         _datastore_api.make_call.assert_called_once_with("RunQuery", request)
 
@@ -117,22 +120,26 @@ class Test__run_query:
     @mock.patch("google.cloud.ndb._datastore_query.datastore_pb2")
     @mock.patch("google.cloud.ndb._datastore_query._datastore_api")
     def test_double_batch(_datastore_api, datastore_pb2):
-        query_pb = mock.Mock(
-            spec=("start_cursor",),
-        )
+        query_pb = mock.Mock(spec=("start_cursor",))
 
         make_call_future1 = tasklets.Future("RunQuery")
         make_call_future2 = tasklets.Future("RunQuery")
-        _datastore_api.make_call.side_effect = (make_call_future1,
-                                                make_call_future2)
+        _datastore_api.make_call.side_effect = (
+            make_call_future1,
+            make_call_future2,
+        )
 
         batch1 = mock.Mock(
             more_results=_datastore_query.MORE_RESULTS_TYPE_NOT_FINISHED,
             entity_result_type="this type",
             entity_results=["foo"],
             end_cursor=b"end",
-            spec=("more_results", "entity_result_type", "entity_results",
-                  "end_cursor"),
+            spec=(
+                "more_results",
+                "entity_result_type",
+                "entity_results",
+                "end_cursor",
+            ),
         )
         batch2 = mock.Mock(
             more_results="nope",

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -131,26 +131,40 @@ class TestParameter:
 class TestParameterizedFunction:
     @staticmethod
     def test_constructor():
-        query = query_module.ParameterizedFunction("user", query_module.Parameter(1))
+        query = query_module.ParameterizedFunction(
+            "user", query_module.Parameter(1)
+        )
         assert query.func == "user"
         assert query.values == query_module.Parameter(1)
 
     @staticmethod
     def test___repr__():
-        query = query_module.ParameterizedFunction("user", query_module.Parameter(1))
-        assert query.__repr__() == "ParameterizedFunction('user', Parameter(1))"
+        query = query_module.ParameterizedFunction(
+            "user", query_module.Parameter(1)
+        )
+        assert (
+            query.__repr__() == "ParameterizedFunction('user', Parameter(1))"
+        )
 
     @staticmethod
     def test___eq__parameter():
-        query = query_module.ParameterizedFunction("user", query_module.Parameter(1))
+        query = query_module.ParameterizedFunction(
+            "user", query_module.Parameter(1)
+        )
         assert (
-            query.__eq__(query_module.ParameterizedFunction("user", query_module.Parameter(1)))
+            query.__eq__(
+                query_module.ParameterizedFunction(
+                    "user", query_module.Parameter(1)
+                )
+            )
             is True
         )
 
     @staticmethod
     def test___eq__no_parameter():
-        query = query_module.ParameterizedFunction("user", query_module.Parameter(1))
+        query = query_module.ParameterizedFunction(
+            "user", query_module.Parameter(1)
+        )
         assert query.__eq__(42) is NotImplemented
 
 
@@ -415,7 +429,9 @@ class TestFilterNode:
 
         filter_node1 = query_module.FilterNode("a", "<", 2.5)
         filter_node2 = query_module.FilterNode("a", ">", 2.5)
-        assert or_node == query_module.DisjunctionNode(filter_node1, filter_node2)
+        assert or_node == query_module.DisjunctionNode(
+            filter_node1, filter_node2
+        )
 
     @staticmethod
     def test_pickling():
@@ -918,7 +934,9 @@ class TestQuery:
     @pytest.mark.usefixtures("in_context")
     def test_constructor_with_ancestor_parameterized_function():
         query = query_module.Query(
-            ancestor=query_module.ParameterizedFunction("key", query_module.Parameter(1))
+            ancestor=query_module.ParameterizedFunction(
+                "key", query_module.Parameter(1)
+            )
         )
         assert query.ancestor == query_module.ParameterizedFunction(
             "key", query_module.Parameter(1)
@@ -954,7 +972,9 @@ class TestQuery:
     @pytest.mark.usefixtures("in_context")
     @unittest.mock.patch("google.cloud.ndb.model.Model._check_properties")
     def test_constructor_with_projection_as_property(_check_props):
-        query = query_module.Query(kind="Foo", projection=[model.Property(name="X")])
+        query = query_module.Query(
+            kind="Foo", projection=[model.Property(name="X")]
+        )
         assert query.projection == ("X",)
         _check_props.assert_not_called()
 
@@ -965,7 +985,9 @@ class TestQuery:
         class Foo(model.Model):
             x = model.IntegerProperty()
 
-        query = query_module.Query(kind="Foo", projection=[model.Property(name="x")])
+        query = query_module.Query(
+            kind="Foo", projection=[model.Property(name="x")]
+        )
         assert query.projection == ("x",)
         _check_props.assert_called_once_with(["x"])
 
@@ -978,7 +1000,9 @@ class TestQuery:
     @staticmethod
     @pytest.mark.usefixtures("in_context")
     def test_constructor_with_filters():
-        query = query_module.Query(filters=query_module.FilterNode("f", None, None))
+        query = query_module.Query(
+            filters=query_module.FilterNode("f", None, None)
+        )
         assert isinstance(query.filters, query_module.Node)
 
     @staticmethod

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -20,49 +20,50 @@ import pytest
 from google.cloud.ndb import exceptions
 from google.cloud.ndb import key as key_module
 from google.cloud.ndb import model
-from google.cloud.ndb import query
+from google.cloud.ndb import query as query_module
+from google.cloud.ndb import tasklets
 import tests.unit.utils
 
 
 def test___all__():
-    tests.unit.utils.verify___all__(query)
+    tests.unit.utils.verify___all__(query_module)
 
 
 def test_Cursor():
-    assert query.Cursor is NotImplemented
+    assert query_module.Cursor is NotImplemented
 
 
 class TestQueryOptions:
     @staticmethod
     def test_constructor():
         with pytest.raises(NotImplementedError):
-            query.QueryOptions()
+            query_module.QueryOptions()
 
 
 class TestQueryOrder:
     @staticmethod
     def test_constructor():
         with pytest.raises(NotImplementedError):
-            query.QueryOrder()
+            query_module.QueryOrder()
 
 
 class TestRepeatedStructuredPropertyPredicate:
     @staticmethod
     def test_constructor():
         with pytest.raises(NotImplementedError):
-            query.RepeatedStructuredPropertyPredicate()
+            query_module.RepeatedStructuredPropertyPredicate()
 
 
 class TestParameterizedThing:
     @staticmethod
     def test___eq__():
-        thing = query.ParameterizedThing()
+        thing = query_module.ParameterizedThing()
         with pytest.raises(NotImplementedError):
             thing == unittest.mock.sentinel.other
 
     @staticmethod
     def test___ne__():
-        thing = query.ParameterizedThing()
+        thing = query_module.ParameterizedThing()
         with pytest.raises(NotImplementedError):
             thing != unittest.mock.sentinel.other
 
@@ -71,23 +72,23 @@ class TestParameter:
     @staticmethod
     def test_constructor():
         for key in (88, "def"):
-            parameter = query.Parameter(key)
+            parameter = query_module.Parameter(key)
             assert parameter._key == key
 
     @staticmethod
     def test_constructor_invalid():
         with pytest.raises(TypeError):
-            query.Parameter(None)
+            query_module.Parameter(None)
 
     @staticmethod
     def test___repr__():
-        parameter = query.Parameter("ghi")
+        parameter = query_module.Parameter("ghi")
         assert repr(parameter) == "Parameter('ghi')"
 
     @staticmethod
     def test___eq__():
-        parameter1 = query.Parameter("yep")
-        parameter2 = query.Parameter("nope")
+        parameter1 = query_module.Parameter("yep")
+        parameter2 = query_module.Parameter("nope")
         parameter3 = unittest.mock.sentinel.parameter
         assert parameter1 == parameter1
         assert not parameter1 == parameter2
@@ -95,8 +96,8 @@ class TestParameter:
 
     @staticmethod
     def test___ne__():
-        parameter1 = query.Parameter("yep")
-        parameter2 = query.Parameter("nope")
+        parameter1 = query_module.Parameter("yep")
+        parameter2 = query_module.Parameter("nope")
         parameter3 = unittest.mock.sentinel.parameter
         assert not parameter1 != parameter1
         assert parameter1 != parameter2
@@ -104,14 +105,14 @@ class TestParameter:
 
     @staticmethod
     def test_key():
-        parameter = query.Parameter(9000)
+        parameter = query_module.Parameter(9000)
         assert parameter.key == 9000
 
     @staticmethod
     def test_resolve():
         key = 9000
         bound_value = "resoolt"
-        parameter = query.Parameter(key)
+        parameter = query_module.Parameter(key)
         used = {}
         result = parameter.resolve({key: bound_value}, used)
         assert result == bound_value
@@ -119,7 +120,7 @@ class TestParameter:
 
     @staticmethod
     def test_resolve_missing_key():
-        parameter = query.Parameter(9000)
+        parameter = query_module.Parameter(9000)
         used = {}
         with pytest.raises(exceptions.BadArgumentError):
             parameter.resolve({}, used)
@@ -130,40 +131,40 @@ class TestParameter:
 class TestParameterizedFunction:
     @staticmethod
     def test_constructor():
-        q = query.ParameterizedFunction("user", query.Parameter(1))
-        assert q.func == "user"
-        assert q.values == query.Parameter(1)
+        query = query_module.ParameterizedFunction("user", query_module.Parameter(1))
+        assert query.func == "user"
+        assert query.values == query_module.Parameter(1)
 
     @staticmethod
     def test___repr__():
-        q = query.ParameterizedFunction("user", query.Parameter(1))
-        assert q.__repr__() == "ParameterizedFunction('user', Parameter(1))"
+        query = query_module.ParameterizedFunction("user", query_module.Parameter(1))
+        assert query.__repr__() == "ParameterizedFunction('user', Parameter(1))"
 
     @staticmethod
     def test___eq__parameter():
-        q = query.ParameterizedFunction("user", query.Parameter(1))
+        query = query_module.ParameterizedFunction("user", query_module.Parameter(1))
         assert (
-            q.__eq__(query.ParameterizedFunction("user", query.Parameter(1)))
+            query.__eq__(query_module.ParameterizedFunction("user", query_module.Parameter(1)))
             is True
         )
 
     @staticmethod
     def test___eq__no_parameter():
-        q = query.ParameterizedFunction("user", query.Parameter(1))
-        assert q.__eq__(42) is NotImplemented
+        query = query_module.ParameterizedFunction("user", query_module.Parameter(1))
+        assert query.__eq__(42) is NotImplemented
 
 
 class TestNode:
     @staticmethod
     def test_constructor():
         with pytest.raises(TypeError):
-            query.Node()
+            query_module.Node()
 
     @staticmethod
     def _make_one():
         # Bypass the intentionally broken constructor.
-        node = object.__new__(query.Node)
-        assert isinstance(node, query.Node)
+        node = object.__new__(query_module.Node)
+        assert isinstance(node, query_module.Node)
         return node
 
     def test___eq__(self):
@@ -223,8 +224,8 @@ class TestNode:
 class TestFalseNode:
     @staticmethod
     def test___eq__():
-        false_node1 = query.FalseNode()
-        false_node2 = query.FalseNode()
+        false_node1 = query_module.FalseNode()
+        false_node2 = query_module.FalseNode()
         false_node3 = unittest.mock.sentinel.false_node
         assert false_node1 == false_node1
         assert false_node1 == false_node2
@@ -232,13 +233,13 @@ class TestFalseNode:
 
     @staticmethod
     def test__to_filter():
-        false_node = query.FalseNode()
+        false_node = query_module.FalseNode()
         with pytest.raises(exceptions.BadQueryError):
             false_node._to_filter()
 
     @staticmethod
     def test__to_filter_post():
-        false_node = query.FalseNode()
+        false_node = query_module.FalseNode()
         assert false_node._to_filter(post=True) is None
 
 
@@ -246,36 +247,36 @@ class TestParameterNode:
     @staticmethod
     def test_constructor():
         prop = model.Property(name="val")
-        param = query.Parameter("abc")
-        parameter_node = query.ParameterNode(prop, "=", param)
+        param = query_module.Parameter("abc")
+        parameter_node = query_module.ParameterNode(prop, "=", param)
         assert parameter_node._prop is prop
         assert parameter_node._op == "="
         assert parameter_node._param is param
 
     @staticmethod
     def test_constructor_bad_property():
-        param = query.Parameter(11)
+        param = query_module.Parameter(11)
         with pytest.raises(TypeError):
-            query.ParameterNode(None, "!=", param)
+            query_module.ParameterNode(None, "!=", param)
 
     @staticmethod
     def test_constructor_bad_op():
         prop = model.Property(name="guitar")
-        param = query.Parameter("pick")
+        param = query_module.Parameter("pick")
         with pytest.raises(TypeError):
-            query.ParameterNode(prop, "less", param)
+            query_module.ParameterNode(prop, "less", param)
 
     @staticmethod
     def test_constructor_bad_param():
         prop = model.Property(name="california")
         with pytest.raises(TypeError):
-            query.ParameterNode(prop, "<", None)
+            query_module.ParameterNode(prop, "<", None)
 
     @staticmethod
     def test_pickling():
         prop = model.Property(name="val")
-        param = query.Parameter("abc")
-        parameter_node = query.ParameterNode(prop, "=", param)
+        param = query_module.Parameter("abc")
+        parameter_node = query_module.ParameterNode(prop, "=", param)
 
         pickled = pickle.dumps(parameter_node)
         unpickled = pickle.loads(pickled)
@@ -284,8 +285,8 @@ class TestParameterNode:
     @staticmethod
     def test___repr__():
         prop = model.Property(name="val")
-        param = query.Parameter("abc")
-        parameter_node = query.ParameterNode(prop, "=", param)
+        param = query_module.Parameter("abc")
+        parameter_node = query_module.ParameterNode(prop, "=", param)
 
         expected = "ParameterNode({!r}, '=', Parameter('abc'))".format(prop)
         assert repr(parameter_node) == expected
@@ -293,13 +294,13 @@ class TestParameterNode:
     @staticmethod
     def test___eq__():
         prop1 = model.Property(name="val")
-        param1 = query.Parameter("abc")
-        parameter_node1 = query.ParameterNode(prop1, "=", param1)
+        param1 = query_module.Parameter("abc")
+        parameter_node1 = query_module.ParameterNode(prop1, "=", param1)
         prop2 = model.Property(name="ue")
-        parameter_node2 = query.ParameterNode(prop2, "=", param1)
-        parameter_node3 = query.ParameterNode(prop1, "<", param1)
-        param2 = query.Parameter(900)
-        parameter_node4 = query.ParameterNode(prop1, "=", param2)
+        parameter_node2 = query_module.ParameterNode(prop2, "=", param1)
+        parameter_node3 = query_module.ParameterNode(prop1, "<", param1)
+        param2 = query_module.Parameter(900)
+        parameter_node4 = query_module.ParameterNode(prop1, "=", param2)
         parameter_node5 = unittest.mock.sentinel.parameter_node
 
         assert parameter_node1 == parameter_node1
@@ -311,62 +312,62 @@ class TestParameterNode:
     @staticmethod
     def test__to_filter():
         prop = model.Property(name="val")
-        param = query.Parameter("abc")
-        parameter_node = query.ParameterNode(prop, "=", param)
+        param = query_module.Parameter("abc")
+        parameter_node = query_module.ParameterNode(prop, "=", param)
         with pytest.raises(exceptions.BadArgumentError):
             parameter_node._to_filter()
 
     @staticmethod
     def test_resolve_simple():
         prop = model.Property(name="val")
-        param = query.Parameter("abc")
-        parameter_node = query.ParameterNode(prop, "=", param)
+        param = query_module.Parameter("abc")
+        parameter_node = query_module.ParameterNode(prop, "=", param)
 
         value = 67
         bindings = {"abc": value}
         used = {}
         resolved_node = parameter_node.resolve(bindings, used)
 
-        assert resolved_node == query.FilterNode("val", "=", value)
+        assert resolved_node == query_module.FilterNode("val", "=", value)
         assert used == {"abc": True}
 
     @staticmethod
     def test_resolve_with_in():
         prop = model.Property(name="val")
-        param = query.Parameter("replace")
-        parameter_node = query.ParameterNode(prop, "in", param)
+        param = query_module.Parameter("replace")
+        parameter_node = query_module.ParameterNode(prop, "in", param)
 
         value = (19, 20, 28)
         bindings = {"replace": value}
         used = {}
         resolved_node = parameter_node.resolve(bindings, used)
 
-        assert resolved_node == query.DisjunctionNode(
-            query.FilterNode("val", "=", 19),
-            query.FilterNode("val", "=", 20),
-            query.FilterNode("val", "=", 28),
+        assert resolved_node == query_module.DisjunctionNode(
+            query_module.FilterNode("val", "=", 19),
+            query_module.FilterNode("val", "=", 20),
+            query_module.FilterNode("val", "=", 28),
         )
         assert used == {"replace": True}
 
     @staticmethod
     def test_resolve_in_empty_container():
         prop = model.Property(name="val")
-        param = query.Parameter("replace")
-        parameter_node = query.ParameterNode(prop, "in", param)
+        param = query_module.Parameter("replace")
+        parameter_node = query_module.ParameterNode(prop, "in", param)
 
         value = ()
         bindings = {"replace": value}
         used = {}
         resolved_node = parameter_node.resolve(bindings, used)
 
-        assert resolved_node == query.FalseNode()
+        assert resolved_node == query_module.FalseNode()
         assert used == {"replace": True}
 
 
 class TestFilterNode:
     @staticmethod
     def test_constructor():
-        filter_node = query.FilterNode("a", ">", 9)
+        filter_node = query_module.FilterNode("a", ">", 9)
         assert filter_node._name == "a"
         assert filter_node._opsymbol == ">"
         assert filter_node._value == 9
@@ -374,51 +375,51 @@ class TestFilterNode:
     @staticmethod
     def test_constructor_with_key():
         key = key_module.Key("a", "b", app="c", namespace="d")
-        filter_node = query.FilterNode("name", "=", key)
+        filter_node = query_module.FilterNode("name", "=", key)
         assert filter_node._name == "name"
         assert filter_node._opsymbol == "="
         assert filter_node._value is key._key
 
     @staticmethod
     def test_constructor_in():
-        or_node = query.FilterNode("a", "in", ("x", "y", "z"))
+        or_node = query_module.FilterNode("a", "in", ("x", "y", "z"))
 
-        filter_node1 = query.FilterNode("a", "=", "x")
-        filter_node2 = query.FilterNode("a", "=", "y")
-        filter_node3 = query.FilterNode("a", "=", "z")
-        assert or_node == query.DisjunctionNode(
+        filter_node1 = query_module.FilterNode("a", "=", "x")
+        filter_node2 = query_module.FilterNode("a", "=", "y")
+        filter_node3 = query_module.FilterNode("a", "=", "z")
+        assert or_node == query_module.DisjunctionNode(
             filter_node1, filter_node2, filter_node3
         )
 
     @staticmethod
     def test_constructor_in_single():
-        filter_node = query.FilterNode("a", "in", [9000])
-        assert isinstance(filter_node, query.FilterNode)
+        filter_node = query_module.FilterNode("a", "in", [9000])
+        assert isinstance(filter_node, query_module.FilterNode)
         assert filter_node._name == "a"
         assert filter_node._opsymbol == "="
         assert filter_node._value == 9000
 
     @staticmethod
     def test_constructor_in_empty():
-        filter_node = query.FilterNode("a", "in", set())
-        assert isinstance(filter_node, query.FalseNode)
+        filter_node = query_module.FilterNode("a", "in", set())
+        assert isinstance(filter_node, query_module.FalseNode)
 
     @staticmethod
     def test_constructor_in_invalid_container():
         with pytest.raises(TypeError):
-            query.FilterNode("a", "in", {})
+            query_module.FilterNode("a", "in", {})
 
     @staticmethod
     def test_constructor_ne():
-        or_node = query.FilterNode("a", "!=", 2.5)
+        or_node = query_module.FilterNode("a", "!=", 2.5)
 
-        filter_node1 = query.FilterNode("a", "<", 2.5)
-        filter_node2 = query.FilterNode("a", ">", 2.5)
-        assert or_node == query.DisjunctionNode(filter_node1, filter_node2)
+        filter_node1 = query_module.FilterNode("a", "<", 2.5)
+        filter_node2 = query_module.FilterNode("a", ">", 2.5)
+        assert or_node == query_module.DisjunctionNode(filter_node1, filter_node2)
 
     @staticmethod
     def test_pickling():
-        filter_node = query.FilterNode("speed", ">=", 88)
+        filter_node = query_module.FilterNode("speed", ">=", 88)
 
         pickled = pickle.dumps(filter_node)
         unpickled = pickle.loads(pickled)
@@ -426,15 +427,15 @@ class TestFilterNode:
 
     @staticmethod
     def test___repr__():
-        filter_node = query.FilterNode("speed", ">=", 88)
+        filter_node = query_module.FilterNode("speed", ">=", 88)
         assert repr(filter_node) == "FilterNode('speed', '>=', 88)"
 
     @staticmethod
     def test___eq__():
-        filter_node1 = query.FilterNode("speed", ">=", 88)
-        filter_node2 = query.FilterNode("slow", ">=", 88)
-        filter_node3 = query.FilterNode("speed", "<=", 88)
-        filter_node4 = query.FilterNode("speed", ">=", 188)
+        filter_node1 = query_module.FilterNode("speed", ">=", 88)
+        filter_node2 = query_module.FilterNode("slow", ">=", 88)
+        filter_node3 = query_module.FilterNode("speed", "<=", 88)
+        filter_node4 = query_module.FilterNode("speed", ">=", 188)
         filter_node5 = unittest.mock.sentinel.filter_node
         assert filter_node1 == filter_node1
         assert not filter_node1 == filter_node2
@@ -444,19 +445,19 @@ class TestFilterNode:
 
     @staticmethod
     def test__to_filter_post():
-        filter_node = query.FilterNode("speed", ">=", 88)
+        filter_node = query_module.FilterNode("speed", ">=", 88)
         assert filter_node._to_filter(post=True) is None
 
     @staticmethod
     def test__to_filter_bad_op():
-        filter_node = query.FilterNode("speed", ">=", 88)
+        filter_node = query_module.FilterNode("speed", ">=", 88)
         filter_node._opsymbol = "!="
         with pytest.raises(NotImplementedError):
             filter_node._to_filter()
 
     @staticmethod
     def test__to_filter():
-        filter_node = query.FilterNode("speed", ">=", 88)
+        filter_node = query_module.FilterNode("speed", ">=", 88)
         with pytest.raises(NotImplementedError):
             filter_node._to_filter()
 
@@ -465,13 +466,13 @@ class TestPostFilterNode:
     @staticmethod
     def test_constructor():
         predicate = unittest.mock.sentinel.predicate
-        post_filter_node = query.PostFilterNode(predicate)
+        post_filter_node = query_module.PostFilterNode(predicate)
         assert post_filter_node.predicate is predicate
 
     @staticmethod
     def test_pickling():
         predicate = "must-be-pickle-able"
-        post_filter_node = query.PostFilterNode(predicate)
+        post_filter_node = query_module.PostFilterNode(predicate)
 
         pickled = pickle.dumps(post_filter_node)
         unpickled = pickle.loads(pickled)
@@ -480,15 +481,15 @@ class TestPostFilterNode:
     @staticmethod
     def test___repr__():
         predicate = "predicate-not-repr"
-        post_filter_node = query.PostFilterNode(predicate)
+        post_filter_node = query_module.PostFilterNode(predicate)
         assert repr(post_filter_node) == "PostFilterNode(predicate-not-repr)"
 
     @staticmethod
     def test___eq__():
         predicate1 = unittest.mock.sentinel.predicate1
-        post_filter_node1 = query.PostFilterNode(predicate1)
+        post_filter_node1 = query_module.PostFilterNode(predicate1)
         predicate2 = unittest.mock.sentinel.predicate2
-        post_filter_node2 = query.PostFilterNode(predicate2)
+        post_filter_node2 = query_module.PostFilterNode(predicate2)
         post_filter_node3 = unittest.mock.sentinel.post_filter_node
         assert post_filter_node1 == post_filter_node1
         assert not post_filter_node1 == post_filter_node2
@@ -497,63 +498,63 @@ class TestPostFilterNode:
     @staticmethod
     def test__to_filter_post():
         predicate = unittest.mock.sentinel.predicate
-        post_filter_node = query.PostFilterNode(predicate)
+        post_filter_node = query_module.PostFilterNode(predicate)
         assert post_filter_node._to_filter(post=True) is predicate
 
     @staticmethod
     def test__to_filter():
         predicate = unittest.mock.sentinel.predicate
-        post_filter_node = query.PostFilterNode(predicate)
+        post_filter_node = query_module.PostFilterNode(predicate)
         assert post_filter_node._to_filter() is None
 
 
 class Test_BooleanClauses:
     @staticmethod
     def test_constructor_or():
-        or_clauses = query._BooleanClauses("name", True)
+        or_clauses = query_module._BooleanClauses("name", True)
         assert or_clauses.name == "name"
         assert or_clauses.combine_or
         assert or_clauses.or_parts == []
 
     @staticmethod
     def test_constructor_and():
-        and_clauses = query._BooleanClauses("name", False)
+        and_clauses = query_module._BooleanClauses("name", False)
         assert and_clauses.name == "name"
         assert not and_clauses.combine_or
         assert and_clauses.or_parts == [[]]
 
     @staticmethod
     def test_add_node_invalid():
-        clauses = query._BooleanClauses("name", False)
+        clauses = query_module._BooleanClauses("name", False)
         with pytest.raises(TypeError):
             clauses.add_node(None)
 
     @staticmethod
     def test_add_node_or_with_simple():
-        clauses = query._BooleanClauses("name", True)
-        node = query.FilterNode("a", "=", 7)
+        clauses = query_module._BooleanClauses("name", True)
+        node = query_module.FilterNode("a", "=", 7)
         clauses.add_node(node)
         assert clauses.or_parts == [node]
 
     @staticmethod
     def test_add_node_or_with_disjunction():
-        clauses = query._BooleanClauses("name", True)
-        node1 = query.FilterNode("a", "=", 7)
-        node2 = query.FilterNode("b", ">", 7.5)
-        node3 = query.DisjunctionNode(node1, node2)
+        clauses = query_module._BooleanClauses("name", True)
+        node1 = query_module.FilterNode("a", "=", 7)
+        node2 = query_module.FilterNode("b", ">", 7.5)
+        node3 = query_module.DisjunctionNode(node1, node2)
         clauses.add_node(node3)
         assert clauses.or_parts == [node1, node2]
 
     @staticmethod
     def test_add_node_and_with_simple():
-        clauses = query._BooleanClauses("name", False)
-        node1 = query.FilterNode("a", "=", 7)
-        node2 = query.FilterNode("b", ">", 7.5)
-        node3 = query.FilterNode("c", "<", "now")
+        clauses = query_module._BooleanClauses("name", False)
+        node1 = query_module.FilterNode("a", "=", 7)
+        node2 = query_module.FilterNode("b", ">", 7.5)
+        node3 = query_module.FilterNode("c", "<", "now")
         # Modify to see the "broadcast"
         clauses.or_parts = [[node1], [node2], [node3]]
 
-        node4 = query.FilterNode("d", ">=", 80)
+        node4 = query_module.FilterNode("d", ">=", 80)
         clauses.add_node(node4)
         assert clauses.or_parts == [
             [node1, node4],
@@ -563,14 +564,14 @@ class Test_BooleanClauses:
 
     @staticmethod
     def test_add_node_and_with_conjunction():
-        clauses = query._BooleanClauses("name", False)
-        node1 = query.FilterNode("a", "=", 7)
-        node2 = query.FilterNode("b", ">", 7.5)
+        clauses = query_module._BooleanClauses("name", False)
+        node1 = query_module.FilterNode("a", "=", 7)
+        node2 = query_module.FilterNode("b", ">", 7.5)
         clauses.or_parts = [[node1], [node2]]  # Modify to see the "broadcast"
 
-        node3 = query.FilterNode("c", "<", "now")
-        node4 = query.FilterNode("d", ">=", 80)
-        node5 = query.ConjunctionNode(node3, node4)
+        node3 = query_module.FilterNode("c", "<", "now")
+        node4 = query_module.FilterNode("d", ">=", 80)
+        node5 = query_module.ConjunctionNode(node3, node4)
         clauses.add_node(node5)
         assert clauses.or_parts == [
             [node1, node3, node4],
@@ -579,14 +580,14 @@ class Test_BooleanClauses:
 
     @staticmethod
     def test_add_node_and_with_disjunction():
-        clauses = query._BooleanClauses("name", False)
-        node1 = query.FilterNode("a", "=", 7)
-        node2 = query.FilterNode("b", ">", 7.5)
+        clauses = query_module._BooleanClauses("name", False)
+        node1 = query_module.FilterNode("a", "=", 7)
+        node2 = query_module.FilterNode("b", ">", 7.5)
         clauses.or_parts = [[node1], [node2]]  # Modify to see the "broadcast"
 
-        node3 = query.FilterNode("c", "<", "now")
-        node4 = query.FilterNode("d", ">=", 80)
-        node5 = query.DisjunctionNode(node3, node4)
+        node3 = query_module.FilterNode("c", "<", "now")
+        node4 = query_module.FilterNode("d", ">=", 80)
+        node5 = query_module.DisjunctionNode(node3, node4)
         clauses.add_node(node5)
         assert clauses.or_parts == [
             [node1, node3],
@@ -600,37 +601,37 @@ class TestConjunctionNode:
     @staticmethod
     def test_constructor_no_nodes():
         with pytest.raises(TypeError):
-            query.ConjunctionNode()
+            query_module.ConjunctionNode()
 
     @staticmethod
     def test_constructor_one_node():
-        node = query.FilterNode("a", "=", 7)
-        result_node = query.ConjunctionNode(node)
+        node = query_module.FilterNode("a", "=", 7)
+        result_node = query_module.ConjunctionNode(node)
         assert result_node is node
 
     @staticmethod
     def test_constructor_many_nodes():
-        node1 = query.FilterNode("a", "=", 7)
-        node2 = query.FilterNode("b", ">", 7.5)
-        node3 = query.FilterNode("c", "<", "now")
-        node4 = query.FilterNode("d", ">=", 80)
+        node1 = query_module.FilterNode("a", "=", 7)
+        node2 = query_module.FilterNode("b", ">", 7.5)
+        node3 = query_module.FilterNode("c", "<", "now")
+        node4 = query_module.FilterNode("d", ">=", 80)
 
-        result_node = query.ConjunctionNode(node1, node2, node3, node4)
-        assert isinstance(result_node, query.ConjunctionNode)
+        result_node = query_module.ConjunctionNode(node1, node2, node3, node4)
+        assert isinstance(result_node, query_module.ConjunctionNode)
         assert result_node._nodes == [node1, node2, node3, node4]
 
     @staticmethod
     def test_constructor_convert_or():
-        node1 = query.FilterNode("a", "=", 7)
-        node2 = query.FilterNode("b", ">", 7.5)
-        node3 = query.DisjunctionNode(node1, node2)
-        node4 = query.FilterNode("d", ">=", 80)
+        node1 = query_module.FilterNode("a", "=", 7)
+        node2 = query_module.FilterNode("b", ">", 7.5)
+        node3 = query_module.DisjunctionNode(node1, node2)
+        node4 = query_module.FilterNode("d", ">=", 80)
 
-        result_node = query.ConjunctionNode(node3, node4)
-        assert isinstance(result_node, query.DisjunctionNode)
+        result_node = query_module.ConjunctionNode(node3, node4)
+        assert isinstance(result_node, query_module.DisjunctionNode)
         assert result_node._nodes == [
-            query.ConjunctionNode(node1, node4),
-            query.ConjunctionNode(node2, node4),
+            query_module.ConjunctionNode(node1, node4),
+            query_module.ConjunctionNode(node2, node4),
         ]
 
     @staticmethod
@@ -641,11 +642,11 @@ class TestConjunctionNode:
         )
         boolean_clauses.return_value = clauses
 
-        node1 = query.FilterNode("a", "=", 7)
-        node2 = query.FilterNode("b", ">", 7.5)
+        node1 = query_module.FilterNode("a", "=", 7)
+        node2 = query_module.FilterNode("b", ">", 7.5)
 
         with pytest.raises(RuntimeError):
-            query.ConjunctionNode(node1, node2)
+            query_module.ConjunctionNode(node1, node2)
 
         boolean_clauses.assert_called_once_with(
             "ConjunctionNode", combine_or=False
@@ -657,9 +658,9 @@ class TestConjunctionNode:
 
     @staticmethod
     def test_pickling():
-        node1 = query.FilterNode("a", "=", 7)
-        node2 = query.FilterNode("b", ">", 7.5)
-        and_node = query.ConjunctionNode(node1, node2)
+        node1 = query_module.FilterNode("a", "=", 7)
+        node2 = query_module.FilterNode("b", ">", 7.5)
+        and_node = query_module.ConjunctionNode(node1, node2)
 
         pickled = pickle.dumps(and_node)
         unpickled = pickle.loads(pickled)
@@ -667,29 +668,29 @@ class TestConjunctionNode:
 
     @staticmethod
     def test___iter__():
-        node1 = query.FilterNode("a", "=", 7)
-        node2 = query.FilterNode("b", ">", 7.5)
-        and_node = query.ConjunctionNode(node1, node2)
+        node1 = query_module.FilterNode("a", "=", 7)
+        node2 = query_module.FilterNode("b", ">", 7.5)
+        and_node = query_module.ConjunctionNode(node1, node2)
 
         assert list(and_node) == and_node._nodes
 
     @staticmethod
     def test___repr__():
-        node1 = query.FilterNode("a", "=", 7)
-        node2 = query.FilterNode("b", ">", 7.5)
-        and_node = query.ConjunctionNode(node1, node2)
+        node1 = query_module.FilterNode("a", "=", 7)
+        node2 = query_module.FilterNode("b", ">", 7.5)
+        and_node = query_module.ConjunctionNode(node1, node2)
         expected = "AND(FilterNode('a', '=', 7), FilterNode('b', '>', 7.5))"
         assert repr(and_node) == expected
 
     @staticmethod
     def test___eq__():
-        filter_node1 = query.FilterNode("a", "=", 7)
-        filter_node2 = query.FilterNode("b", ">", 7.5)
-        filter_node3 = query.FilterNode("c", "<", "now")
+        filter_node1 = query_module.FilterNode("a", "=", 7)
+        filter_node2 = query_module.FilterNode("b", ">", 7.5)
+        filter_node3 = query_module.FilterNode("c", "<", "now")
 
-        and_node1 = query.ConjunctionNode(filter_node1, filter_node2)
-        and_node2 = query.ConjunctionNode(filter_node2, filter_node1)
-        and_node3 = query.ConjunctionNode(filter_node1, filter_node3)
+        and_node1 = query_module.ConjunctionNode(filter_node1, filter_node2)
+        and_node2 = query_module.ConjunctionNode(filter_node2, filter_node1)
+        and_node3 = query_module.ConjunctionNode(filter_node1, filter_node3)
         and_node4 = unittest.mock.sentinel.and_node
 
         assert and_node1 == and_node1
@@ -699,20 +700,20 @@ class TestConjunctionNode:
 
     @staticmethod
     def test__to_filter_empty():
-        node1 = query.FilterNode("a", "=", 7)
-        node2 = query.FilterNode("b", "<", 6)
-        and_node = query.ConjunctionNode(node1, node2)
+        node1 = query_module.FilterNode("a", "=", 7)
+        node2 = query_module.FilterNode("b", "<", 6)
+        and_node = query_module.ConjunctionNode(node1, node2)
 
         as_filter = and_node._to_filter(post=True)
         assert as_filter is None
 
     @staticmethod
     def test__to_filter_single():
-        node1 = unittest.mock.Mock(spec=query.FilterNode)
-        node2 = query.PostFilterNode("predicate")
-        node3 = unittest.mock.Mock(spec=query.FilterNode)
+        node1 = unittest.mock.Mock(spec=query_module.FilterNode)
+        node2 = query_module.PostFilterNode("predicate")
+        node3 = unittest.mock.Mock(spec=query_module.FilterNode)
         node3._to_filter.return_value = False
-        and_node = query.ConjunctionNode(node1, node2, node3)
+        and_node = query_module.ConjunctionNode(node1, node2, node3)
 
         as_filter = and_node._to_filter()
         assert as_filter is node1._to_filter.return_value
@@ -721,55 +722,55 @@ class TestConjunctionNode:
 
     @staticmethod
     def test__to_filter_multiple():
-        node1 = query.PostFilterNode("predicate1")
-        node2 = query.PostFilterNode("predicate2")
-        and_node = query.ConjunctionNode(node1, node2)
+        node1 = query_module.PostFilterNode("predicate1")
+        node2 = query_module.PostFilterNode("predicate2")
+        and_node = query_module.ConjunctionNode(node1, node2)
 
         with pytest.raises(NotImplementedError):
             and_node._to_filter(post=True)
 
     @staticmethod
     def test__post_filters_empty():
-        node1 = query.FilterNode("a", "=", 7)
-        node2 = query.FilterNode("b", ">", 77)
-        and_node = query.ConjunctionNode(node1, node2)
+        node1 = query_module.FilterNode("a", "=", 7)
+        node2 = query_module.FilterNode("b", ">", 77)
+        and_node = query_module.ConjunctionNode(node1, node2)
 
         post_filters_node = and_node._post_filters()
         assert post_filters_node is None
 
     @staticmethod
     def test__post_filters_single():
-        node1 = query.FilterNode("a", "=", 7)
-        node2 = query.PostFilterNode("predicate2")
-        and_node = query.ConjunctionNode(node1, node2)
+        node1 = query_module.FilterNode("a", "=", 7)
+        node2 = query_module.PostFilterNode("predicate2")
+        and_node = query_module.ConjunctionNode(node1, node2)
 
         post_filters_node = and_node._post_filters()
         assert post_filters_node is node2
 
     @staticmethod
     def test__post_filters_multiple():
-        node1 = query.FilterNode("a", "=", 7)
-        node2 = query.PostFilterNode("predicate2")
-        node3 = query.PostFilterNode("predicate3")
-        and_node = query.ConjunctionNode(node1, node2, node3)
+        node1 = query_module.FilterNode("a", "=", 7)
+        node2 = query_module.PostFilterNode("predicate2")
+        node3 = query_module.PostFilterNode("predicate3")
+        and_node = query_module.ConjunctionNode(node1, node2, node3)
 
         post_filters_node = and_node._post_filters()
-        assert post_filters_node == query.ConjunctionNode(node2, node3)
+        assert post_filters_node == query_module.ConjunctionNode(node2, node3)
 
     @staticmethod
     def test__post_filters_same():
-        node1 = query.PostFilterNode("predicate1")
-        node2 = query.PostFilterNode("predicate2")
-        and_node = query.ConjunctionNode(node1, node2)
+        node1 = query_module.PostFilterNode("predicate1")
+        node2 = query_module.PostFilterNode("predicate2")
+        and_node = query_module.ConjunctionNode(node1, node2)
 
         post_filters_node = and_node._post_filters()
         assert post_filters_node is and_node
 
     @staticmethod
     def test_resolve():
-        node1 = query.FilterNode("a", "=", 7)
-        node2 = query.FilterNode("b", ">", 77)
-        and_node = query.ConjunctionNode(node1, node2)
+        node1 = query_module.FilterNode("a", "=", 7)
+        node2 = query_module.FilterNode("b", ">", 77)
+        and_node = query_module.ConjunctionNode(node1, node2)
 
         bindings = {}
         used = {}
@@ -781,17 +782,17 @@ class TestConjunctionNode:
 
     @staticmethod
     def test_resolve_changed():
-        node1 = unittest.mock.Mock(spec=query.FilterNode)
-        node2 = query.FilterNode("b", ">", 77)
-        node3 = query.FilterNode("c", "=", 7)
+        node1 = unittest.mock.Mock(spec=query_module.FilterNode)
+        node2 = query_module.FilterNode("b", ">", 77)
+        node3 = query_module.FilterNode("c", "=", 7)
         node1.resolve.return_value = node3
-        and_node = query.ConjunctionNode(node1, node2)
+        and_node = query_module.ConjunctionNode(node1, node2)
 
         bindings = {}
         used = {}
         resolved_node = and_node.resolve(bindings, used)
 
-        assert isinstance(resolved_node, query.ConjunctionNode)
+        assert isinstance(resolved_node, query_module.ConjunctionNode)
         assert resolved_node._nodes == [node3, node2]
         assert bindings == {}
         assert used == {}
@@ -802,30 +803,30 @@ class TestDisjunctionNode:
     @staticmethod
     def test_constructor_no_nodes():
         with pytest.raises(TypeError):
-            query.DisjunctionNode()
+            query_module.DisjunctionNode()
 
     @staticmethod
     def test_constructor_one_node():
-        node = query.FilterNode("a", "=", 7)
-        result_node = query.DisjunctionNode(node)
+        node = query_module.FilterNode("a", "=", 7)
+        result_node = query_module.DisjunctionNode(node)
         assert result_node is node
 
     @staticmethod
     def test_constructor_many_nodes():
-        node1 = query.FilterNode("a", "=", 7)
-        node2 = query.FilterNode("b", ">", 7.5)
-        node3 = query.FilterNode("c", "<", "now")
-        node4 = query.FilterNode("d", ">=", 80)
+        node1 = query_module.FilterNode("a", "=", 7)
+        node2 = query_module.FilterNode("b", ">", 7.5)
+        node3 = query_module.FilterNode("c", "<", "now")
+        node4 = query_module.FilterNode("d", ">=", 80)
 
-        result_node = query.DisjunctionNode(node1, node2, node3, node4)
-        assert isinstance(result_node, query.DisjunctionNode)
+        result_node = query_module.DisjunctionNode(node1, node2, node3, node4)
+        assert isinstance(result_node, query_module.DisjunctionNode)
         assert result_node._nodes == [node1, node2, node3, node4]
 
     @staticmethod
     def test_pickling():
-        node1 = query.FilterNode("a", "=", 7)
-        node2 = query.FilterNode("b", ">", 7.5)
-        or_node = query.DisjunctionNode(node1, node2)
+        node1 = query_module.FilterNode("a", "=", 7)
+        node2 = query_module.FilterNode("b", ">", 7.5)
+        or_node = query_module.DisjunctionNode(node1, node2)
 
         pickled = pickle.dumps(or_node)
         unpickled = pickle.loads(pickled)
@@ -833,29 +834,29 @@ class TestDisjunctionNode:
 
     @staticmethod
     def test___iter__():
-        node1 = query.FilterNode("a", "=", 7)
-        node2 = query.FilterNode("b", ">", 7.5)
-        or_node = query.DisjunctionNode(node1, node2)
+        node1 = query_module.FilterNode("a", "=", 7)
+        node2 = query_module.FilterNode("b", ">", 7.5)
+        or_node = query_module.DisjunctionNode(node1, node2)
 
         assert list(or_node) == or_node._nodes
 
     @staticmethod
     def test___repr__():
-        node1 = query.FilterNode("a", "=", 7)
-        node2 = query.FilterNode("b", ">", 7.5)
-        or_node = query.DisjunctionNode(node1, node2)
+        node1 = query_module.FilterNode("a", "=", 7)
+        node2 = query_module.FilterNode("b", ">", 7.5)
+        or_node = query_module.DisjunctionNode(node1, node2)
         expected = "OR(FilterNode('a', '=', 7), FilterNode('b', '>', 7.5))"
         assert repr(or_node) == expected
 
     @staticmethod
     def test___eq__():
-        filter_node1 = query.FilterNode("a", "=", 7)
-        filter_node2 = query.FilterNode("b", ">", 7.5)
-        filter_node3 = query.FilterNode("c", "<", "now")
+        filter_node1 = query_module.FilterNode("a", "=", 7)
+        filter_node2 = query_module.FilterNode("b", ">", 7.5)
+        filter_node3 = query_module.FilterNode("c", "<", "now")
 
-        or_node1 = query.DisjunctionNode(filter_node1, filter_node2)
-        or_node2 = query.DisjunctionNode(filter_node2, filter_node1)
-        or_node3 = query.DisjunctionNode(filter_node1, filter_node3)
+        or_node1 = query_module.DisjunctionNode(filter_node1, filter_node2)
+        or_node2 = query_module.DisjunctionNode(filter_node2, filter_node1)
+        or_node3 = query_module.DisjunctionNode(filter_node1, filter_node3)
         or_node4 = unittest.mock.sentinel.or_node
 
         assert or_node1 == or_node1
@@ -865,9 +866,9 @@ class TestDisjunctionNode:
 
     @staticmethod
     def test_resolve():
-        node1 = query.FilterNode("a", "=", 7)
-        node2 = query.FilterNode("b", ">", 77)
-        or_node = query.DisjunctionNode(node1, node2)
+        node1 = query_module.FilterNode("a", "=", 7)
+        node2 = query_module.FilterNode("b", ">", 77)
+        or_node = query_module.DisjunctionNode(node1, node2)
 
         bindings = {}
         used = {}
@@ -879,17 +880,17 @@ class TestDisjunctionNode:
 
     @staticmethod
     def test_resolve_changed():
-        node1 = unittest.mock.Mock(spec=query.FilterNode)
-        node2 = query.FilterNode("b", ">", 77)
-        node3 = query.FilterNode("c", "=", 7)
+        node1 = unittest.mock.Mock(spec=query_module.FilterNode)
+        node2 = query_module.FilterNode("b", ">", 77)
+        node3 = query_module.FilterNode("c", "=", 7)
         node1.resolve.return_value = node3
-        or_node = query.DisjunctionNode(node1, node2)
+        or_node = query_module.DisjunctionNode(node1, node2)
 
         bindings = {}
         used = {}
         resolved_node = or_node.resolve(bindings, used)
 
-        assert isinstance(resolved_node, query.DisjunctionNode)
+        assert isinstance(resolved_node, query_module.DisjunctionNode)
         assert resolved_node._nodes == [node3, node2]
         assert bindings == {}
         assert used == {}
@@ -897,64 +898,64 @@ class TestDisjunctionNode:
 
 
 def test_AND():
-    assert query.AND is query.ConjunctionNode
+    assert query_module.AND is query_module.ConjunctionNode
 
 
 def test_OR():
-    assert query.OR is query.DisjunctionNode
+    assert query_module.OR is query_module.DisjunctionNode
 
 
 class TestQuery:
     @staticmethod
     def test_constructor():
-        q = query.Query(kind="Foo")
-        assert q.kind == "Foo"
-        assert q.ancestor is None
-        assert q.filters is None
-        assert q.orders is None
+        query = query_module.Query(kind="Foo")
+        assert query.kind == "Foo"
+        assert query.ancestor is None
+        assert query.filters is None
+        assert query.orders is None
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
     def test_constructor_with_ancestor_parameterized_function():
-        q = query.Query(
-            ancestor=query.ParameterizedFunction("key", query.Parameter(1))
+        query = query_module.Query(
+            ancestor=query_module.ParameterizedFunction("key", query_module.Parameter(1))
         )
-        assert q.ancestor == query.ParameterizedFunction(
-            "key", query.Parameter(1)
+        assert query.ancestor == query_module.ParameterizedFunction(
+            "key", query_module.Parameter(1)
         )
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
     def test_constructor_with_ancestor_and_app():
         key = key_module.Key("a", "b", app="app")
-        q = query.Query(ancestor=key, app="app")
-        assert q.app == "app"
+        query = query_module.Query(ancestor=key, app="app")
+        assert query.app == "app"
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
     def test_constructor_with_ancestor_and_namespace():
         key = key_module.Key("a", "b", namespace="space")
-        q = query.Query(ancestor=key, namespace="space")
-        assert q.namespace == "space"
+        query = query_module.Query(ancestor=key, namespace="space")
+        assert query.namespace == "space"
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
     def test_constructor_with_ancestor_parameterized_thing():
-        q = query.Query(ancestor=query.ParameterizedThing())
-        assert isinstance(q.ancestor, query.ParameterizedThing)
+        query = query_module.Query(ancestor=query_module.ParameterizedThing())
+        assert isinstance(query.ancestor, query_module.ParameterizedThing)
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
     def test_constructor_with_projection():
-        q = query.Query(kind="Foo", projection=["X"])
-        assert q.projection == ("X",)
+        query = query_module.Query(kind="Foo", projection=["X"])
+        assert query.projection == ("X",)
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
     @unittest.mock.patch("google.cloud.ndb.model.Model._check_properties")
     def test_constructor_with_projection_as_property(_check_props):
-        q = query.Query(kind="Foo", projection=[model.Property(name="X")])
-        assert q.projection == ("X",)
+        query = query_module.Query(kind="Foo", projection=[model.Property(name="X")])
+        assert query.projection == ("X",)
         _check_props.assert_not_called()
 
     @staticmethod
@@ -964,70 +965,103 @@ class TestQuery:
         class Foo(model.Model):
             x = model.IntegerProperty()
 
-        q = query.Query(kind="Foo", projection=[model.Property(name="x")])
-        assert q.projection == ("x",)
+        query = query_module.Query(kind="Foo", projection=[model.Property(name="x")])
+        assert query.projection == ("x",)
         _check_props.assert_called_once_with(["x"])
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
     def test_constructor_with_group_by():
-        q = query.Query(kind="Foo", group_by=["X"])
-        assert q.group_by == ("X",)
+        query = query_module.Query(kind="Foo", group_by=["X"])
+        assert query.group_by == ("X",)
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
     def test_constructor_with_filters():
-        q = query.Query(filters=query.FilterNode("f", None, None))
-        assert isinstance(q.filters, query.Node)
+        query = query_module.Query(filters=query_module.FilterNode("f", None, None))
+        assert isinstance(query.filters, query_module.Node)
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
     def test_constructor_with_orders():
-        q = query.Query(orders=[])
-        assert q.orders == []
+        query = query_module.Query(orders=[])
+        assert query.orders == []
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
     def test_query_errors():
         with pytest.raises(TypeError):
-            query.Query(
-                ancestor=query.ParameterizedFunction(
-                    "user", query.Parameter(1)
+            query_module.Query(
+                ancestor=query_module.ParameterizedFunction(
+                    "user", query_module.Parameter(1)
                 )
             )
         with pytest.raises(TypeError):
-            query.Query(ancestor=42)
+            query_module.Query(ancestor=42)
         with pytest.raises(ValueError):
-            query.Query(ancestor=model.Key("Kind", None))
+            query_module.Query(ancestor=model.Key("Kind", None))
         with pytest.raises(TypeError):
-            query.Query(ancestor=model.Key("Kind", 1), app="another")
+            query_module.Query(ancestor=model.Key("Kind", 1), app="another")
         with pytest.raises(TypeError):
-            query.Query(ancestor=model.Key("X", 1), namespace="another")
+            query_module.Query(ancestor=model.Key("X", 1), namespace="another")
         with pytest.raises(TypeError):
-            query.Query(filters=42)
+            query_module.Query(filters=42)
         with pytest.raises(TypeError):
-            query.Query(orders=42)
+            query_module.Query(orders=42)
         # with pytest.raises(TypeError):
-        #     query.Query(default_options=42)
+        #     query_module.Query(default_options=42)
         with pytest.raises(TypeError):
-            query.Query(projection="")
+            query_module.Query(projection="")
         with pytest.raises(TypeError):
-            query.Query(projection=42)
+            query_module.Query(projection=42)
         with pytest.raises(TypeError):
-            query.Query(projection=[42])
+            query_module.Query(projection=[42])
         with pytest.raises(TypeError):
-            query.Query(group_by="")
+            query_module.Query(group_by="")
         with pytest.raises(TypeError):
-            query.Query(group_by=42)
+            query_module.Query(group_by=42)
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    @unittest.mock.patch("google.cloud.ndb.query._datastore_query")
+    def test_fetch_async(_datastore_query):
+        future = tasklets.Future("fetch")
+        _datastore_query.fetch.return_value = future
+        query = query_module.Query()
+        assert query.fetch_async() is future
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test_fetch_async_with_limit():
+        query = query_module.Query()
+        with pytest.raises(NotImplementedError):
+            query.fetch_async(limit=20)
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test_fetch_async_with_options():
+        query = query_module.Query()
+        with pytest.raises(NotImplementedError):
+            query.fetch_async(foo="bar")
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    @unittest.mock.patch("google.cloud.ndb.query._datastore_query")
+    def test_fetch(_datastore_query):
+        future = tasklets.Future("fetch")
+        future.set_result("foo")
+        _datastore_query.fetch.return_value = future
+        query = query_module.Query()
+        assert query.fetch() == "foo"
 
 
 def test_gql():
     with pytest.raises(NotImplementedError):
-        query.gql()
+        query_module.gql()
 
 
 class TestQueryIterator:
     @staticmethod
     def test_constructor():
         with pytest.raises(NotImplementedError):
-            query.QueryIterator()
+            query_module.QueryIterator()


### PR DESCRIPTION
This is the bare minimum necessary to run the simplest query possible:
all of the entities of a given kind.