### PR TITLE
Query housecleaning.

### DIFF
--- a/MIGRATION_NOTES.md
+++ b/MIGRATION_NOTES.md
@@ -153,7 +153,7 @@ The primary differences come from:
   `google.cloud.ndb.metadata.EntityGroup` and
   `google.cloud.ndb.metadata.get_entity_group_version` both throw a
   `google.cloud.ndb.exceptions.NoLongerImplementedError` exception when used.
-- The `batch_size` and `prefetch_size` argumnets to `Query.fetch` and
+- The `batch_size` and `prefetch_size` arguments to `Query.fetch` and
   `Query.fetch_async` are no longer supported. These were passed through
   directly to Datastore, which no longer supports these options.
 

--- a/MIGRATION_NOTES.md
+++ b/MIGRATION_NOTES.md
@@ -153,6 +153,9 @@ The primary differences come from:
   `google.cloud.ndb.metadata.EntityGroup` and
   `google.cloud.ndb.metadata.get_entity_group_version` both throw a
   `google.cloud.ndb.exceptions.NoLongerImplementedError` exception when used.
+- The `batch_size` and `prefetch_size` argumnets to `Query.fetch` and
+  `Query.fetch_async` are no longer supported. These were passed through
+  directly to Datastore, which no longer supports these options.
 
 ## Privatization
 

--- a/MIGRATION_NOTES.md
+++ b/MIGRATION_NOTES.md
@@ -171,6 +171,8 @@ facing, private API:
   and is no longer among top level exports.
 - `tasklets.MultiFuture` has been renamed to `tasklets._MultiFuture`, removed
   from top level exports, and has a much simpler interface.
+- `Query.run_to_queue` is no longer implemented. Appears to be aimed at
+  internal usage, despite being nominally public.
 
 ## Bare Metal
 

--- a/tests/system/__init__.py
+++ b/tests/system/__init__.py
@@ -12,5 +12,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
+
 KIND = "SomeKind"
 OTHER_NAMESPACE = "other-namespace"
+
+
+def eventually(predicate, timeout=30, interval=1):
+    """Runs `predicate` in a loop, hoping for eventual success.
+
+    Some things we're trying to test in Datastore are eventually
+    consistent—we'll write something to the Datastore and can read back out
+    data, eventually. This is particularly true for metadata, where we can
+    write an entity to Datastore and it takes some amount of time for metadata
+    about the entity's "kind" to update to match the new data just written,
+    which can be challenging for system testing.
+
+    With `eventually`, you can pass in a callable `predicate` which can tell us
+    whether the Datastore is now in a consistent state, at least for the piece
+    we're trying to test. This function will call the predicate repeatedly in a
+    loop until it either returns `True` or `timeout` is exceeded.
+
+    Args:
+        predicate (Callable[[], bool]): A function to be called. A return value
+            of `True` indicates a consistent state and will cause `eventually`
+            to return so execution can proceed in the calling context.
+        timeout (float): Time in seconds to wait for predicate to return
+            `True`. After this amount of time, `eventually` will return
+            regardless of `predicate` return value.
+        interval (float): Time in seconds to wait in between invocations of
+            `predicate`.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            break
+        time.sleep(interval)

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -1502,6 +1502,17 @@ class TestQuery:
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
+    @unittest.mock.patch("google.cloud.ndb.query._datastore_query")
+    def test_fetch_async_with_limit_as_positional_arg(_datastore_query):
+        query = query_module.Query()
+        response = _datastore_query.fetch.return_value
+        assert query.fetch_async(20) is response
+        _datastore_query.fetch.assert_called_once_with(
+            query_module.QueryOptions(limit=20)
+        )
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
     def test_fetch_async_with_batch_size():
         query = query_module.Query()
         with pytest.raises(NotImplementedError):
@@ -1558,6 +1569,96 @@ class TestQuery:
         _datastore_query.fetch.return_value = future
         query = query_module.Query()
         assert query.fetch() == "foo"
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    @unittest.mock.patch("google.cloud.ndb.query._datastore_query")
+    def test_fetch_with_limit_as_positional_arg(_datastore_query):
+        future = tasklets.Future("fetch")
+        future.set_result("foo")
+        _datastore_query.fetch.return_value = future
+        query = query_module.Query()
+        assert query.fetch(20) == "foo"
+        _datastore_query.fetch.assert_called_once_with(
+            query_module.QueryOptions(limit=20)
+        )
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test_run_to_queue():
+        query = query_module.Query()
+        with pytest.raises(NotImplementedError):
+            query.run_to_queue("foo", "bar")
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test_iter():
+        query = query_module.Query()
+        with pytest.raises(NotImplementedError):
+            query.iter()
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test___iter__():
+        query = query_module.Query()
+        with pytest.raises(NotImplementedError):
+            iter(query)
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test_map():
+        query = query_module.Query()
+        with pytest.raises(NotImplementedError):
+            query.map(None)
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test_map_async():
+        query = query_module.Query()
+        with pytest.raises(NotImplementedError):
+            query.map_async(None)
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test_get():
+        query = query_module.Query()
+        with pytest.raises(NotImplementedError):
+            query.get(None)
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test_get_async():
+        query = query_module.Query()
+        with pytest.raises(NotImplementedError):
+            query.get_async(None)
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test_count():
+        query = query_module.Query()
+        with pytest.raises(NotImplementedError):
+            query.count(None)
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test_count_async():
+        query = query_module.Query()
+        with pytest.raises(NotImplementedError):
+            query.count_async(None)
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test_fetch_page():
+        query = query_module.Query()
+        with pytest.raises(NotImplementedError):
+            query.fetch_page(None)
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test_fetch_page_async():
+        query = query_module.Query()
+        with pytest.raises(NotImplementedError):
+            query.fetch_page_async(None)
 
 
 def test_gql():


### PR DESCRIPTION
State intent to not implement the `batch_size` and `prefetch_size`
attributes, as well as the `run_to_queue` method.

Fix the `fetch` and `fetch_async` method signatures to match legacy.
(`limit` can be passed as a single positional arg.)

Stub out remaining `Query` methods, so it's easier to see what remains
to be done.