### PR TITLE
Support using the Datastore Emulator.

### DIFF
--- a/src/google/cloud/ndb/client.py
+++ b/src/google/cloud/ndb/client.py
@@ -85,7 +85,11 @@ class Client(google_client.ClientWithProject):
         self.host = os.environ.get(
             environment_vars.GCD_HOST, DATASTORE_API_HOST
         )
-        self.secure = True
+
+        # Use insecure connection when using Datastore Emulator, otherwise
+        # use secure connection
+        emulator = bool(os.environ.get("DATASTORE_EMULATOR_HOST"))
+        self.secure = not emulator
 
     @contextlib.contextmanager
     def context(self):


### PR DESCRIPTION
In order to use the Datastore Emulator, the client needs to create an
insecure channel rather than the usual secure channel. This patch checks
for the environment variable ``DATASTORE_EMULATOR_HOST`` which indicates
the user is connecting to the Datastore Emulator, and sets the secure
flag for the client accordingly.

Fixes #110.