### PR TITLE
Implement group_by for queries.

### DIFF
--- a/src/google/cloud/ndb/_datastore_query.py
+++ b/src/google/cloud/ndb/_datastore_query.py
@@ -40,13 +40,7 @@ def fetch(query):
     Returns:
         tasklets.Future: Result is List[model.Model]: The query results.
     """
-    for name in (
-        "filters",
-        "orders",
-        "namespace",
-        "default_options",
-        "group_by",
-    ):
+    for name in ("filters", "orders", "namespace", "default_options"):
         if getattr(query, name, None):
             raise NotImplementedError(
                 "{} is not yet implemented for queries.".format(name)
@@ -113,6 +107,11 @@ def _query_to_protobuf(query):
                 property=query_pb2.PropertyReference(name=name)
             )
             for name in query.projection
+        ]
+
+    if query.group_by:
+        query_args["distinct_on"] = [
+            query_pb2.PropertyReference(name=name) for name in query.group_by
         ]
 
     filters = []

--- a/tests/system/test_query.py
+++ b/tests/system/test_query.py
@@ -113,3 +113,27 @@ def test_projection(ds_entity):
     assert results[1].foo == 21
     with pytest.raises(ndb.UnprojectedPropertyError):
         results[1].bar
+
+
+@pytest.mark.usefixtures("client_context")
+def test_distinct_on(ds_entity):
+    for i in range(6):
+        entity_id = test_utils.system.unique_resource_id()
+        ds_entity(KIND, entity_id, foo=i % 2, bar="none")
+
+    class SomeKind(ndb.Model):
+        foo = ndb.IntegerProperty()
+        bar = ndb.StringProperty()
+
+    # query = ndb.Query(kind=KIND, distinct_on=("foo",))  # TODO
+    query = ndb.Query(kind=KIND, group_by=("foo",))
+    results = query.fetch()
+    assert len(results) == 2
+
+    results = sorted(results, key=operator.attrgetter("foo"))
+
+    assert results[0].foo == 0
+    assert results[0].bar == "none"
+
+    assert results[1].foo == 1
+    assert results[1].bar == "none"

--- a/tests/unit/test__datastore_query.py
+++ b/tests/unit/test__datastore_query.py
@@ -166,6 +166,17 @@ class Test__query_to_protobuf:
         )
         assert _datastore_query._query_to_protobuf(query) == expected_pb
 
+    @staticmethod
+    def test_distinct_on():
+        query = query_module.Query(group_by=("a", "b"))
+        expected_pb = query_pb2.Query(
+            distinct_on=[
+                query_pb2.PropertyReference(name="a"),
+                query_pb2.PropertyReference(name="b"),
+            ]
+        )
+        assert _datastore_query._query_to_protobuf(query) == expected_pb
+
 
 @pytest.mark.usefixtures("in_context")
 class Test__run_query:


### PR DESCRIPTION
Datastore has renamed `group_by` to `distinct_on`. I think, for consistency, we should do the same and leave `group_by` as an optional synonym for `distinct_on` for backwards compatibility. I didn't want to do that now, with #46 pending, as I'd probably just create conflicts. One of us can do it after both of these are merged.