### PR TITLE
Refactor options.

### DIFF
--- a/src/google/cloud/ndb/_datastore_api.py
+++ b/src/google/cloud/ndb/_datastore_api.py
@@ -27,6 +27,7 @@ from google.cloud.datastore_v1.proto import entity_pb2
 
 from google.cloud.ndb import context as context_module
 from google.cloud.ndb import _eventloop
+from google.cloud.ndb import _options
 from google.cloud.ndb import _remote
 from google.cloud.ndb import _retry
 from google.cloud.ndb import tasklets
@@ -105,7 +106,7 @@ def make_call(rpc_name, request, retries=None):
     return rpc_call()
 
 
-def lookup(key, **options):
+def lookup(key, options):
     """Look up a Datastore entity.
 
     Gets an entity from Datastore, asynchronously. Actually adds the request to
@@ -114,15 +115,13 @@ def lookup(key, **options):
 
     Args:
         key (~datastore.Key): The key for the entity to retrieve.
-        options (Dict[str, Any]): The options for the request. For example,
-            ``{"read_consistency": EVENTUAL}``.
+        options (_options.ReadOptions): The options for the request. For
+            example, ``{"read_consistency": EVENTUAL}``.
 
     Returns:
         :class:`~tasklets.Future`: If not an exception, future's result will be
             either an entity protocol buffer or _NOT_FOUND.
     """
-    _check_unsupported_options(options)
-
     batch = _get_batch(_LookupBatch, options)
     return batch.add(key)
 
@@ -138,9 +137,8 @@ def _get_batch(batch_cls, options):
     Args:
         batch_cls (type): Class representing the kind of operation being
             batched.
-        options (Dict[str, Any]): The options for the request. For example,
-            ``{"read_consistency": EVENTUAL}``. Calls with different options
-            will be placed in different batches.
+        options (_options.ReadOptions): The options for the request. Calls with
+            different options will be placed in different batches.
 
     Returns:
         batch_cls: An instance of the batch class.
@@ -150,7 +148,15 @@ def _get_batch(batch_cls, options):
     if batches is None:
         context.batches[batch_cls] = batches = {}
 
-    options_key = tuple(sorted(options.items()))
+    options_key = tuple(
+        sorted(
+            (
+                (key, value)
+                for key, value in options.items()
+                if value is not None
+            )
+        )
+    )
     batch = batches.get(options_key)
     if batch is not None:
         return batch
@@ -173,9 +179,8 @@ class _LookupBatch:
             protocol buffers to dependent futures.
 
     Args:
-        options (Dict[str, Any]): The options for the request. For example,
-            ``{"read_consistency": EVENTUAL}``. Calls with different options
-            will be placed in different batches.
+        options (_options.ReadOptions): The options for the request. Calls with
+            different options will be placed in different batches.
     """
 
     def __init__(self, options):
@@ -205,7 +210,7 @@ class _LookupBatch:
             keys.append(key_pb)
 
         read_options = _get_read_options(self.options)
-        retries = self.options.get("retries")
+        retries = self.options.retries
         rpc = _datastore_lookup(keys, read_options, retries=retries)
         rpc.add_done_callback(self.lookup_callback)
 
@@ -288,10 +293,9 @@ def _get_read_options(options):
     """Get the read options for a request.
 
     Args:
-        options (Dict[str, Any]): The options for the request. For example,
-            ``{"read_consistency": EVENTUAL}``. May contain options unrelated
-            to creating a :class:`datastore_pb2.ReadOptions` instance, which
-            will be ignored.
+        options (_options.ReadOptions): The options for the request. May
+            contain options unrelated to creating a
+            :class:`datastore_pb2.ReadOptions` instance, which will be ignored.
 
     Returns:
         datastore_pb2.ReadOptions: The options instance for passing to the
@@ -303,13 +307,11 @@ def _get_read_options(options):
     """
     transaction = _get_transaction(options)
 
-    read_consistency = options.get("read_consistency")
-    if read_consistency is None:
-        read_consistency = options.get("read_policy")  # Legacy NDB
+    read_consistency = options.read_consistency
 
     if transaction is not None and read_consistency is EVENTUAL:
         raise ValueError(
-            "read_consistency must be EVENTUAL when in transaction"
+            "read_consistency must not be EVENTUAL when in transaction"
         )
 
     return datastore_pb2.ReadOptions(
@@ -324,17 +326,21 @@ def _get_transaction(options):
     it will return the transaction for the current context.
 
     Args:
-        options (Dict[str, Any]): The options for the request. Only
+        options (_options.ReadOptions): The options for the request. Only
             ``transaction`` will have any bearing here.
 
     Returns:
         Union[bytes, NoneType]: The transaction identifier, or :data:`None`.
     """
