### PR TITLE
Local caching

### DIFF
--- a/src/google/cloud/ndb/_options.py
+++ b/src/google/cloud/ndb/_options.py
@@ -29,8 +29,8 @@ class Options:
         # Supported
         "retries",
         "timeout",
-        # Not yet implemented
         "use_cache",
+        # Not yet implemented
         "use_memcache",
         "use_datastore",
         "memcache_timeout",
@@ -135,9 +135,6 @@ class Options:
                     type(self).__name__, next(iter(kwargs))
                 )
             )
-
-        if self.use_cache is not None:
-            raise NotImplementedError
 
         if self.use_memcache is not None:
             raise NotImplementedError

--- a/src/google/cloud/ndb/context.py
+++ b/src/google/cloud/ndb/context.py
@@ -81,9 +81,9 @@ def get_context():
 class _Cache(collections.UserDict):
     """An in-memory entity cache.
 
-       This cache verifies the fetched entity has the correct key before
-       returning a result, in order to handle cases where the entity's key was
-       modified but the cache's key was not updated."""
+    This cache verifies the fetched entity has the correct key before
+    returning a result, in order to handle cases where the entity's key was
+    modified but the cache's key was not updated."""
 
     def get_and_validate(self, key):
         """Verify that the entity's key has not changed since it was added
@@ -93,6 +93,7 @@ class _Cache(collections.UserDict):
         if entity is None or entity._key == key:
             return entity
         else:
+            del self.data[key]
             raise KeyError(key)
 
 

--- a/src/google/cloud/ndb/context.py
+++ b/src/google/cloud/ndb/context.py
@@ -41,6 +41,7 @@ _ContextTuple = collections.namedtuple(
         "batches",
         "commit_batches",
         "transaction",
+        "cache",
     ],
 )
 
@@ -77,6 +78,27 @@ def get_context():
     raise exceptions.ContextError()
 
 
+class _Cache(collections.UserDict):
+    """An in-memory entity cache.
+
+       This cache verifies the fetched entity has the correct key before
+       returning a result, in order to handle cases where the entity's key was
+       modified but the cache's key was not updated."""
+
+    def __getitem__(self, key):
+        entity = self.data[key]  # May be None, meaning "doesn't exist".
+        if entity is None or entity._key == key:
+            # Verify that the entity's key has not changed since it was added
+            # to the cache. If it has changed, consider this a cache miss.
+            # See issue 13.  http://goo.gl/jxjOP
+            return entity
+        else:
+            raise KeyError(key)
+
+    def clear(self):
+        # Bypass custom __getitem__, which will be activated clear otherwise.
+        self.data.clear()
+
 class _Context(_ContextTuple):
     """Current runtime state.
 
@@ -102,6 +124,7 @@ class _Context(_ContextTuple):
         batches=None,
         commit_batches=None,
         transaction=None,
+        cache=None,
     ):
         if eventloop is None:
             eventloop = _eventloop.EventLoop()
@@ -123,6 +146,7 @@ class _Context(_ContextTuple):
             batches=batches,
             commit_batches=commit_batches,
             transaction=transaction,
+            cache=_Cache(),
         )
 
     def new(self, **kwargs):
@@ -148,6 +172,7 @@ class _Context(_ContextTuple):
         try:
             yield self
         finally:
+            _state.context.cache.update(self.cache)
             _state.context = prev_context
 
 
@@ -159,7 +184,7 @@ class Context(_Context):
 
         This does not affect memcache.
         """
-        raise NotImplementedError
+        self.cache.clear()
 
     def flush(self):
         """Force any pending batch operations to go ahead and run."""

--- a/src/google/cloud/ndb/key.py
+++ b/src/google/cloud/ndb/key.py
@@ -844,7 +844,7 @@ class Key:
         def get():
             if _options.use_cache:
                 try:
-                    # This result may be None even on a cache hit.
+                    # This result may be None, if None is cached for this key.
                     return context_module.get_context().cache.get_and_validate(
                         self
                     )

--- a/src/google/cloud/ndb/key.py
+++ b/src/google/cloud/ndb/key.py
@@ -846,7 +846,8 @@ class Key:
             if use_cache:
                 try:
                     # This result may be None even on a cache hit.
-                    return context_module.get_context().cache[self._key]
+                    return context_module.get_context().cache.safe_getitem(
+                        self._key)
                 except KeyError:
                     pass
 

--- a/src/google/cloud/ndb/key.py
+++ b/src/google/cloud/ndb/key.py
@@ -842,12 +842,11 @@ class Key:
 
         @tasklets.tasklet
         def get():
