### PR TITLE
Fix url in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def main():
         author="Google LLC",
         author_email="googleapis-packages@google.com",
         license="Apache 2.0",
-        url="https://github.com/GoogleCloudPlatform/google-cloud-python",
+        url="https://github.com/googleapis/python-ndb",
         classifiers=[
             "Development Status :: 3 - Alpha",
             "Intended Audience :: Developers",


### PR DESCRIPTION
The URL in setup.py (and therefore the one shown on PyPI) is out of date; this should fix it.