-    context = context_module.get_context()
-    return options.get("transaction", context.transaction)
+    transaction = getattr(options, "transaction", None)
+    if transaction is None:
+        context = context_module.get_context()
+        transaction = context.transaction
+
+    return transaction
 
 
-def put(entity_pb, **options):
+def put(entity_pb, options):
     """Store an entity in datastore.
 
     The entity can be a new entity to be saved for the first time or an
@@ -342,7 +348,7 @@ def put(entity_pb, **options):
 
     Args:
         entity_pb (datastore_v1.types.Entity): The entity to be stored.
-        options (Dict[str, Any]): Options for this request.
+        options (_options.Options): Options for this request.
 
     Returns:
         tasklets.Future: Result will be completed datastore key
@@ -357,7 +363,7 @@ def put(entity_pb, **options):
     return batch.put(entity_pb)
 
 
-def delete(key, **options):
+def delete(key, options):
     """Delete an entity from Datastore.
 
     Deleting an entity that doesn't exist does not result in an error. The
@@ -365,7 +371,7 @@ def delete(key, **options):
 
     Args:
         key (datastore.Key): The key for the entity to be deleted.
-        options (Dict[str, Any]): Options for this request.
+        options (_options.Options): Options for this request.
 
     Returns:
         tasklets.Future: Will be finished when entity is deleted. Result will
@@ -384,7 +390,7 @@ class _NonTransactionalCommitBatch:
     """Batch for tracking a set of mutations for a non-transactional commit.
 
     Attributes:
-        options (Dict[str, Any]): See Args.
+        options (_options.Options): See Args.
         mutations (List[datastore_pb2.Mutation]): Sequence of mutation protocol
             buffers accumumlated for this batch.
         futures (List[tasklets.Future]): Sequence of futures for return results
@@ -392,12 +398,11 @@ class _NonTransactionalCommitBatch:
             i-th element of ``mutations``.
 
     Args:
-        options (Dict[str, Any]): The options for the request. Calls with
+        options (_options.Options): The options for the request. Calls with
             different options will be placed in different batches.
     """
 
     def __init__(self, options):
-        _check_unsupported_options(options)
         self.options = options
         self.mutations = []
         self.futures = []
@@ -441,7 +446,7 @@ class _NonTransactionalCommitBatch:
         def commit_callback(rpc):
             _process_commit(rpc, futures)
 
-        retries = self.options.get("retries")
+        retries = self.options.retries
         rpc = _datastore_commit(self.mutations, None, retries=retries)
         rpc.add_done_callback(commit_callback)
 
@@ -459,7 +464,7 @@ def commit(transaction, retries=None):
         tasklets.Future: Result will be none, will finish when the transaction
             is committed.
     """
-    batch = _get_commit_batch(transaction, {})
+    batch = _get_commit_batch(transaction, _options.Options())
     return batch.commit(retries=retries)
 
 
@@ -469,8 +474,8 @@ def _get_commit_batch(transaction, options):
     Args:
         transaction (bytes): The transaction id. Different transactions will
             have different batchs.
-        options (Dict[str, Any]): Options for the batch. Only "transaction" is
-            supported at this time.
+        options (_options.Options): Options for the batch. Only "transaction"
+            is supported at this time.
 
     Returns:
         _TransactionalCommitBatch: The batch.
@@ -478,18 +483,17 @@ def _get_commit_batch(transaction, options):
     # Support for different options will be tricky if we're in a transaction,
     # since we can only do one commit, so any options that affect that gRPC
     # call would all need to be identical. For now, only "transaction" is
-    # suppoorted if there is a transaction.
-    options = options.copy()
-    options.pop("transaction", None)
-    for key in options:
-        raise NotImplementedError("Passed bad option: {!r}".format(key))
+    # supported if there is a transaction.
+    for key, value in options.items():
+        if value:
+            raise NotImplementedError("Passed bad option: {!r}".format(key))
 
     # Since we're in a transaction, we need to hang on to the batch until
     # commit time, so we need to store it separately from other batches.
     context = context_module.get_context()
     batch = context.commit_batches.get(transaction)
     if batch is None:
-        batch = _TransactionalCommitBatch({"transaction": transaction})
+        batch = _TransactionalCommitBatch(transaction, options)
         context.commit_batches[transaction] = batch
 
     return batch
@@ -499,14 +503,14 @@ class _TransactionalCommitBatch(_NonTransactionalCommitBatch):
     """Batch for tracking a set of mutations to be committed for a transaction.
 
     Attributes:
-        options (Dict[str, Any]): See Args.
+        options (_options.Options): See Args.
         mutations (List[datastore_pb2.Mutation]): Sequence of mutation protocol
             buffers accumumlated for this batch.
         futures (List[tasklets.Future]): Sequence of futures for return results
             of the commit. The i-th element of ``futures`` corresponds to the
             i-th element of ``mutations``.
         transaction (bytes): The transaction id of the transaction for this
-            commit, if in a transaction.
+            commit.
         allocating_ids (List[tasklets.Future]): Futures for any calls to
             AllocateIds that are fired off before commit.
         incomplete_mutations (List[datastore_pb2.Mutation]): List of mutations
@@ -519,13 +523,15 @@ class _TransactionalCommitBatch(_NonTransactionalCommitBatch):
             receive results of id allocation.
 
     Args:
