### PR TITLE
Implement transaction for queries.

### DIFF
--- a/src/google/cloud/ndb/__init__.py
+++ b/src/google/cloud/ndb/__init__.py
@@ -30,6 +30,7 @@ __all__ = [
     "ContextOptions",
     "EVENTUAL",
     "EVENTUAL_CONSISTENCY",
+    "STRONG",
     "TransactionOptions",
     "Key",
     "BlobKey",
@@ -131,6 +132,7 @@ from google.cloud.ndb.context import get_context
 from google.cloud.ndb.context import TransactionOptions
 from google.cloud.ndb._datastore_api import EVENTUAL
 from google.cloud.ndb._datastore_api import EVENTUAL_CONSISTENCY
+from google.cloud.ndb._datastore_api import STRONG
 from google.cloud.ndb._datastore_query import Cursor
 from google.cloud.ndb._datastore_query import QueryIterator
 from google.cloud.ndb.key import Key

--- a/src/google/cloud/ndb/_datastore_query.py
+++ b/src/google/cloud/ndb/_datastore_query.py
@@ -704,8 +704,14 @@ def _datastore_run_query(query):
     partition_id = entity_pb2.PartitionId(
         project_id=query.project, namespace_id=query.namespace
     )
+    read_options = _datastore_api.get_read_options(
+        query, default_read_consistency=_datastore_api.EVENTUAL
+    )
     request = datastore_pb2.RunQueryRequest(
-        project_id=query.project, partition_id=partition_id, query=query_pb
+        project_id=query.project,
+        partition_id=partition_id,
+        query=query_pb,
+        read_options=read_options,
     )
     response = yield _datastore_api.make_call(
         "RunQuery", request, timeout=query.timeout

--- a/tests/unit/test__datastore_api.py
+++ b/tests/unit/test__datastore_api.py
@@ -403,20 +403,20 @@ class Test_get_read_options:
     @pytest.mark.usefixtures("in_context")
     def test_no_args_no_transaction():
         assert (
-            _api._get_read_options(_options.ReadOptions())
+            _api.get_read_options(_options.ReadOptions())
             == datastore_pb2.ReadOptions()
         )
 
     @staticmethod
     def test_no_args_transaction(context):
         with context.new(transaction=b"txfoo").use():
-            options = _api._get_read_options(_options.ReadOptions())
+            options = _api.get_read_options(_options.ReadOptions())
             assert options == datastore_pb2.ReadOptions(transaction=b"txfoo")
 
     @staticmethod
     def test_args_override_transaction(context):
         with context.new(transaction=b"txfoo").use():
-            options = _api._get_read_options(
+            options = _api.get_read_options(
                 _options.ReadOptions(transaction=b"txbar")
             )
             assert options == datastore_pb2.ReadOptions(transaction=b"txbar")
@@ -424,7 +424,7 @@ class Test_get_read_options:
     @staticmethod
     @pytest.mark.usefixtures("in_context")
     def test_eventually_consistent():
-        options = _api._get_read_options(
+        options = _api.get_read_options(
             _options.ReadOptions(read_consistency=_api.EVENTUAL)
         )
         assert options == datastore_pb2.ReadOptions(
@@ -435,7 +435,7 @@ class Test_get_read_options:
     @pytest.mark.usefixtures("in_context")
     def test_eventually_consistent_with_transaction():
         with pytest.raises(ValueError):
-            _api._get_read_options(
+            _api.get_read_options(
                 _options.ReadOptions(
                     read_consistency=_api.EVENTUAL, transaction=b"txfoo"
                 )

--- a/tests/unit/test__datastore_query.py
+++ b/tests/unit/test__datastore_query.py
@@ -995,17 +995,23 @@ class Test__datastore_run_query:
     def test_it(_datastore_api):
         query = query_module.QueryOptions(project="testing", namespace="")
         query_pb = _datastore_query._query_to_protobuf(query)
+        _datastore_api.make_call.return_value = future_result("foo")
+        read_options = datastore_pb2.ReadOptions()
         request = datastore_pb2.RunQueryRequest(
             project_id="testing",
             partition_id=entity_pb2.PartitionId(
                 project_id="testing", namespace_id=""
             ),
             query=query_pb,
+            read_options=read_options,
         )
-        _datastore_api.make_call.return_value = future_result("foo")
+        _datastore_api.get_read_options.return_value = read_options
         assert _datastore_query._datastore_run_query(query).result() == "foo"
         _datastore_api.make_call.assert_called_once_with(
             "RunQuery", request, timeout=None
+        )
+        _datastore_api.get_read_options.assert_called_once_with(
+            query, default_read_consistency=_datastore_api.EVENTUAL
         )
 
 


### PR DESCRIPTION
Legacy NDB claims to use eventual consistency by default for queries. With
this change eventual consistency is the default when there isn't a
transaction, but when there is a transaction we run a query that will
return results consistent with the current transaction.