### PR TITLE
Remove ``query.QueryOrder``.

### DIFF
--- a/src/google/cloud/ndb/query.py
+++ b/src/google/cloud/ndb/query.py
@@ -22,7 +22,6 @@ from google.cloud.ndb import model
 __all__ = [
     "Cursor",
     "QueryOptions",
-    "QueryOrder",
     "PropertyOrder",
     "RepeatedStructuredPropertyPredicate",
     "ParameterizedThing",
@@ -93,13 +92,6 @@ class QueryOptions:
             ]
         )
         return "QueryOptions({})".format(options)
-
-
-class QueryOrder:
-    __slots__ = ()
-
-    def __init__(self, *args, **kwargs):
-        raise NotImplementedError
 
 
 class PropertyOrder(object):

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -64,13 +64,6 @@ class TestQueryOptions:
         assert options.__repr__() == representation
 
 
-class TestQueryOrder:
-    @staticmethod
-    def test_constructor():
-        with pytest.raises(NotImplementedError):
-            query_module.QueryOrder()
-
-
 class TestPropertyOrder:
     @staticmethod
     def test_constructor():


### PR DESCRIPTION
It wasn't in Legacy NDB, it wasn't implemented here, and it looks like
we aren't going to use it.