-        options (Dict[str, Any]): The options for the request. Calls with
+        transaction (bytes): The transaction id of the transaction for this
+            commit.
+        options (_options.Options): The options for the request. Calls with
             different options will be placed in different batches.
     """
 
-    def __init__(self, options):
+    def __init__(self, transaction, options):
         super(_TransactionalCommitBatch, self).__init__(options)
-        self.transaction = _get_transaction(options)
+        self.transaction = transaction
         self.allocating_ids = []
         self.incomplete_mutations = []
         self.incomplete_futures = []
@@ -582,7 +588,7 @@ class _TransactionalCommitBatch(_NonTransactionalCommitBatch):
             # Signal that we're done allocating these ids
             allocating_ids.set_result(None)
 
-        retries = self.options.get("retries")
+        retries = self.options.retries
         keys = [mutation.upsert.key for mutation in mutations]
         rpc = _datastore_allocate_ids(keys, retries=retries)
         rpc.add_done_callback(callback)
@@ -612,8 +618,9 @@ class _TransactionalCommitBatch(_NonTransactionalCommitBatch):
 
         Args:
             retries (int): Number of times to potentially retry the call. If
-                :data:`None` is passed, will use :data:`_retry._DEFAULT_RETRIES`.
-                If :data:`0` is passed, the call is attempted only once.
+                :data:`None` is passed, will use
+                :data:`_retry._DEFAULT_RETRIES`.  If :data:`0` is passed, the
+                call is attempted only once.
         """
         if not self.mutations:
             return
@@ -851,46 +858,3 @@ def _datastore_rollback(transaction, retries=None):
     )
 
     return make_call("Rollback", request, retries=retries)
-
-
-_OPTIONS_SUPPORTED = {
-    "transaction",
-    "read_consistency",
-    "read_policy",
-    "retries",
-}
-
-_OPTIONS_NOT_IMPLEMENTED = {
-    "deadline",
-    "force_writes",
-    "use_cache",
-    "use_memcache",
-    "use_datastore",
-    "memcache_timeout",
-    "max_memcache_items",
-    "xg",
-    "propagation",
-    "retries",
-}
-
-
-def _check_unsupported_options(options):
-    """Check to see if any passed options are not supported.
-
-    options (Dict[str, Any]): The options for the request. For example,
-        ``{"read_consistency": EVENTUAL}``.
-
-    Raises: NotImplementedError if any options are not supported.
-    """
-    for key in options:
-        if key in _OPTIONS_NOT_IMPLEMENTED:
-            # option is used in Legacy NDB, but has not yet been implemented in
-            # the rewrite, nor have we determined it won't be used, yet.
-            raise NotImplementedError(
-                "Support for option {!r} has not yet been implemented".format(
-                    key
-                )
-            )
-
-        elif key not in _OPTIONS_SUPPORTED:
-            raise NotImplementedError("Passed bad option: {!r}".format(key))

--- a/src/google/cloud/ndb/_datastore_api.py
+++ b/src/google/cloud/ndb/_datastore_api.py
@@ -474,16 +474,16 @@ def _get_commit_batch(transaction, options):
     Args:
         transaction (bytes): The transaction id. Different transactions will
             have different batchs.
