### PR TITLE
ndb.Expando properties load and save

### DIFF
--- a/src/google/cloud/ndb/model.py
+++ b/src/google/cloud/ndb/model.py
@@ -571,7 +571,7 @@ def _entity_to_ds_entity(entity, set_key=True):
         if not hasattr(cls, '_properties'):
             continue
 
-        for _, prop in cls._properties.items():
+        for prop in cls._properties.values():
             if (
                 not isinstance(prop, Property)
                 or isinstance(prop, ModelKey)

--- a/src/google/cloud/ndb/model.py
+++ b/src/google/cloud/ndb/model.py
@@ -526,10 +526,16 @@ def _entity_from_ds_entity(ds_entity, model_class=None):
     for name, value in ds_entity.items():
         prop = getattr(model_class, name, None)
         if not (prop is not None and isinstance(prop, Property)):
+            if value is not None and isinstance(entity, Expando):
+                if isinstance(value, list):
+                    value = [(_BaseValue(sub_value) if sub_value else None) for sub_value in value]
+                else:
+                    value = _BaseValue(value)
+                setattr(entity, name, value)
             continue
         if value is not None:
             if prop._repeated:
-                value = [_BaseValue(sub_value) for sub_value in value]
+                value = [(_BaseValue(sub_value) if sub_value else None) for sub_value in value]
             else:
                 value = _BaseValue(value)
         prop._store_value(entity, value)
@@ -562,7 +568,10 @@ def _entity_to_ds_entity(entity, set_key=True):
     """
     data = {}
     for cls in type(entity).mro():
-        for prop in cls.__dict__.values():
+        if not hasattr(cls, '_properties'):
+            continue
+
+        for _, prop in cls._properties.items():
             if (
                 not isinstance(prop, Property)
                 or isinstance(prop, ModelKey)

--- a/tests/system/test_crud.py
+++ b/tests/system/test_crud.py
@@ -417,3 +417,18 @@ def test_insert_entity_with_structured_property(dispose_of):
     assert isinstance(retrieved.bar, OtherKind)
 
     dispose_of(key._key)
+
+@pytest.mark.usefixtures("client_context")
+def test_insert_expando(dispose_of):
+    class SomeKind(ndb.Expando):
+        foo = ndb.IntegerProperty()
+
+    entity = SomeKind(foo=42)
+    entity.expando_prop = "exp-value"
+    key = entity.put()
+
+    retrieved = key.get()
+    assert retrieved.foo == 42
+    assert retrieved.expando_prop == "exp-value"
+
+    dispose_of(key._key)


### PR DESCRIPTION
We are porting our py27 GAE project to py37 GAE and replacing built-in services to their gcloud library counterparts.

During writing exploration tests for python-ndb we found that Expando models properties are **not loaded from datastore for existing models** and also **not saved for new ones**.
Also in the case of repeated properties that contains None values, _BaseValue(value) raising an exception.

After investigation, we made some changes in **_entity_from_ds_entity** and **_entity_to_ds_entity** functions and currently expando properties loads and saves as expected.

Please review.