### PR TITLE
Namespace management

### DIFF
--- a/src/google/cloud/ndb/key.py
+++ b/src/google/cloud/ndb/key.py
@@ -137,7 +137,7 @@ class Key:
 
         from unittest import mock
         from google.cloud.ndb import context as context_module
-        client = mock.Mock(project="testing", spec=("project",))
+        client = mock.Mock(project="testing", spec=("project",), namespace="")
         context = context_module.Context(client, stub=mock.Mock(spec=())).use()
         context.__enter__()
         kind1, id1 = "Parent", "C"
@@ -274,6 +274,11 @@ class Key:
     def __new__(cls, *path_args, **kwargs):
         _constructor_handle_positional(path_args, kwargs)
         instance = super(Key, cls).__new__(cls)
+        # Make sure to pass in the namespace if it's not explicitly set.
+        if "namespace" not in kwargs:
+            client = context_module.get_context().client
+            if client.namespace:
+                kwargs["namespace"] = client.namespace
         if (
             "reference" in kwargs
             or "serialized" in kwargs

--- a/src/google/cloud/ndb/model.py
+++ b/src/google/cloud/ndb/model.py
@@ -20,7 +20,7 @@
     from google.cloud import ndb
     from google.cloud.ndb import context as context_module
 
-    client = mock.Mock(project="testing", spec=("project",))
+    client = mock.Mock(project="testing", spec=("project",), namespace="")
     context = context_module.Context(client, stub=mock.Mock(spec=())).use()
     context.__enter__()
 

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -104,7 +104,12 @@ def dispose_of(ds_client, to_delete):
 
 
 @pytest.fixture
-def client_context():
-    client = ndb.Client()
+def namespace():
+    return ""
+
+
+@pytest.fixture
+def client_context(namespace):
+    client = ndb.Client(namespace=namespace)
     with client.context():
         yield

--- a/tests/system/test_metadata.py
+++ b/tests/system/test_metadata.py
@@ -230,6 +230,36 @@ def test_get_properties_of_kind(dispose_of):
 
 
 @pytest.mark.usefixtures("client_context")
+@pytest.mark.parametrize("namespace", ["DiffNamespace"])
+def test_get_properties_of_kind_different_namespace(dispose_of, namespace):
+    from google.cloud.ndb.metadata import get_properties_of_kind
+
+    class AnyKind(ndb.Model):
+        foo = ndb.IntegerProperty()
+        bar = ndb.StringProperty()
+        baz = ndb.IntegerProperty()
+        qux = ndb.StringProperty()
+
+    entity1 = AnyKind(
+        foo=1, bar="x", baz=3, qux="y", namespace="DiffNamespace"
+    )
+    entity1.put()
+    dispose_of(entity1.key._key)
+
+    properties = get_properties_of_kind("AnyKind")
+    assert properties == ["bar", "baz", "foo", "qux"]
+
+    properties = get_properties_of_kind("AnyKind", start="c")
+    assert properties == ["foo", "qux"]
+
+    properties = get_properties_of_kind("AnyKind", end="e")
+    assert properties == ["bar", "baz"]
+
+    properties = get_properties_of_kind("AnyKind", start="c", end="p")
+    assert properties == ["foo"]
+
+
+@pytest.mark.usefixtures("client_context")
 def test_get_representations_of_kind(dispose_of):
     from google.cloud.ndb.metadata import get_representations_of_kind
 

--- a/tests/unit/test_key.py
+++ b/tests/unit/test_key.py
@@ -45,6 +45,18 @@ class TestKey:
         assert key._reference is None
 
     @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test_constructor_with_different_namespace(context):
+        context.client.namespace = "DiffNamespace"
+        key = key_module.Key("Kind", 42)
+
+        assert key._key == google.cloud.datastore.Key(
+            "Kind", 42, project="testing", namespace="DiffNamespace"
+        )
+        assert key._reference is None
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
     def test_constructor_empty_path():
         with pytest.raises(TypeError):
             key_module.Key(pairs=())
@@ -63,6 +75,7 @@ class TestKey:
         assert key._reference is None
 
     @staticmethod
+    @pytest.mark.usefixtures("in_context")
     def test_constructor_invalid_id_type():
         with pytest.raises(TypeError):
             key_module.Key("Kind", object())
@@ -70,6 +83,7 @@ class TestKey:
             key_module.Key("Kind", None, "Also", 10)
 
     @staticmethod
+    @pytest.mark.usefixtures("in_context")
     def test_constructor_invalid_kind_type():
         with pytest.raises(TypeError):
             key_module.Key(object(), 47)
@@ -89,6 +103,7 @@ class TestKey:
         assert key._reference is None
 
     @staticmethod
+    @pytest.mark.usefixtures("in_context")
     def test_constructor_with_reference():
         reference = make_reference()
         key = key_module.Key(reference=reference)
@@ -104,6 +119,7 @@ class TestKey:
         assert key._reference is reference
 
     @staticmethod
+    @pytest.mark.usefixtures("in_context")
     def test_constructor_with_serialized():
         serialized = (
             b"j\x18s~sample-app-no-locationr\n\x0b\x12\x04Zorp\x18X\x0c"
@@ -119,6 +135,7 @@ class TestKey:
             namespace=None,
         )
 
+    @pytest.mark.usefixtures("in_context")
     def test_constructor_with_urlsafe(self):
         key = key_module.Key(urlsafe=self.URLSAFE)
 
@@ -152,11 +169,13 @@ class TestKey:
         assert key._reference is None
 
     @staticmethod
+    @pytest.mark.usefixtures("in_context")
     def test_constructor_with_flat_and_pairs():
         with pytest.raises(TypeError):
             key_module.Key(pairs=[("Kind", 1)], flat=["Kind", 1])
 
     @staticmethod
+    @pytest.mark.usefixtures("in_context")
     def test_constructor_with_app():
         key = key_module.Key("Kind", 10, app="s~foo")
 
@@ -175,6 +194,7 @@ class TestKey:
         )
         assert key._reference is None
 