-
-            if use_cache:
+            if _options.use_cache:
                 try:
                     # This result may be None even on a cache hit.
-                    return context_module.get_context().cache.safe_getitem(
-                        self._key)
+                    return context_module.get_context().cache.get_and_validate(
+                        self)
                 except KeyError:
                     pass
 
@@ -857,8 +856,8 @@ class Key:
             else:
                 result = None
 
-            if use_cache:
-                context_module.get_context().cache[self._key] = result
+            if _options.use_cache:
+                context_module.get_context().cache[self] = result
 
             return result
 
@@ -971,8 +970,8 @@ class Key:
         @tasklets.tasklet
         def delete():
             result = yield _datastore_api.delete(self._key, _options)
-            if use_cache:
-                context_module.get_context().cache[self._key] = None
+            if _options.use_cache:
+                context_module.get_context().cache[self] = None
             return result
 
         future = delete()

--- a/src/google/cloud/ndb/key.py
+++ b/src/google/cloud/ndb/key.py
@@ -846,7 +846,8 @@ class Key:
                 try:
                     # This result may be None even on a cache hit.
                     return context_module.get_context().cache.get_and_validate(
-                        self)
+                        self
+                    )
                 except KeyError:
                     pass
 

--- a/src/google/cloud/ndb/model.py
+++ b/src/google/cloud/ndb/model.py
@@ -42,6 +42,7 @@ from google.cloud.datastore import entity as entity_module
 from google.cloud.datastore import helpers
 from google.cloud.datastore_v1.proto import entity_pb2
 
+from google.cloud.ndb import context as context_module
 from google.cloud.ndb import _datastore_api
 from google.cloud.ndb import _datastore_types
 from google.cloud.ndb import exceptions