-        options (_options.Options): Options for the batch. Only "transaction"
-            is supported at this time.
+        options (_options.Options): Options for the batch. Not supported at
+            this time.
 
     Returns:
         _TransactionalCommitBatch: The batch.
     """
     # Support for different options will be tricky if we're in a transaction,
     # since we can only do one commit, so any options that affect that gRPC
-    # call would all need to be identical. For now, only "transaction" is
-    # supported if there is a transaction.
+    # call would all need to be identical. For now, no options are supported
+    # here.
     for key, value in options.items():
         if value:
             raise NotImplementedError("Passed bad option: {!r}".format(key))

--- a/src/google/cloud/ndb/_options.py
+++ b/src/google/cloud/ndb/_options.py
@@ -1,0 +1,158 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Support for options."""
+
+import functools
+import itertools
+import logging
+
+from google.cloud.ndb import exceptions
+
+log = logging.getLogger(__name__)
+
+
+class Options:
+    __slots__ = (
+        # Supported
+        "retries",
+        # Not yet implemented
+        "deadline",
+        "use_cache",
+        "use_memcache",
+        "use_datastore",
+        "memcache_timeout",
+        "max_memcache_items",
+        # Might or might not implement
+        "force_writes",
+        # Deprecated
+        "propagation",
+    )
+
+    @classmethod
+    def options(cls, wrapped):
+        @functools.wraps(wrapped)
+        def wrapper(arg, **kwargs):
+            _options = kwargs.get("_options")
+            if not _options:
+                _options = cls(**kwargs)
+            return wrapped(arg, _options=_options)
+
+        return wrapper
+
+    @classmethod
+    def slots(cls):
+        return itertools.chain(
+            *(
+                ancestor.__slots__
+                for ancestor in cls.mro()
+                if hasattr(ancestor, "__slots__")
+            )
+        )
+
+    def __init__(self, config=None, **kwargs):
+        cls = type(self)
+        if config is not None and not isinstance(config, cls):
+            raise TypeError(
+                "Config must be a {} instance.".format(cls.__name__)
+            )
+
+        for key in self.slots():
+            default = getattr(config, key, None) if config else None
+            setattr(self, key, kwargs.pop(key, default))
+
+        if kwargs.pop("xg", False):
+            log.warning(
+                "Use of the 'xg' option is deprecated. All transactions are "
+                "cross group (up to 25 groups) transactions, by default. This "
+                "option is ignored."
+            )
+
+        if kwargs:
+            raise TypeError(
+                "{} got an unexpected keyword argument '{}'".format(
+                    type(self).__name__, next(iter(kwargs))
+                )
+            )
+
+        if self.deadline is not None:
+            raise NotImplementedError
+
+        if self.use_cache is not None:
+            raise NotImplementedError
+
+        if self.use_memcache is not None:
+            raise NotImplementedError
+
+        if self.use_datastore is not None:
+            raise NotImplementedError
+
+        if self.memcache_timeout is not None:
+            raise NotImplementedError
+
+        if self.max_memcache_items is not None:
+            raise NotImplementedError
+
+        if self.force_writes is not None:
+            raise NotImplementedError
+
+        if self.propagation is not None:
+            raise exceptions.NoLongerImplementedError()
+
+    def __eq__(self, other):
+        if type(self) is not type(other):
+            return NotImplemented
+
+        for key in self.slots():
+            if getattr(self, key, None) != getattr(other, key, None):
+                return False
+
+        return True
+
+    def __repr__(self):
+        options = ", ".join(
+            [
+                "{}={}".format(key, repr(getattr(self, key, None)))
+                for key in self.slots()
+                if getattr(self, key, None) is not None
+            ]
+        )
+        return "{}({})".format(type(self).__name__, options)
+
+    def copy(self, **kwargs):
+        return type(self)(config=self, **kwargs)
+
+    def items(self):
+        for name in self.slots():
+            yield name, getattr(self, name, None)
+
+
+class ReadOptions(Options):
+    __slots__ = ("read_consistency", "transaction")
+
+    def __init__(self, config=None, **kwargs):
+        read_policy = kwargs.pop("read_policy", None)
+        if read_policy:
+            log.warning(
+                "Use of the 'read_policy' options is deprecated. Please use "
+                "'read_consistency'"
+            )
+            if kwargs.get("read_consistency"):
+                raise TypeError(
+                    "Cannot use both 'read_policy' and 'read_consistency' "
+                    "options."
+                )
+            kwargs["read_consistency"] = read_policy
+
+        super(ReadOptions, self).__init__(config=config, **kwargs)

--- a/src/google/cloud/ndb/query.py
+++ b/src/google/cloud/ndb/query.py
@@ -23,6 +23,7 @@ from google.cloud.ndb import _datastore_query
 from google.cloud.ndb import _gql
 from google.cloud.ndb import exceptions
 from google.cloud.ndb import model
