### PR TITLE
Implement ``Model.query``.

### DIFF
--- a/src/google/cloud/ndb/_datastore_query.py
+++ b/src/google/cloud/ndb/_datastore_query.py
@@ -98,7 +98,7 @@ def fetch(query):
     """
     client = context_module.get_context().client
 
-    project_id = query.app
+    project_id = query.project
     if not project_id:
         project_id = client.project
 

--- a/src/google/cloud/ndb/model.py
+++ b/src/google/cloud/ndb/model.py
@@ -3973,6 +3973,83 @@ class Model(metaclass=MetaModel):
 
     put_async = _put_async
 
+    @classmethod
+    def _query(
+        cls,
+        *filters,
+        distinct=False,
+        ancestor=None,
+        order_by=None,
+        orders=None,
+        project=None,
+        app=None,
+        namespace=None,
+        projection=None,
+        distinct_on=None,
+        group_by=None,
+    ):
+        """Generate a query for this class.
+
+        Args:
+            *filters (query.FilterNode): Filters to apply to this query.
+            distinct (Optional[bool]): Setting this to :data:`True` is
+                shorthand for setting `distinct_on` to `projection`.
+            ancestor (key.Key): Entities returned will be descendants of
+                `ancestor`.
+            order_by (list[Union[str, google.cloud.ndb.model.Property]]):
+                The model properties used to order query results.
+            orders (list[Union[str, google.cloud.ndb.model.Property]]):
+                Deprecated. Synonym for `order_by`.
+            project (str): The project to perform the query in. Also known as
+                the app, in Google App Engine. If not passed, uses the
+                client's value.
+            app (str): Deprecated. Synonym for `project`.
+            namespace (str): The namespace to which to restrict results.
+                If not passed, uses the client's value.
+            projection (list[str]): The fields to return as part of the
+                query results.
+            distinct_on (list[str]): The field names used to group query
+                results.
+            group_by (list[str]): Deprecated. Synonym for distinct_on.
+        """
+        # Validating distinct
+        if distinct:
+            if distinct_on:
+                raise TypeError(
+                    "Cannot use `distinct` and `distinct_on` together."
+                )
+
+            if group_by:
+                raise TypeError(
+                    "Cannot use `distinct` and `group_by` together."
+                )
+
+            if not projection:
+                raise TypeError("Cannot use `distinct` without `projection`.")
+
+            distinct_on = projection
+
+        # Avoid circular import
+        from google.cloud.ndb import query as query_module
+
+        query = query_module.Query(
+            kind=cls._get_kind(),
+            ancestor=ancestor,
+            order_by=order_by,
+            orders=orders,
+            project=project,
+            app=app,
+            namespace=namespace,
+            projection=projection,
+            distinct_on=distinct_on,
+            group_by=group_by,
+        )
+        query = query.filter(*cls._default_filters())
+        query = query.filter(*filters)
+        return query
+
+    query = _query
+
 
 class Expando(Model):
     __slots__ = ()

--- a/tests/system/test_query.py
+++ b/tests/system/test_query.py
@@ -36,8 +36,7 @@ def test_fetch_all_of_a_kind(ds_entity):
     class SomeKind(ndb.Model):
         foo = ndb.IntegerProperty()
 
-    # query = SomeKind.query()  # Not implemented yet
-    query = ndb.Query(kind=KIND)
+    query = SomeKind.query()
     results = query.fetch()
     assert len(results) == 5
 
@@ -61,8 +60,7 @@ def test_fetch_lots_of_a_kind(dispose_of):
     for key in make_entities().result():
         dispose_of(key._key)
 
-    # query = SomeKind.query()  # Not implemented yet
-    query = ndb.Query(kind=KIND)
+    query = SomeKind.query()
     results = query.fetch()
     assert len(results) == n_entities
 
@@ -84,7 +82,7 @@ def test_ancestor_query(ds_entity):
     class SomeKind(ndb.Model):
         foo = ndb.IntegerProperty()
 
-    query = ndb.Query(ancestor=ndb.Key(KIND, root_id))
+    query = SomeKind.query(ancestor=ndb.Key(KIND, root_id))
     results = query.fetch()
     assert len(results) == 6
 
@@ -103,7 +101,7 @@ def test_projection(ds_entity):
         foo = ndb.IntegerProperty()
         bar = ndb.StringProperty()
 
-    query = ndb.Query(kind=KIND, projection=("foo",))
+    query = SomeKind.query(projection=("foo",))
     results = query.fetch()
     assert len(results) == 2
 
@@ -128,7 +126,7 @@ def test_distinct_on(ds_entity):
         foo = ndb.IntegerProperty()
         bar = ndb.StringProperty()
 
-    query = ndb.Query(kind=KIND, distinct_on=("foo",))
+    query = SomeKind.query(distinct_on=("foo",))
     results = query.fetch()
     assert len(results) == 2
 
@@ -155,7 +153,7 @@ def test_namespace(dispose_of):
     entity2.put()
     dispose_of(entity2.key._key)
 
-    query = ndb.Query(kind=KIND, namespace=OTHER_NAMESPACE)
+    query = SomeKind.query(namespace=OTHER_NAMESPACE)
     results = query.fetch()
     assert len(results) == 1
 
@@ -173,8 +171,7 @@ def test_filter_equal(ds_entity):
     class SomeKind(ndb.Model):
         foo = ndb.IntegerProperty()
 
-    # query = SomeKind.query()  # Not implemented yet
-    query = ndb.Query(kind=KIND).filter(SomeKind.foo == 2)
+    query = SomeKind.query(SomeKind.foo == 2)
     results = query.fetch()
     assert len(results) == 1
     assert results[0].foo == 2
@@ -189,8 +186,7 @@ def test_filter_not_equal(ds_entity):
     class SomeKind(ndb.Model):
         foo = ndb.IntegerProperty()
 
-    # query = SomeKind.query()  # Not implemented yet
-    query = ndb.Query(kind=KIND).filter(SomeKind.foo != 2)
+    query = SomeKind.query(SomeKind.foo != 2)
     results = query.fetch()
     assert len(results) == 4
 
@@ -215,9 +211,7 @@ def test_filter_or(dispose_of):
             dispose_of(key._key)
 
     make_entities().check_success()
-    query = ndb.Query(kind=KIND).filter(
-        ndb.OR(SomeKind.foo == 1, SomeKind.bar == "c")
-    )
+    query = SomeKind.query(ndb.OR(SomeKind.foo == 1, SomeKind.bar == "c"))
     results = query.fetch()
     assert len(results) == 2
 
@@ -234,8 +228,7 @@ def test_order_by_ascending(ds_entity):
     class SomeKind(ndb.Model):
         foo = ndb.IntegerProperty()
 
-    # query = SomeKind.query()  # Not implemented yet
-    query = ndb.Query(kind=KIND).order(SomeKind.foo)
+    query = SomeKind.query().order(SomeKind.foo)
     results = query.fetch()
     assert len(results) == 5
 
@@ -252,7 +245,7 @@ def test_order_by_descending(ds_entity):
         foo = ndb.IntegerProperty()
 
     # query = SomeKind.query()  # Not implemented yet
-    query = ndb.Query(kind=KIND).order(-SomeKind.foo)
+    query = SomeKind.query().order(-SomeKind.foo)
     results = query.fetch()
     assert len(results) == 5
 
@@ -283,9 +276,7 @@ def test_order_by_with_or_filter(dispose_of):
             dispose_of(key._key)
 
     make_entities().check_success()
-    query = ndb.Query(kind=KIND).filter(
-        ndb.OR(SomeKind.bar == "a", SomeKind.bar == "b")
-    )
+    query = SomeKind.query(ndb.OR(SomeKind.bar == "a", SomeKind.bar == "b"))
     query = query.order(SomeKind.foo)
     results = query.fetch()
     assert len(results) == 4

--- a/tests/unit/test__datastore_query.py
+++ b/tests/unit/test__datastore_query.py
@@ -68,7 +68,7 @@ class Test_fetch:
     @mock.patch("google.cloud.ndb._datastore_query._query_to_protobuf")
     def test_project_from_query(_query_to_protobuf, _run_query):
         query = mock.Mock(
-            app="myapp",
+            project="myapp",
             filters=None,
             order_by=None,
             namespace="zeta",
@@ -96,7 +96,7 @@ class Test_fetch:
     @mock.patch("google.cloud.ndb._datastore_query._query_to_protobuf")
     def test_project_from_context(_query_to_protobuf, _run_query, in_context):
         query = mock.Mock(
-            app=None,
+            project=None,
             filters=None,
             order_by=None,
             namespace=None,
@@ -127,7 +127,7 @@ class Test_fetch:
             _to_filter=mock.Mock(return_value="thefilter"), spec="_to_filter"
         )
         query = mock.Mock(
-            app=None,
+            project=None,
             filters=filters,
             order_by=None,
             namespace=None,
@@ -163,7 +163,7 @@ class Test_fetch:
             spec="_to_filter",
         )
         query = mock.Mock(
-            app=None,
+            project=None,
             filters=filters,
             order_by=None,
             namespace=None,

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -1009,6 +1009,11 @@ class TestQuery:
         assert query.order_by is None
 
     @staticmethod
+    def test_constructor_app_and_project():
+        with pytest.raises(TypeError):
+            query_module.Query(app="foo", project="bar")
+
+    @staticmethod
     @pytest.mark.usefixtures("in_context")
     def test_constructor_with_ancestor_parameterized_function():
         query = query_module.Query(
@@ -1022,10 +1027,10 @@ class TestQuery:
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
-    def test_constructor_with_ancestor_and_app():
+    def test_constructor_with_ancestor_and_project():
         key = key_module.Key("a", "b", app="app")
-        query = query_module.Query(ancestor=key, app="app")
-        assert query.app == "app"
+        query = query_module.Query(ancestor=key, project="app")
+        assert query.project == "app"
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
@@ -1183,7 +1188,7 @@ class TestQuery:
             order_by=[],
         )
         rep = (
-            "Query(app='app', namespace='space', kind='Foo', ancestor="
+            "Query(project='app', namespace='space', kind='Foo', ancestor="
             "Key('a', 'b', app='app', namespace='space'), filters="
             "FilterNode('f', None, None), order_by=[], projection=['x'], "
             "distinct_on=['X'], default_options=QueryOptions(kind='Bar'))"


### PR DESCRIPTION
This seems to have been missed when originally stubbing out ``Model``.

Took the opportunity to attempt to normalize the signatures of this
method and the ``Query`` constructor so they are largely the same. Part
of this involves moving away from catchall ``**options`` style arguments
and explicitly naming all potential arguments, as discussed in the
Hangout.

Also took this opportunity to start phasing out ``app`` in favor of
``project``. (See #2.)