@@ -4530,14 +4531,19 @@ class Model(metaclass=MetaModel):
                 entity. This is always a complete key.
         """
 
+        self._pre_put_hook()
+
         @tasklets.tasklet
         def put(self):
-            self._pre_put_hook()
             entity_pb = _entity_to_protobuf(self)
             key_pb = yield _datastore_api.put(entity_pb, _options)
             if key_pb:
                 ds_key = helpers.key_from_protobuf(key_pb)
                 self._key = key_module.Key._from_ds_key(ds_key)
+
+                if use_cache:
+                    context_module.get_context().cache[self._key] = self
+
             return self._key
 
         future = put(self)

--- a/src/google/cloud/ndb/model.py
+++ b/src/google/cloud/ndb/model.py
@@ -4541,7 +4541,7 @@ class Model(metaclass=MetaModel):
                 ds_key = helpers.key_from_protobuf(key_pb)
                 self._key = key_module.Key._from_ds_key(ds_key)
 
-                if use_cache:
+                if _options.use_cache:
                     context_module.get_context().cache[self._key] = self
 
             return self._key

--- a/tests/unit/test__options.py
+++ b/tests/unit/test__options.py
@@ -50,8 +50,8 @@ class TestOptions:
 
     @staticmethod
     def test_constructor_w_use_cache():
-        with pytest.raises(NotImplementedError):
-            MyOptions(use_cache=20)
+        options = MyOptions(use_cache=20)
+        assert options.use_cache == 20
 
     @staticmethod
     def test_constructor_w_memcache_timeout():

--- a/tests/unit/test__transaction.py
+++ b/tests/unit/test__transaction.py
@@ -19,7 +19,6 @@ from unittest import mock
 import pytest
 
 from google.api_core import exceptions as core_exceptions
-from google.cloud.ndb import context as context_module
 from google.cloud.ndb import tasklets
 from google.cloud.ndb import _transaction
 
@@ -52,14 +51,13 @@ class Test_transaction:
     @staticmethod
     def test_transaction_inherits_and_merges_cache(in_context):
         original_cache = in_context.cache
-        in_context.cache['test'] = 'original value'
+        in_context.cache["test"] = "original value"
         with in_context.new(transaction=b"tx123").use() as new_context:
             assert new_context.cache is not original_cache
-            assert new_context.cache['test'] == original_cache['test']
-            new_context.cache['test'] = 'new_value'
-            assert new_context.cache['test'] != original_cache['test']
-        assert in_context.cache['test'] == 'new_value'
-
+            assert new_context.cache["test"] == original_cache["test"]
+            new_context.cache["test"] = "new_value"
+            assert new_context.cache["test"] != original_cache["test"]
+        assert in_context.cache["test"] == "new_value"
 
     @staticmethod
     @mock.patch("google.cloud.ndb._transaction.transaction_async")

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -219,3 +219,33 @@ class TestTransactionOptions:
     def test_constructor():
         with pytest.raises(NotImplementedError):
             context_module.TransactionOptions()
+
+
+class TestCache:
+    @staticmethod
+    def test_get_and_validate_valid():
+        cache = context_module._Cache()
+        test_entity = mock.Mock(_key='test')
+        cache['test'] = test_entity
+        assert cache.get_and_validate('test') is test_entity
+
+    @staticmethod
+    def test_get_and_validate_invalid():
+        cache = context_module._Cache()
+        test_entity = mock.Mock(_key='test')
+        cache['test'] = test_entity
+        test_entity._key = 'changed_key'
+        with pytest.raises(KeyError):
+            cache.get_and_validate('test')
+
+    @staticmethod
+    def test_get_and_validate_none():
+        cache = context_module._Cache()
+        cache['test'] = None
+        assert cache.get_and_validate('test') is None
+
+    @staticmethod
+    def test_get_and_validate_miss():
+        cache = context_module._Cache()
+        with pytest.raises(KeyError):
+            cache.get_and_validate('nonexistent_key')

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -225,27 +225,27 @@ class TestCache:
     @staticmethod
     def test_get_and_validate_valid():
         cache = context_module._Cache()
-        test_entity = mock.Mock(_key='test')
-        cache['test'] = test_entity
-        assert cache.get_and_validate('test') is test_entity
+        test_entity = mock.Mock(_key="test")
+        cache["test"] = test_entity
+        assert cache.get_and_validate("test") is test_entity
 
     @staticmethod
     def test_get_and_validate_invalid():
         cache = context_module._Cache()
-        test_entity = mock.Mock(_key='test')
-        cache['test'] = test_entity
-        test_entity._key = 'changed_key'
+        test_entity = mock.Mock(_key="test")
+        cache["test"] = test_entity
+        test_entity._key = "changed_key"
         with pytest.raises(KeyError):
-            cache.get_and_validate('test')
+            cache.get_and_validate("test")
 
     @staticmethod
     def test_get_and_validate_none():
         cache = context_module._Cache()
-        cache['test'] = None
-        assert cache.get_and_validate('test') is None
+        cache["test"] = None
+        assert cache.get_and_validate("test") is None
 
     @staticmethod
     def test_get_and_validate_miss():
         cache = context_module._Cache()
         with pytest.raises(KeyError):
-            cache.get_and_validate('nonexistent_key')
+            cache.get_and_validate("nonexistent_key")

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -70,8 +70,9 @@ class TestContext:
 
     def test_clear_cache(self):
         context = self._make_one()
-        with pytest.raises(NotImplementedError):
-            context.clear_cache()
+        context.cache["testkey"] = "testdata"
+        context.clear_cache()
+        assert not context.cache
 
     def test_flush(self):
         context = self._make_one()

--- a/tests/unit/test_key.py
+++ b/tests/unit/test_key.py
@@ -556,7 +556,8 @@ class TestKey:
     @unittest.mock.patch("google.cloud.ndb.key._datastore_api")
     @unittest.mock.patch("google.cloud.ndb.model._entity_from_protobuf")
     def test_get_with_cache_hit(
-        _entity_from_protobuf, _datastore_api, in_context):
+        _entity_from_protobuf, _datastore_api, in_context
+    ):
         class Simple(model.Model):
             pass
 
@@ -576,8 +577,7 @@ class TestKey:
     @staticmethod
     @unittest.mock.patch("google.cloud.ndb.key._datastore_api")
     @unittest.mock.patch("google.cloud.ndb.model._entity_from_protobuf")
-    def test_get_no_cache(
-        _entity_from_protobuf, _datastore_api, in_context):
+    def test_get_no_cache(_entity_from_protobuf, _datastore_api, in_context):
         class Simple(model.Model):
             pass
 
@@ -693,7 +693,7 @@ class TestKey:
         in_context.cache[key] = mock_cached_entity
 
         assert key.delete(use_cache=True) == "result"
-        assert in_context.cache[key] == None
+        assert in_context.cache[key] is None
         _datastore_api.delete.assert_called_once_with(
             key._key, _options.Options(use_cache=True)
         )

--- a/tests/unit/test_key.py
+++ b/tests/unit/test_key.py
@@ -535,7 +535,7 @@ class TestKey:
     @pytest.mark.usefixtures("in_context")
     @unittest.mock.patch("google.cloud.ndb.key._datastore_api")
     @unittest.mock.patch("google.cloud.ndb.model._entity_from_protobuf")
-    def test_get(_entity_from_protobuf, _datastore_api):
+    def test_get_with_cache_miss(_entity_from_protobuf, _datastore_api):
         class Simple(model.Model):
             pass
 
@@ -545,10 +545,54 @@ class TestKey:
         _entity_from_protobuf.return_value = "the entity"
 
         key = key_module.Key("Simple", "b", app="c")
-        assert key.get() == "the entity"
+        assert key.get(use_cache=True) == "the entity"
 
         _datastore_api.lookup.assert_called_once_with(
-            key._key, _options.ReadOptions()
+            key._key, _options.ReadOptions(use_cache=True)
+        )
+        _entity_from_protobuf.assert_called_once_with("ds_entity")
+
+    @staticmethod
+    @unittest.mock.patch("google.cloud.ndb.key._datastore_api")
+    @unittest.mock.patch("google.cloud.ndb.model._entity_from_protobuf")
+    def test_get_with_cache_hit(
+        _entity_from_protobuf, _datastore_api, in_context):
+        class Simple(model.Model):
+            pass
+
+        ds_future = tasklets.Future()
+        ds_future.set_result("ds_entity")
+        _datastore_api.lookup.return_value = ds_future
+        _entity_from_protobuf.return_value = "the entity"
+
+        key = key_module.Key("Simple", "b", app="c")
+        mock_cached_entity = unittest.mock.Mock(_key=key)
+        in_context.cache[key] = mock_cached_entity
+        assert key.get(use_cache=True) == mock_cached_entity
+
+        _datastore_api.lookup.assert_not_called()
+        _entity_from_protobuf.assert_not_called()
+
+    @staticmethod
+    @unittest.mock.patch("google.cloud.ndb.key._datastore_api")
+    @unittest.mock.patch("google.cloud.ndb.model._entity_from_protobuf")
+    def test_get_no_cache(
+        _entity_from_protobuf, _datastore_api, in_context):
+        class Simple(model.Model):
+            pass
+
+        ds_future = tasklets.Future()
+        ds_future.set_result("ds_entity")
+        _datastore_api.lookup.return_value = ds_future
+        _entity_from_protobuf.return_value = "the entity"
+
+        key = key_module.Key("Simple", "b", app="c")
+        mock_cached_entity = unittest.mock.Mock(_key=key)
+        in_context.cache[key] = mock_cached_entity
+        assert key.get(use_cache=False) == "the entity"
+
+        _datastore_api.lookup.assert_called_once_with(
+            key._key, _options.ReadOptions(use_cache=False)
         )
         _entity_from_protobuf.assert_called_once_with("ds_entity")
 
@@ -632,6 +676,46 @@ class TestKey:
         assert key.delete() == "result"
         _datastore_api.delete.assert_called_once_with(
             key._key, _options.Options()
+        )
+
+    @staticmethod
+    @unittest.mock.patch("google.cloud.ndb.key._datastore_api")
+    def test_delete_with_cache(_datastore_api, in_context):
+        class Simple(model.Model):
+            pass
+
+        future = tasklets.Future()
+        _datastore_api.delete.return_value = future
+        future.set_result("result")
+
+        key = key_module.Key("Simple", "b", app="c")
+        mock_cached_entity = unittest.mock.Mock(_key=key)
+        in_context.cache[key] = mock_cached_entity
+
+        assert key.delete(use_cache=True) == "result"
+        assert in_context.cache[key] == None
+        _datastore_api.delete.assert_called_once_with(
+            key._key, _options.Options(use_cache=True)
+        )
+
+    @staticmethod
+    @unittest.mock.patch("google.cloud.ndb.key._datastore_api")
+    def test_delete_no_cache(_datastore_api, in_context):
+        class Simple(model.Model):
+            pass
+
+        future = tasklets.Future()
+        _datastore_api.delete.return_value = future
+        future.set_result("result")
+
+        key = key_module.Key("Simple", "b", app="c")
+        mock_cached_entity = unittest.mock.Mock(_key=key)
+        in_context.cache[key] = mock_cached_entity
+
+        assert key.delete(use_cache=False) == "result"
+        assert in_context.cache[key] == mock_cached_entity
+        _datastore_api.delete.assert_called_once_with(
+            key._key, _options.Options(use_cache=False)
         )
 
     @staticmethod


### PR DESCRIPTION
This implements local caching for get, put, delete and transactions. It does not implement the nested "defaults" options system or turn caching on by default as in the original implementation; caching in this PR only works when use_cache=True is passed into methods.

It also alters "pre hooks" so they are run synchronously in the main thread instead of in the nested tasklet to be uniform across these methods and conform to the original implementation.

One thought: once these functions support the trio of use_datastore, use_cache and use_memcache, the matrix of options for testing could become unmanageable, and we may have to consider a complex parameterized test suite for these methods.