+from google.cloud.ndb import _options
 
 
 __all__ = [
@@ -54,65 +55,6 @@ _GT_OP = ">"
 _OPS = frozenset([_EQ_OP, _NE_OP, _LT_OP, "<=", _GT_OP, ">=", _IN_OP])
 
 _log = logging.getLogger(__name__)
-
-
-class QueryOptions:
-    __slots__ = (
-        # Query options
-        "kind",
-        "project",
-        "namespace",
-        "ancestor",
-        "filters",
-        "order_by",
-        "orders",
-        "distinct_on",
-        "group_by",
-        # Fetch options
-        "keys_only",
-        "limit",
-        "offset",
-        "batch_size",
-        "prefetch_size",
-        "produce_cursors",
-        "start_cursor",
-        "end_cursor",
-        "deadline",
-        "read_policy",
-        # Both (!?!)
-        "projection",
-    )
-
-    def __init__(self, config=None, **kwargs):
-        if config is not None and not isinstance(config, QueryOptions):
-            raise TypeError("Config must be a QueryOptions instance.")
-
-        for key in self.__slots__:
-            default = getattr(config, key, None) if config else None
-            setattr(self, key, kwargs.get(key, default))
-
-    def __eq__(self, other):
-        if not isinstance(other, QueryOptions):
-            return NotImplemented
-
-        for key in self.__slots__:
-            if getattr(self, key, None) != getattr(other, key, None):
-                return False
-
-        return True
-
-    def __repr__(self):
-        options = ", ".join(
-            [
-                "{}={}".format(key, repr(getattr(self, key, None)))
-                for key in self.__slots__
-                if getattr(self, key, None) is not None
-            ]
-        )
-        return "QueryOptions({})".format(options)
-
-    def copy(self, **kwargs):
-        return type(self)(config=self, **kwargs)
 
 
 class PropertyOrder(object):
@@ -989,7 +931,7 @@ def _query_options(wrapped):
 
     This decorator wraps these methods with a function that does this
     processing for them and passes in a :class:`QueryOptions` instance using
-    the ``_query_options`` argument to those functions, bypassing all of the
+    the ``_options`` argument to those functions, bypassing all of the
     other arguments.
     """
     # If there are any positional arguments, get their names
@@ -1006,8 +948,8 @@ def _query_options(wrapped):
     @functools.wraps(wrapped)
     def wrapper(self, *args, **kwargs):
         # Maybe we already did this (in the case of X calling X_async)
-        if "_query_options" in kwargs:
-            return wrapped(self, _query_options=kwargs["_query_options"])
+        if "_options" in kwargs:
+            return wrapped(self, _options=kwargs["_options"])
 
         # Transfer any positional args to keyword args, so they're all in the
         # same structure.
@@ -1027,107 +969,80 @@ def _query_options(wrapped):
                 "deprecated. Please pass arguments directly."
             )
 
-        batch_size = kwargs.pop("batch_size", None)
-        batch_size = self._option("batch_size", batch_size, options)
-        if batch_size:
+        # Get arguments for QueryOptions attributes
+        query_arguments = {
+            name: self._option(name, kwargs.pop(name, None), options)
+            for name in QueryOptions.slots()
+        }
+
+        # Any left over kwargs don't actually correspond to slots in
+        # QueryOptions, but should be left to the QueryOptions constructor to
+        # sort out. Some might be synonyms or shorthand for other options.
+        query_arguments.update(kwargs)
+
+        client = context_module.get_context().client
+        query_options = QueryOptions(client=client, **query_arguments)
+
+        return wrapped(self, _options=query_options)
+
+    return wrapper
+
+
+class QueryOptions(_options.Options):
+    __slots__ = (
+        # Query options
+        "kind",
+        "ancestor",
+        "filters",
+        "order_by",
+        "orders",
+        "distinct_on",
+        "group_by",
+        "namespace",
+        "project",
+        # Fetch options
+        "keys_only",
+        "limit",
+        "offset",
+        "start_cursor",
+        "end_cursor",
+        # Both (!?!)
+        "projection",
+    )
+
+    def __init__(self, config=None, client=None, **kwargs):
+        if kwargs.get("read_policy") or kwargs.get("read_consistency"):
+            raise NotImplementedError
+
+        if kwargs.get("batch_size"):
             raise exceptions.NoLongerImplementedError()
 
-        prefetch_size = kwargs.pop("prefetch_size", None)
-        prefetch_size = self._option("prefetch_size", prefetch_size, options)
-        if prefetch_size:
+        if kwargs.get("prefetch_size"):
             raise exceptions.NoLongerImplementedError()
 
-        produce_cursors = kwargs.pop("produce_cursors", None)
-        produce_cursors = self._option(
-            "produce_cursors", produce_cursors, options
-        )
-        if produce_cursors:
+        if kwargs.pop("produce_cursors", None):
             _log.warning(
                 "Deprecation warning: 'produce_cursors' is deprecated. "
                 "Cursors are always produced when available. This option is "
                 "ignored."
             )
 
-        start_cursor = kwargs.pop("start_cursor", None)
-        start_cursor = self._option("start_cursor", start_cursor, options)
-
-        end_cursor = kwargs.pop("end_cursor", None)
-        end_cursor = self._option("end_cursor", end_cursor, options)
-
-        deadline = kwargs.pop("deadline", None)
-        deadline = self._option("deadline", deadline, options)
-        if deadline:
-            raise NotImplementedError(
-                "'deadline' is not implemented yet for queries"
-            )
-
-        read_policy = kwargs.pop("read_policy", None)
-        read_policy = self._option("read_policy", read_policy, options)
-        if read_policy:
-            raise NotImplementedError(
-                "'read_policy' is not implemented yet for queries"
-            )
-
-        projection = kwargs.pop("projection", None)
-        projection = self._option("projection", projection, options)
-
-        keys_only = kwargs.pop("keys_only", None)
-        keys_only = self._option("keys_only", keys_only, options)
-
-        if keys_only:
-            if projection:
+        if kwargs.get("keys_only"):
+            if kwargs.get("projection"):
                 raise TypeError(
                     "Cannot specify 'projection' with 'keys_only=True'"
                 )
-            projection = ["__key__"]
+            kwargs["projection"] = ["__key__"]
+            del kwargs["keys_only"]
 
-        offset = kwargs.pop("offset", None)
-        limit = kwargs.pop("limit", None)
+        super(QueryOptions, self).__init__(config=config, **kwargs)
 
-        client = context_module.get_context().client
+        if client:
+            if not self.project:
+                self.project = client.project
 
-        project = kwargs.pop("project", None)
-        project = self._option("project", project, options)
-        if not project:
-            project = client.project
-
-        namespace = kwargs.pop("namespace", None)
-        namespace = self._option("namespace", namespace, options)
-        if not namespace:
-            namespace = client.namespace
-
-        if kwargs:
-            raise TypeError(
-                "{}() got unexpected keyword argument '{}'".format(
-                    wrapped.__name__, next(iter(kwargs))
-                )
-            )
-
-        query_arguments = (
-            ("kind", self._option("kind", None, options)),
-            ("project", project),
-            ("namespace", namespace),
-            ("ancestor", self._option("ancestor", None, options)),
-            ("filters", self._option("filters", None, options)),
-            ("order_by", self._option("order_by", None, options)),
-            ("distinct_on", self._option("distinct_on", None, options)),
-            ("projection", projection),
-            ("offset", self._option("offset", offset, options)),
-            ("limit", self._option("limit", limit, options)),
-            (
-                "start_cursor",
-                self._option("start_cursor", start_cursor, options),
-            ),
-            ("end_cursor", self._option("end_cursor", end_cursor, options)),
-        )
-        query_arguments = {
-            name: value for name, value in query_arguments if value is not None
-        }
-        query_options = QueryOptions(**query_arguments)
-
-        return wrapped(self, _query_options=query_options)
-
-    return wrapper
+            if not self.namespace:
+                self.namespace = client.namespace
 
 
 class Query:
@@ -1175,6 +1090,14 @@ class Query:
     ):
         self.default_options = None
 
+        if app:
+            if project:
+                raise TypeError(
+                    "Cannot use both app and project, they are synonyms. app "
+                    "is deprecated."
+                )
+            project = app
+
         if default_options is not None:
             _log.warning(
                 "Deprecation warning: passing default_options to the Query"
@@ -1210,14 +1133,6 @@ class Query:
             projection = self._option("projection", projection)
             distinct_on = self._option("distinct_on", distinct_on)
             group_by = self._option("group_by", group_by)
-
-        if app:
-            if project:
-                raise TypeError(
-                    "Cannot use both app and project, they are synonyms. app "
-                    "is deprecated."
-                )
-            project = app
 
         if ancestor is not None:
             if isinstance(ancestor, ParameterizedThing):
@@ -1547,7 +1462,7 @@ class Query:
         deadline=None,
         read_policy=None,  #  _datastore_api.EVENTUAL,  # placeholder
         options=None,
-        _query_options=None,
+        _options=None,
     ):
         """Run a query, fetching results.
 
@@ -1578,7 +1493,7 @@ class Query:
         Returns:
             List([model.Model]): The query results.
         """
-        return self.fetch_async(_query_options=_query_options).result()
+        return self.fetch_async(_options=_options).result()
 
     @_query_options
     def fetch_async(
@@ -1596,7 +1511,7 @@ class Query:
         deadline=None,
         read_policy=None,  #  _datastore_api.EVENTUAL,  # placeholder
         options=None,
-        _query_options=None,
+        _options=None,
     ):
         """Run a query, asynchronously fetching the results.
 
@@ -1626,7 +1541,7 @@ class Query:
             tasklets.Future: Eventual result will be a List[model.Model] of the
                 results.
         """
-        return _datastore_query.fetch(_query_options)
+        return _datastore_query.fetch(_options)
 
     def _option(self, name, given, options=None):
         """Get given value or a provided default for an option.
@@ -1687,7 +1602,7 @@ class Query:
         deadline=None,
         read_policy=None,  #  _datastore_api.EVENTUAL,  # placeholder
         options=None,
-        _query_options=None,
+        _options=None,
     ):
         """Get an iterator over query results.
 
@@ -1716,7 +1631,7 @@ class Query:
         Returns:
             QueryIterator: An iterator.
         """
