### PR TITLE
EventLoop and tasklets refactor.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,9 +24,16 @@ from unittest import mock
 
 from google.cloud import environment_vars
 from google.cloud.ndb import context as context_module
+from google.cloud.ndb import _eventloop
 from google.cloud.ndb import model
 
 import pytest
+
+
+class TestingEventLoop(_eventloop.EventLoop):
+    def call_soon(self, callback, *args, **kwargs):
+        """For testing, call the callback immediately."""
+        callback(*args, **kwargs)
 
 
 @pytest.fixture(autouse=True)
@@ -76,7 +83,9 @@ def context():
     client = mock.Mock(
         project="testing", namespace=None, spec=("project", "namespace")
     )
-    context = context_module.Context(client, stub=mock.Mock(spec=()))
+    context = context_module.Context(
+        client, stub=mock.Mock(spec=()), eventloop=TestingEventLoop()
+    )
     return context
 
 

--- a/tests/unit/test__datastore_api.py
+++ b/tests/unit/test__datastore_api.py
@@ -764,7 +764,8 @@ class Test__TransactionalCommitBatch:
         rpc = tasklets.Future("_datastore_commit")
         datastore_commit.return_value = rpc
 
-        eventloop = mock.Mock(spec=("queue_rpc", "run"))
+        eventloop = mock.Mock(spec=("queue_rpc", "run", "call_soon"))
+        eventloop.call_soon = lambda f, *args, **kwargs: f(*args, **kwargs)
         with in_context.new(eventloop=eventloop).use():
             future = batch.commit()
 
@@ -788,7 +789,8 @@ class Test__TransactionalCommitBatch:
         rpc = tasklets.Future("_datastore_commit")
         datastore_commit.return_value = rpc
 
-        eventloop = mock.Mock(spec=("queue_rpc", "run"))
+        eventloop = mock.Mock(spec=("queue_rpc", "run", "call_soon"))
+        eventloop.call_soon = lambda f, *args, **kwargs: f(*args, **kwargs)
         with in_context.new(eventloop=eventloop).use():
             future = batch.commit()
 
@@ -824,7 +826,8 @@ class Test__TransactionalCommitBatch:
         rpc = tasklets.Future("_datastore_commit")
         datastore_commit.return_value = rpc
 
-        eventloop = mock.Mock(spec=("queue_rpc", "run"))
+        eventloop = mock.Mock(spec=("queue_rpc", "run", "call_soon"))
+        eventloop.call_soon = lambda f, *args, **kwargs: f(*args, **kwargs)
         with in_context.new(eventloop=eventloop).use():
             future = batch.commit()
 


### PR DESCRIPTION
It was found, through working query iterators, that when a TaskletFuture
calls ``_advance_tasklet`` in its done callback, if it calls it
directly, we can get a really deep call stack that eventually reaches
the limit for maximum recursion. This refactors that to add the
``_advance_tasklet`` call to the eventloop to be run soon, rather than
calling it directly, which fixes this issue by keeping the call stack
shallow. The legacy NDB code was actually already using this
indirection and I had changed it to a direct call because I couldn't
figure out why the legacy code didn't just do that, already. I knew
there was a chance that the reason would reveal itself through trial and
error, and it eventually did.

I also performed a minor refactor on the eventloop itself, adding the
``call_soon`` method to handle the case that was previously handled by
passing ``None`` for the ``delay`` argument to ``queue_call``. This just
makes that API a little bit cleaner.