### PR TITLE
Fix system test under Datastore Emulator. (Fixes #118)

### DIFF
--- a/src/google/cloud/ndb/client.py
+++ b/src/google/cloud/ndb/client.py
@@ -16,6 +16,7 @@
 
 import contextlib
 import os
+import requests
 
 from google.cloud import environment_vars
 from google.cloud import _helpers
@@ -80,7 +81,6 @@ class Client(google_client.ClientWithProject):
     """The scopes required for authenticating as a Cloud Datastore consumer."""
 
     def __init__(self, project=None, namespace=None, credentials=None):
-        super(Client, self).__init__(project=project, credentials=credentials)
         self.namespace = namespace
         self.host = os.environ.get(
             environment_vars.GCD_HOST, DATASTORE_API_HOST
@@ -90,6 +90,22 @@ class Client(google_client.ClientWithProject):
         # use secure connection
         emulator = bool(os.environ.get("DATASTORE_EMULATOR_HOST"))
         self.secure = not emulator
+
+        if emulator:
+            # When using the emulator, in theory, the client should need to
+            # call home to authenticate, as you don't need to authenticate to
+            # use the local emulator. Unfortunately, the client calls home to
+            # authenticate anyway, unless you pass ``requests.Session`` to
+            # ``_http`` which seems to be the preferred work around.
+            super(Client, self).__init__(
+                project=project,
+                credentials=credentials,
+                _http=requests.Session,
+            )
+        else:
+            super(Client, self).__init__(
+                project=project, credentials=credentials
+            )
 
     @contextlib.contextmanager
     def context(self, cache_policy=None):

--- a/src/google/cloud/ndb/client.py
+++ b/src/google/cloud/ndb/client.py
@@ -92,7 +92,7 @@ class Client(google_client.ClientWithProject):
         self.secure = not emulator
 
         if emulator:
-            # When using the emulator, in theory, the client should need to
+            # When using the emulator, in theory, the client shouldn't need to
             # call home to authenticate, as you don't need to authenticate to
             # use the local emulator. Unfortunately, the client calls home to
             # authenticate anyway, unless you pass ``requests.Session`` to

--- a/src/google/cloud/ndb/query.py
+++ b/src/google/cloud/ndb/query.py
@@ -2279,7 +2279,7 @@ class Query:
             results.append(result.entity())
             cursor = result.cursor
 
-        more = (
+        more = results and (
             iterator._more_results_after_limit or iterator.probably_has_next()
         )
         return results, cursor, more

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -1,12 +1,24 @@
 import itertools
+import os
 import uuid
 
 import pytest
+import requests
 
 from google.cloud import datastore
 from google.cloud import ndb
 
 from . import KIND, OTHER_KIND, OTHER_NAMESPACE
+
+
+def _make_ds_client(namespace):
+    emulator = bool(os.environ.get("DATASTORE_EMULATOR_HOST"))
+    if emulator:
+        client = datastore.Client(namespace=namespace, _http=requests.Session)
+    else:
+        client = datastore.Client(namespace=namespace)
+
+    return client
 
 
 def all_entities(client):
@@ -20,7 +32,7 @@ def all_entities(client):
 @pytest.fixture(scope="module", autouse=True)
 def initial_clean():
     # Make sure database is in clean state at beginning of test run
-    client = datastore.Client()
+    client = _make_ds_client(None)
     for entity in all_entities(client):
         client.delete(entity.key)
 
@@ -36,39 +48,42 @@ def to_delete():
 
 
 @pytest.fixture
-def ds_client(namespace, to_delete, deleted_keys):
-    client = datastore.Client(namespace=namespace)
+def ds_client(namespace):
+    return _make_ds_client(namespace)
 
+
+@pytest.fixture
+def with_ds_client(ds_client, to_delete, deleted_keys):
     # Make sure we're leaving database as clean as we found it after each test
     results = [
         entity
-        for entity in all_entities(client)
+        for entity in all_entities(ds_client)
         if entity.key not in deleted_keys
     ]
     assert not results
 
-    yield client
+    yield ds_client
 
     if to_delete:
-        client.delete_multi(to_delete)
+        ds_client.delete_multi(to_delete)
         deleted_keys.update(to_delete)
 
     not_deleted = [
         entity
-        for entity in all_entities(client)
+        for entity in all_entities(ds_client)
         if entity.key not in deleted_keys
     ]
     assert not not_deleted
 
 
 @pytest.fixture
-def ds_entity(ds_client, dispose_of):
+def ds_entity(with_ds_client, dispose_of):
     def make_entity(*key_args, **entity_kwargs):
-        key = ds_client.key(*key_args)
-        assert ds_client.get(key) is None
+        key = with_ds_client.key(*key_args)
+        assert with_ds_client.get(key) is None
         entity = datastore.Entity(key=key)
         entity.update(entity_kwargs)
-        ds_client.put(entity)
+        with_ds_client.put(entity)
         dispose_of(key)
 
         return entity
@@ -77,7 +92,7 @@ def ds_entity(ds_client, dispose_of):
 
 
 @pytest.fixture
-def dispose_of(ds_client, to_delete):
+def dispose_of(with_ds_client, to_delete):
     def delete_entity(ds_key):
         to_delete.append(ds_key)
 

--- a/tests/system/test_crud.py
+++ b/tests/system/test_crud.py
@@ -22,7 +22,6 @@ import pytest
 
 import test_utils.system
 
-from google.cloud import datastore
 from google.cloud import ndb
 
 from tests.system import KIND, eventually
@@ -132,7 +131,7 @@ def test_retrieve_two_entities_in_parallel(ds_entity):
 
 
 @pytest.mark.usefixtures("client_context")
-def test_insert_entity(dispose_of):
+def test_insert_entity(dispose_of, ds_client):
     class SomeKind(ndb.Model):
         foo = ndb.IntegerProperty()
         bar = ndb.StringProperty()
@@ -145,7 +144,6 @@ def test_insert_entity(dispose_of):
     assert retrieved.bar == "none"
 
     # Make sure strings are stored as strings in datastore
-    ds_client = datastore.Client()
     ds_entity = ds_client.get(key._key)
     assert ds_entity["bar"] == "none"
 

--- a/tests/system/test_query.py
+++ b/tests/system/test_query.py
@@ -522,6 +522,9 @@ def test_fetch_page(dispose_of):
         page_size, start_cursor=next_cursor
     )
     assert [entity.foo for entity in results] == [5, 6, 7, 8, 9]
+
+    results, cursor, more = query.fetch_page(page_size, start_cursor=cursor)
+    assert not results
     assert not more
 
 


### PR DESCRIPTION
Improve usage of Datastore Emulator by not requiring credentials to be
set.

Rewrite failing system test to work around emulator discrepency with
``more_results`` field of ``QueryResultsBatch`` message.

See: https://github.com/GoogleCloudPlatform/google-cloud-datastore/issues/130

Update the ``more`` return value of ``Query.fetch_page`` to be ``False``
if an empty page has just been retrieved. This is intended to prevent
possible infinite loops in client code when using the Datastore
emulator.

Fixes #118 