### PR TITLE
Fix system tests

### DIFF
--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -53,32 +53,11 @@ def ds_client(namespace, to_delete, deleted_keys):
         client.delete_multi(to_delete)
         deleted_keys.update(to_delete)
 
-    # Datastore takes some time to delete entities even after it says it's
-    # deleted them. (With Firestore using the Datastore interface, an entity is
-    # deleted when you get a return from a call to delete.) Keep checking for
-    # up to 2 minutes.
-    deadline = time.time() + 120
-    while True:
-        results = list(all_entities(client))
-        print(results)
-        if not results:
-            # all clean, yeah
-            break
-
-        # Make sure we're only waiting on entities that have been deleted
-        not_deleted = [
-            entity for entity in results if entity.key not in deleted_keys
-        ]
-        assert not not_deleted
-
-        # How are we doing on time?
-        assert (
-            time.time() < deadline
-        ), "Entities taking too long to delete: {}".format(results)
-
-        # Give Datastore a second to find a consistent state before checking
-        # again
-        time.sleep(1)
+    not_deleted = [
+        entity for entity in all_entities(client)
+        if entity.key not in deleted_keys
+    ]
+    assert not not_deleted
 
 
 @pytest.fixture

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -1,5 +1,4 @@
 import itertools
-import time
 import uuid
 
 import pytest

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -54,7 +54,8 @@ def ds_client(namespace, to_delete, deleted_keys):
         deleted_keys.update(to_delete)
 
     not_deleted = [
-        entity for entity in all_entities(client)
+        entity
+        for entity in all_entities(client)
         if entity.key not in deleted_keys
     ]
     assert not not_deleted


### PR DESCRIPTION
Based on #65. 

The big advantage of using the random namespace is we can assume that entities we've asked Datastore to delete will, in fact, be deleted at some point in the future, but we don't have to wait for them anymore.