-        return _datastore_query.iterate(_query_options)
+        return _datastore_query.iterate(_options)
 
     __iter__ = iter
 

--- a/src/google/cloud/ndb/query.py
+++ b/src/google/cloud/ndb/query.py
@@ -969,6 +969,14 @@ def _query_options(wrapped):
                 "deprecated. Please pass arguments directly."
             )
 
+        if kwargs.get("keys_only"):
+            if kwargs.get("projection"):
+                raise TypeError(
+                    "Cannot specify 'projection' with 'keys_only=True'"
+                )
+            kwargs["projection"] = ["__key__"]
+            del kwargs["keys_only"]
+
         # Get arguments for QueryOptions attributes
         query_arguments = {
             name: self._option(name, kwargs.pop(name, None), options)
@@ -1026,14 +1034,6 @@ class QueryOptions(_options.Options):
                 "Cursors are always produced when available. This option is "
                 "ignored."
             )
-
-        if kwargs.get("keys_only"):
-            if kwargs.get("projection"):
-                raise TypeError(
-                    "Cannot specify 'projection' with 'keys_only=True'"
-                )
-            kwargs["projection"] = ["__key__"]
-            del kwargs["keys_only"]
 
         super(QueryOptions, self).__init__(config=config, **kwargs)
 

--- a/tests/system/test_query.py
+++ b/tests/system/test_query.py
@@ -252,7 +252,7 @@ def test_order_by_descending(ds_entity):
     assert [entity.foo for entity in results] == [4, 3, 2, 1, 0]
 
 