+    @pytest.mark.usefixtures("in_context")
     def test_constructor_with_parent(self):
         parent = key_module.Key(urlsafe=self.URLSAFE)
         key = key_module.Key("Zip", 10, parent=parent)
@@ -184,16 +204,19 @@ class TestKey:
         )
         assert key._reference is None
 
+    @pytest.mark.usefixtures("in_context")
     def test_constructor_with_parent_bad_type(self):
         parent = unittest.mock.sentinel.parent
         with pytest.raises(exceptions.BadValueError):
             key_module.Key("Zip", 10, parent=parent)
 
     @staticmethod
+    @pytest.mark.usefixtures("in_context")
     def test_constructor_insufficient_args():
         with pytest.raises(TypeError):
             key_module.Key(app="foo")
 
+    @pytest.mark.usefixtures("in_context")
     def test_no_subclass_for_reference(self):
         class KeySubclass(key_module.Key):
             pass
@@ -202,10 +225,12 @@ class TestKey:
             KeySubclass(urlsafe=self.URLSAFE)
 
     @staticmethod
+    @pytest.mark.usefixtures("in_context")
     def test_invalid_argument_combination():
         with pytest.raises(TypeError):
             key_module.Key(flat=["a", "b"], urlsafe=b"foo")
 
+    @pytest.mark.usefixtures("in_context")
     def test_colliding_reference_arguments(self):
         urlsafe = self.URLSAFE
         padding = b"=" * (-len(urlsafe) % 4)
@@ -390,6 +415,7 @@ class TestKey:
         assert key.namespace() == namespace
 
     @staticmethod
+    @pytest.mark.usefixtures("in_context")
     def test_app():
         app = "s~example"
         key = key_module.Key("X", 100, app=app)
@@ -452,6 +478,7 @@ class TestKey:
         assert key.kind() == "c"
 
     @staticmethod
+    @pytest.mark.usefixtures("in_context")
     def test_reference():
         key = key_module.Key("This", "key", app="fire")
         assert key.reference() == make_reference(
@@ -466,6 +493,7 @@ class TestKey:
         assert key.reference() is unittest.mock.sentinel.reference
 
     @staticmethod
+    @pytest.mark.usefixtures("in_context")
     def test_reference_bad_kind():
         too_long = "a" * (key_module._MAX_KEYPART_BYTES + 1)
         for kind in ("", too_long):
@@ -474,6 +502,7 @@ class TestKey:
                 key.reference()
 
     @staticmethod
+    @pytest.mark.usefixtures("in_context")
     def test_reference_bad_string_id():
         too_long = "a" * (key_module._MAX_KEYPART_BYTES + 1)
         for id_ in ("", too_long):
@@ -482,6 +511,7 @@ class TestKey:
                 key.reference()
 
     @staticmethod
+    @pytest.mark.usefixtures("in_context")
     def test_reference_bad_integer_id():
         for id_ in (-10, 0, 2 ** 64):
             key = key_module.Key("kind", id_, app="app")
@@ -489,11 +519,13 @@ class TestKey:
                 key.reference()
 
     @staticmethod
+    @pytest.mark.usefixtures("in_context")
     def test_serialized():
         key = key_module.Key("a", 108, app="c")
         assert key.serialized() == b"j\x01cr\x07\x0b\x12\x01a\x18l\x0c"
 
     @staticmethod
+    @pytest.mark.usefixtures("in_context")
     def test_urlsafe():
         key = key_module.Key("d", None, app="f")
         assert key.urlsafe() == b"agFmcgULEgFkDA"

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -2992,6 +2992,7 @@ class TestModel:
 
 class Test_entity_from_protobuf:
     @staticmethod
+    @pytest.mark.usefixtures("in_context")
     def test_standard_case():
         class ThisKind(model.Model):
             a = model.IntegerProperty()
@@ -3048,6 +3049,7 @@ class Test_entity_from_protobuf:
 
 class Test_entity_to_protobuf:
     @staticmethod
+    @pytest.mark.usefixtures("in_context")
     def test_standard_case():
         class ThisKind(model.Model):
             a = model.IntegerProperty()
@@ -3084,6 +3086,7 @@ class Test_entity_to_protobuf:
         assert "__key__" not in entity_pb.properties
 
     @staticmethod
+    @pytest.mark.usefixtures("in_context")
     def test_property_named_key():
         class ThisKind(model.Model):
             key = model.StringProperty()
@@ -3097,6 +3100,7 @@ class Test_entity_to_protobuf:
         assert entity_pb.key.path[0].id == 123
 
     @staticmethod
+    @pytest.mark.usefixtures("in_context")
     def test_override_property():
         class ThatKind(model.Model):
             a = model.StringProperty()


### PR DESCRIPTION
The Key constructor was not taking into account the current client namespace, which resulted in mismatched namespaces or incorrect ancestors in queries where keys are created and passed in as arguments.