-@pytest.mark.skip("Requires an index")
+# @pytest.mark.skip("Requires an index")
 @pytest.mark.usefixtures("client_context")
 def test_order_by_with_or_filter(dispose_of):
     """
@@ -320,7 +320,7 @@ def test_offset_and_limit(ds_entity):
     assert [entity.foo for entity in results] == [2, 3]
 
 
-@pytest.mark.skip("Requires an index")
+# @pytest.mark.skip("Requires an index")
 @pytest.mark.usefixtures("client_context")
 def test_offset_and_limit_with_or_filter(dispose_of):
     class SomeKind(ndb.Model):

--- a/tests/system/test_query.py
+++ b/tests/system/test_query.py
@@ -252,7 +252,7 @@ def test_order_by_descending(ds_entity):
     assert [entity.foo for entity in results] == [4, 3, 2, 1, 0]
 
 
-# @pytest.mark.skip("Requires an index")
+@pytest.mark.skip("Requires an index")
 @pytest.mark.usefixtures("client_context")
 def test_order_by_with_or_filter(dispose_of):
     """
@@ -320,7 +320,7 @@ def test_offset_and_limit(ds_entity):
     assert [entity.foo for entity in results] == [2, 3]
 
 
-# @pytest.mark.skip("Requires an index")
+@pytest.mark.skip("Requires an index")
 @pytest.mark.usefixtures("client_context")
 def test_offset_and_limit_with_or_filter(dispose_of):
     class SomeKind(ndb.Model):

--- a/tests/unit/test__options.py
+++ b/tests/unit/test__options.py
@@ -1,0 +1,138 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from google.cloud.ndb import _datastore_api
+from google.cloud.ndb import _options
+
+
+class MyOptions(_options.Options):
+    __slots__ = ["foo", "bar"]
+
+
+class TestOptions:
+    @staticmethod
+    def test_constructor_w_bad_arg():
+        with pytest.raises(TypeError):
+            MyOptions(kind="test")
+
+    @staticmethod
+    def test_constructor_w_deadline():
+        with pytest.raises(NotImplementedError):
+            MyOptions(deadline=20)
+
+    @staticmethod
+    def test_constructor_w_use_memcache():
+        with pytest.raises(NotImplementedError):
+            MyOptions(use_memcache=20)
+
+    @staticmethod
+    def test_constructor_w_use_datastore():
+        with pytest.raises(NotImplementedError):
+            MyOptions(use_datastore=20)
+
+    @staticmethod
+    def test_constructor_w_use_cache():
+        with pytest.raises(NotImplementedError):
+            MyOptions(use_cache=20)
+
+    @staticmethod
+    def test_constructor_w_memcache_timeout():
+        with pytest.raises(NotImplementedError):
+            MyOptions(memcache_timeout=20)
+
+    @staticmethod
+    def test_constructor_w_max_memcache_items():
+        with pytest.raises(NotImplementedError):
+            MyOptions(max_memcache_items=20)
+
+    @staticmethod
+    def test_constructor_w_force_writes():
+        with pytest.raises(NotImplementedError):
+            MyOptions(force_writes=20)
+
+    @staticmethod
+    def test_constructor_w_propagation():
+        with pytest.raises(NotImplementedError):
+            MyOptions(propagation=20)
+
+    @staticmethod
+    def test_constructor_w_xg():
+        options = MyOptions(xg=True)
+        assert options == MyOptions()
+
+    @staticmethod
+    def test_constructor_with_config():
+        config = MyOptions(retries=5, foo="config_test")
+        options = MyOptions(config=config, retries=8, bar="app")
+        assert options.retries == 8
+        assert options.bar == "app"
+        assert options.foo == "config_test"
+
+    @staticmethod
+    def test_constructor_with_bad_config():
+        with pytest.raises(TypeError):
+            MyOptions(config="bad")
+
+    @staticmethod
+    def test___repr__():
+        representation = "MyOptions(foo='test', bar='app')"
+        options = MyOptions(foo="test", bar="app")
+        assert options.__repr__() == representation
+
+    @staticmethod
+    def test__eq__():
+        options = MyOptions(foo="test", bar="app")
+        other = MyOptions(foo="test", bar="app")
+        otherother = MyOptions(foo="nope", bar="noway")
+
+        assert options == other
+        assert options != otherother
+        assert options != "foo"
+
+    @staticmethod
+    def test_copy():
+        options = MyOptions(retries=8, bar="app")
+        options = options.copy(bar="app2", foo="foo")
+        assert options.retries == 8
+        assert options.bar == "app2"
+        assert options.foo == "foo"
+
+    @staticmethod
+    def test_items():
+        options = MyOptions(retries=8, bar="app")
+        items = [
+            (key, value) for key, value in options.items() if value is not None
+        ]
+        assert items == [("bar", "app"), ("retries", 8)]
+
+
+class TestReadOptions:
+    @staticmethod
+    def test_constructor_w_read_policy():
+        options = _options.ReadOptions(
+            read_policy=_datastore_api.EVENTUAL_CONSISTENCY
+        )
+        assert options == _options.ReadOptions(
+            read_consistency=_datastore_api.EVENTUAL
+        )
+
+    @staticmethod
+    def test_constructor_w_read_policy_and_read_consistency():
+        with pytest.raises(TypeError):
+            _options.ReadOptions(
+                read_policy=_datastore_api.EVENTUAL_CONSISTENCY,
+                read_consistency=_datastore_api.EVENTUAL,
+            )

--- a/tests/unit/test_key.py
+++ b/tests/unit/test_key.py
@@ -23,6 +23,7 @@ import pytest
 from google.cloud.ndb import exceptions
 from google.cloud.ndb import key as key_module
 from google.cloud.ndb import model
+from google.cloud.ndb import _options
 from google.cloud.ndb import tasklets
 import tests.unit.utils
 
@@ -543,7 +544,9 @@ class TestKey:
         key = key_module.Key("a", "b", app="c")
         assert key.get() == "the entity"
 
-        _datastore_api.lookup.assert_called_once_with(key._key)
+        _datastore_api.lookup.assert_called_once_with(
+            key._key, _options.ReadOptions()
+        )
         _entity_from_protobuf.assert_called_once_with("ds_entity")
 
     @staticmethod
@@ -560,7 +563,9 @@ class TestKey:
         ds_future.set_result("ds_entity")
         assert future.result() == "the entity"
 
-        _datastore_api.lookup.assert_called_once_with(key._key)
+        _datastore_api.lookup.assert_called_once_with(
+            key._key, _options.ReadOptions()
+        )
         _entity_from_protobuf.assert_called_once_with("ds_entity")
 
     @staticmethod
@@ -585,7 +590,9 @@ class TestKey:
 
         key = key_module.Key("a", "b", app="c")
         assert key.delete() == "result"
-        _datastore_api.delete.assert_called_once_with(key._key)
+        _datastore_api.delete.assert_called_once_with(
+            key._key, _options.Options()
+        )
 
     @staticmethod
     @unittest.mock.patch("google.cloud.ndb.key._datastore_api")
@@ -595,7 +602,9 @@ class TestKey:
         with in_context.new(transaction=b"tx123").use():
             key = key_module.Key("a", "b", app="c")
             assert key.delete() is None
-            _datastore_api.delete.assert_called_once_with(key._key)
+            _datastore_api.delete.assert_called_once_with(
+                key._key, _options.Options()
+            )
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
@@ -604,7 +613,9 @@ class TestKey:
         key = key_module.Key("a", "b", app="c")
         future = key.delete_async()
 
-        _datastore_api.delete.assert_called_once_with(key._key)
+        _datastore_api.delete.assert_called_once_with(
+            key._key, _options.Options()
+        )
         assert future is _datastore_api.delete.return_value
 
     @staticmethod

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -28,6 +28,7 @@ from google.cloud.ndb import _datastore_types
 from google.cloud.ndb import exceptions
 from google.cloud.ndb import key as key_module
 from google.cloud.ndb import model
+from google.cloud.ndb import _options
 from google.cloud.ndb import query as query_module
 from google.cloud.ndb import tasklets
 import tests.unit.utils
@@ -2873,7 +2874,9 @@ class TestModel:
 
         entity_pb = model._entity_to_protobuf(entity)
         assert entity._put() == entity.key
-        _datastore_api.put.assert_called_once_with(entity_pb)
+        _datastore_api.put.assert_called_once_with(
+            entity_pb, _options.Options()
+        )
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
@@ -2887,7 +2890,9 @@ class TestModel:
 
         entity_pb = model._entity_to_protobuf(entity)
         assert entity._put() == key
-        _datastore_api.put.assert_called_once_with(entity_pb)
+        _datastore_api.put.assert_called_once_with(
+            entity_pb, _options.Options()
+        )
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
@@ -2902,7 +2907,9 @@ class TestModel:
         entity_pb = model._entity_to_protobuf(entity)
         tasklet_future = entity._put_async()
         assert tasklet_future.result() == key
-        _datastore_api.put.assert_called_once_with(entity_pb)
+        _datastore_api.put.assert_called_once_with(
+            entity_pb, _options.Options()
+        )
 
     @staticmethod
     def test__lookup_model():

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -1454,16 +1454,16 @@ class TestQuery:
         assert query.fetch_async(options=options) is response
         _datastore_query.fetch.assert_called_once_with(
             query_module.QueryOptions(
-                project="testing", projection=["__key__"]
+                project="testing", keys_only=True,
             )
         )
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
     def test_fetch_async_with_keys_only_and_projection():
-        query = query_module.Query(projection=["foo", "bar"])
+        query = query_module.Query()
         with pytest.raises(TypeError):
-            query.fetch_async(keys_only=True)
+            query.fetch_async(keys_only=True, projection=["foo", "bar"])
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -55,6 +55,7 @@ class TestQueryOptions:
             query_module.QueryOptions(config="bad")
 
     @staticmethod
+    @pytest.mark.usefixtures("in_context")
     def test___repr__():
         representation = "QueryOptions(kind='test', project='app')"
         options = query_module.QueryOptions(kind="test", project="app")

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -1453,9 +1453,7 @@ class TestQuery:
         response = _datastore_query.fetch.return_value
         assert query.fetch_async(options=options) is response
         _datastore_query.fetch.assert_called_once_with(
-            query_module.QueryOptions(
-                project="testing", keys_only=True,
-            )
+            query_module.QueryOptions(project="testing", keys_only=True)
         )
 
     @staticmethod


### PR DESCRIPTION
Treat "options" in a more or less uniform way for get/put/delete/query. This got more involved than I was anticipating. Sorry about the large diff.