### PR TITLE
Remote caching

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@
    blobstore
    metadata
    stats
+   remote_cache
 
 This is a Python 3 version of the `ndb` client library for use with
 `Google Cloud Datastore <https://cloud.google.com/datastore>`_.

--- a/docs/remote_cache.rst
+++ b/docs/remote_cache.rst
@@ -1,0 +1,9 @@
+##################
+Remote Cache
+##################
+
+.. automodule:: google.cloud.ndb.remote_cache
+    :members:
+    :exclude-members:
+    :undoc-members:
+    :show-inheritance:

--- a/src/google/cloud/ndb/__init__.py
+++ b/src/google/cloud/ndb/__init__.py
@@ -121,6 +121,7 @@ __all__ = [
     "toplevel",
     "wait_all",
     "wait_any",
+    "RemoteCacheAdapter",
 ]
 """All top-level exported names."""
 
@@ -224,3 +225,4 @@ from google.cloud.ndb._transaction import transactional
 from google.cloud.ndb._transaction import transactional_async
 from google.cloud.ndb._transaction import transactional_tasklet
 from google.cloud.ndb._transaction import non_transactional
+from google.cloud.ndb.remote_cache import RemoteCacheAdapter

--- a/src/google/cloud/ndb/_options.py
+++ b/src/google/cloud/ndb/_options.py
@@ -30,8 +30,8 @@ class Options:
         "retries",
         "timeout",
         "use_cache",
-        "use_memcache",
-        "memcache_timeout",
+        "use_remote_cache",
+        "remote_cache_timeout",
         # Not yet implemented
         "use_datastore",
         "max_memcache_items",

--- a/src/google/cloud/ndb/_options.py
+++ b/src/google/cloud/ndb/_options.py
@@ -31,9 +31,9 @@ class Options:
         "timeout",
         "use_cache",
         "use_memcache",
+        "memcache_timeout",
         # Not yet implemented
         "use_datastore",
-        "memcache_timeout",
         "max_memcache_items",
         # Might or might not implement
         "force_writes",
@@ -137,9 +137,6 @@ class Options:
             )
 
         if self.use_datastore is not None:
-            raise NotImplementedError
-
-        if self.memcache_timeout is not None:
             raise NotImplementedError
 
         if self.max_memcache_items is not None:

--- a/src/google/cloud/ndb/_options.py
+++ b/src/google/cloud/ndb/_options.py
@@ -30,8 +30,8 @@ class Options:
         "retries",
         "timeout",
         "use_cache",
-        # Not yet implemented
         "use_memcache",
+        # Not yet implemented
         "use_datastore",
         "memcache_timeout",
         "max_memcache_items",
@@ -135,9 +135,6 @@ class Options:
                     type(self).__name__, next(iter(kwargs))
                 )
             )
-
-        if self.use_memcache is not None:
-            raise NotImplementedError
 
         if self.use_datastore is not None:
             raise NotImplementedError

--- a/src/google/cloud/ndb/_transaction.py
+++ b/src/google/cloud/ndb/_transaction.py
@@ -115,7 +115,7 @@ def _transaction_async(context, callback, read_only=False):
             yield _datastore_api.rollback(transaction_id)
             raise
 
-        yield tx_context.clear_memcache()
+        yield tx_context.clear_remote_cache()
 
         return result
 

--- a/src/google/cloud/ndb/_transaction.py
+++ b/src/google/cloud/ndb/_transaction.py
@@ -99,7 +99,8 @@ def _transaction_async(context, callback, read_only=False):
         read_only, retries=0
     )
 
-    with context.new(transaction=transaction_id).use():
+    tx_context = context.new(transaction=transaction_id)
+    with tx_context.use():
         try:
             # Run the callback
             result = callback()
@@ -113,6 +114,8 @@ def _transaction_async(context, callback, read_only=False):
         except:
             yield _datastore_api.rollback(transaction_id)
             raise
+
+        yield tx_context.clear_memcache()
 
         return result
 

--- a/src/google/cloud/ndb/client.py
+++ b/src/google/cloud/ndb/client.py
@@ -108,7 +108,7 @@ class Client(google_client.ClientWithProject):
             )
 
     @contextlib.contextmanager
-    def context(self, cache_policy=None):
+    def context(self, cache_policy=None, remote_cache=None):
         """Establish a context for a set of NDB calls.
 
         This method provides a context manager which establishes the runtime
@@ -143,7 +143,11 @@ class Client(google_client.ClientWithProject):
                 cache policy to use in this context. See:
                 :meth:`~google.cloud.ndb.context.Context.set_cache_policy`.
         """
-        context = context_module.Context(self, cache_policy=cache_policy)
+        context = context_module.Context(
+            self,
+            cache_policy=cache_policy,
+            remote_cache=remote_cache,
+        )
         with context.use():
             yield context
 

--- a/src/google/cloud/ndb/client.py
+++ b/src/google/cloud/ndb/client.py
@@ -112,8 +112,8 @@ class Client(google_client.ClientWithProject):
         self,
         cache_policy=None,
         remote_cache=None,
-        memcache_policy=None,
-        memcache_timeout_policy=None,
+        remote_cache_policy=None,
+        remote_cache_timeout_policy=None,
     ):
         """Establish a context for a set of NDB calls.
 
@@ -153,8 +153,8 @@ class Client(google_client.ClientWithProject):
             self,
             cache_policy=cache_policy,
             remote_cache=remote_cache,
-            memcache_policy=memcache_policy,
-            memcache_timeout_policy=memcache_timeout_policy,
+            remote_cache_policy=remote_cache_policy,
+            remote_cache_timeout_policy=remote_cache_timeout_policy,
         )
         with context.use():
             yield context

--- a/src/google/cloud/ndb/client.py
+++ b/src/google/cloud/ndb/client.py
@@ -108,7 +108,13 @@ class Client(google_client.ClientWithProject):
             )
 
     @contextlib.contextmanager
-    def context(self, cache_policy=None, remote_cache=None):
+    def context(
+        self,
+        cache_policy=None,
+        remote_cache=None,
+        memcache_policy=None,
+        memcache_timeout_policy=None,
+    ):
         """Establish a context for a set of NDB calls.
 
         This method provides a context manager which establishes the runtime
@@ -147,6 +153,8 @@ class Client(google_client.ClientWithProject):
             self,
             cache_policy=cache_policy,
             remote_cache=remote_cache,
+            memcache_policy=memcache_policy,
+            memcache_timeout_policy=memcache_timeout_policy,
         )
         with context.use():
             yield context

--- a/src/google/cloud/ndb/client.py
+++ b/src/google/cloud/ndb/client.py
@@ -148,6 +148,15 @@ class Client(google_client.ClientWithProject):
             cache_policy (Optional[Callable[[key.Key], bool]]): The
                 cache policy to use in this context. See:
                 :meth:`~google.cloud.ndb.context.Context.set_cache_policy`.
+            remote_cache (Optional[remote_cache.RemoteCacheAdapter]):
+                The remote cache adapter. See:
+                :class:`~google.cloud.ndb.remote_cache.RemoteCacheAdapter`.
+            remote_cache_policy (Optional[Callable[[key.Key], bool]]): The
+                remote cache policy to use in this context. See:
+                :meth:`~google.cloud.ndb.context.Context.set_remote_cache_policy`.
+            remote_cache_timeout_policy (Optional[Callable[[key.Key], int]]):
+                The remote cache timeout to use in this context. See:
+                :meth:`~google.cloud.ndb.context.Context.set_remote_cache_timeout_policy`.
         """
         context = context_module.Context(
             self,

--- a/src/google/cloud/ndb/context.py
+++ b/src/google/cloud/ndb/context.py
@@ -108,7 +108,7 @@ def _default_cache_policy(key):
 
 
 def _default_remote_cache_policy(key):
-    """The default remote_cache policy.
+    """The default remote cache policy.
 
     Defers to ``_use_remote_cache`` on the Model class for the key's kind.
 
@@ -129,7 +129,7 @@ def _default_remote_cache_policy(key):
 
 
 def _default_remote_cache_timeout_policy(key):
-    """The default remote_cache timeout policy.
+    """The default remote cache timeout policy.
 
     Defers to ``_remote_cache_timeout`` on the Model class for the key's kind.
 
@@ -274,9 +274,7 @@ class Context(_Context):
         self.cache.clear()
 
     def clear_remote_cache(self):
-        """Clears the in-memory cache.
-
-        This does not affect remote_cache.
+        """Clears the remote cache.
         """
 
         keys = set(
@@ -319,18 +317,18 @@ class Context(_Context):
         raise NotImplementedError
 
     def get_remote_cache_policy(self):
-        """Return the current remote_cache policy function.
+        """Return the current remote cache policy function.
 
         Returns:
             Callable: A function that accepts a
                 :class:`~google.cloud.ndb.key.Key` instance as a single
                 positional argument and returns a ``bool`` indicating if it
-                should be cached. May be :data:`None`.
+                should be cached remotely. May be :data:`None`.
         """
         return self.remote_cache_policy
 
     def get_remote_cache_timeout_policy(self):
-        """Return the current policy function remote_cache timeout (expiration).
+        """Return the current policy function remote cache timeout (expiration).
 
         Returns:
             Callable: A function that accepts a
@@ -373,13 +371,13 @@ class Context(_Context):
         raise NotImplementedError
 
     def set_remote_cache_policy(self, policy):
-        """Set the remote_cache policy function.
+        """Set the remote cache policy function.
 
         Args:
             policy (Callable): A function that accepts a
                 :class:`~google.cloud.ndb.key.Key` instance as a single
                 positional argument and returns a ``bool`` indicating if it
-                should be cached.  May be :data:`None`.
+                should be cached remotely.  May be :data:`None`.
         """
         if policy is None:
             policy = _default_remote_cache_policy
@@ -393,7 +391,7 @@ class Context(_Context):
         self.remote_cache_policy = policy
 
     def set_remote_cache_timeout_policy(self, policy):
-        """Set the policy function for remote_cache timeout (expiration).
+        """Set the policy function for remote cache timeout (expiration).
 
         Args:
             policy (Callable): A function that accepts a
@@ -509,7 +507,7 @@ class Context(_Context):
         return flag
 
     def _use_remote_cache(self, key, options):
-        """Return whether to use the context cache for this key."""
+        """Return whether to use the remote cache for this key."""
         flag = None
         if options:
             flag = options.use_remote_cache
@@ -520,7 +518,7 @@ class Context(_Context):
         return flag
 
     def _remote_cache_timeout(self, key, options):
-        """Return whether to use the context cache for this key."""
+        """Return remote cache timeout (expiration) for this key."""
         timeout = None
         if options:
             timeout = options.remote_cache_timeout

--- a/src/google/cloud/ndb/key.py
+++ b/src/google/cloud/ndb/key.py
@@ -876,7 +876,8 @@ class Key:
                 context.cache[self] = result
 
             if use_memcache and result and not remote_cache_locked:
-                yield remote_cache.cache_cas(self, result)
+                expire = context._memcache_timeout(self, _options)
+                yield remote_cache.cache_cas(self, result, expire=expire)
 
             return result
 

--- a/src/google/cloud/ndb/key.py
+++ b/src/google/cloud/ndb/key.py
@@ -726,9 +726,9 @@ class Key:
         deadline=None,
         force_writes=None,
         use_cache=None,
-        use_memcache=None,
+        use_remote_cache=None,
         use_datastore=None,
-        memcache_timeout=None,
+        remote_cache_timeout=None,
         max_memcache_items=None,
         _options=None,
     ):
@@ -757,12 +757,13 @@ class Key:
                 user controlled read-only periods.)
             use_cache (bool): Specifies whether to store entities in in-process
                 cache; overrides in-process cache policy for this operation.
-            use_memcache (bool): Specifies whether to store entities in
-                memcache; overrides memcache policy for this operation.
+            use_remote_cache (bool): Specifies whether to store entities in
+                remote cache; overrides remote cache policy for this operation.
             use_datastore (bool): Specifies whether to store entities in
                 Datastore; overrides Datastore policy for this operation.
-            memcache_timeout (int): Maximum lifetime for entities in memcache;
-                overrides memcache timeout policy for this operation.
+            remote_cache_timeout (int): Maximum lifetime for entities in
+                remote cache; overrides remote cache timeout policy for this
+                operation.
             max_memcache_items (int): Maximum batch size for the auto-batching
                 feature of the Context memcache methods. For example, with the
                 default size of max_memcache_items (100), up to 100 memcache
@@ -787,9 +788,9 @@ class Key:
         deadline=None,
         force_writes=None,
         use_cache=None,
-        use_memcache=None,
+        use_remote_cache=None,
         use_datastore=None,
-        memcache_timeout=None,
+        remote_cache_timeout=None,
         max_memcache_items=None,
         _options=None,
     ):
@@ -818,12 +819,13 @@ class Key:
                 user controlled read-only periods.)
             use_cache (bool): Specifies whether to store entities in in-process
                 cache; overrides in-process cache policy for this operation.
-            use_memcache (bool): Specifies whether to store entities in
-                memcache; overrides memcache policy for this operation.
+            use_remote_cache (bool): Specifies whether to store entities in
+                remote cache; overrides remote cache policy for this operation.
             use_datastore (bool): Specifies whether to store entities in
                 Datastore; overrides Datastore policy for this operation.
-            memcache_timeout (int): Maximum lifetime for entities in memcache;
-                overrides memcache timeout policy for this operation.
+            remote_cache_timeout (int): Maximum lifetime for entities in
+                remote cache; overrides remote cache timeout policy for this
+                operation.
             max_memcache_items (int): Maximum batch size for the auto-batching
                 feature of the Context memcache methods. For example, with the
                 default size of max_memcache_items (100), up to 100 memcache
@@ -845,9 +847,9 @@ class Key:
         def get():
             context = context_module.get_context()
             use_cache = context._use_cache(self, _options)
-            use_memcache = context._use_memcache(self, _options)
+            use_remote_cache = context._use_remote_cache(self, _options)
             if context.in_transaction():
-                use_memcache = False
+                use_remote_cache = False
 
             if use_cache:
                 try:
@@ -857,7 +859,7 @@ class Key:
                     pass
 
             remote_cache_locked = False
-            if use_memcache:
+            if use_remote_cache:
                 result = yield remote_cache.cache_get(self)
                 remote_cache_locked = remote_cache.is_locked_value(result)
                 if result is not None and not remote_cache_locked:
@@ -875,8 +877,8 @@ class Key:
             if use_cache:
                 context.cache[self] = result
 
-            if use_memcache and result and not remote_cache_locked:
-                expire = context._memcache_timeout(self, _options)
+            if use_remote_cache and result and not remote_cache_locked:
+                expire = context._remote_cache_timeout(self, _options)
                 yield remote_cache.cache_cas(self, result, expire=expire)
 
             return result
@@ -897,9 +899,9 @@ class Key:
         deadline=None,
         force_writes=None,
         use_cache=None,
-        use_memcache=None,
+        use_remote_cache=None,
         use_datastore=None,
-        memcache_timeout=None,
+        remote_cache_timeout=None,
         max_memcache_items=None,
         _options=None,
     ):
@@ -924,12 +926,12 @@ class Key:
                 user controlled read-only periods.)
             use_cache (bool): Specifies whether to store entities in in-process
                 cache; overrides in-process cache policy for this operation.
-            use_memcache (bool): Specifies whether to store entities in
-                memcache; overrides memcache policy for this operation.
+            use_remote_cache (bool): Specifies whether to store entities in
+                remote cache; overrides remote cache policy for this operation.
             use_datastore (bool): Specifies whether to store entities in
                 Datastore; overrides Datastore policy for this operation.
-            memcache_timeout (int): Maximum lifetime for entities in memcache;
-                overrides memcache timeout policy for this operation.
+            remote_cache_timeout (int): Maximum lifetime for entities in
+                remote cache; overrides remote cache timeout policy for this operation.
             max_memcache_items (int): Maximum batch size for the auto-batching
                 feature of the Context memcache methods. For example, with the
                 default size of max_memcache_items (100), up to 100 memcache
@@ -949,9 +951,9 @@ class Key:
         deadline=None,
         force_writes=None,
         use_cache=None,
-        use_memcache=None,
+        use_remote_cache=None,
         use_datastore=None,
-        memcache_timeout=None,
+        remote_cache_timeout=None,
         max_memcache_items=None,
         _options=None,
     ):
@@ -969,12 +971,13 @@ class Key:
                 user controlled read-only periods.)
             use_cache (bool): Specifies whether to store entities in in-process
                 cache; overrides in-process cache policy for this operation.
-            use_memcache (bool): Specifies whether to store entities in
-                memcache; overrides memcache policy for this operation.
+            use_remote_cache (bool): Specifies whether to store entities in
+                remote cache; overrides remote cache policy for this operation.
             use_datastore (bool): Specifies whether to store entities in
                 Datastore; overrides Datastore policy for this operation.
-            memcache_timeout (int): Maximum lifetime for entities in memcache;
-                overrides memcache timeout policy for this operation.
+            remote_cache_timeout (int): Maximum lifetime for entities in
+                remote cache; overrides remote cache timeout policy for this
+                operation.
             max_memcache_items (int): Maximum batch size for the auto-batching
                 feature of the Context memcache methods. For example, with the
                 default size of max_memcache_items (100), up to 100 memcache
@@ -990,14 +993,14 @@ class Key:
         @tasklets.tasklet
         def delete():
             context = context_module.get_context()
-            use_memcache = context._use_memcache(self, _options)
+            use_remote_cache = context._use_remote_cache(self, _options)
 
-            if use_memcache:
+            if use_remote_cache:
                 yield remote_cache.cache_set_locked(self)
 
             result = yield _datastore_api.delete(self._key, _options)
 
-            if use_memcache and not context.in_transaction():
+            if use_remote_cache and not context.in_transaction():
                 yield remote_cache.cache_delete(self)
 
             if context._use_cache(self, _options):

--- a/src/google/cloud/ndb/key.py
+++ b/src/google/cloud/ndb/key.py
@@ -875,7 +875,7 @@ class Key:
             if use_cache:
                 context.cache[self] = result
 
-            if use_memcache and not remote_cache_locked:
+            if use_memcache and result and not remote_cache_locked:
                 yield remote_cache.cache_cas(self, result)
 
             return result

--- a/src/google/cloud/ndb/metadata.py
+++ b/src/google/cloud/ndb/metadata.py
@@ -62,7 +62,7 @@ class _BaseMetadata(model.Model):
     __slots__ = ()
 
     _use_cache = False
-    _use_memcache = False
+    _use_remote_cache = False
 
     KIND_NAME = ""
 

--- a/src/google/cloud/ndb/model.py
+++ b/src/google/cloud/ndb/model.py
@@ -2964,7 +2964,7 @@ class UserProperty(Property):
             >>>
             >>> entity.put()
             >>> # Reload without the cached values
-            >>> entity = entity.key.get(use_cache=False, use_memcache=False)
+            >>> entity = entity.key.get(use_cache=False, use_remote_cache=False)
             >>> entity.u.user_id()
             '...9174...'
 
@@ -4718,9 +4718,9 @@ class Model(metaclass=MetaModel):
         deadline=None,
         force_writes=None,
         use_cache=None,
-        use_memcache=None,
+        use_remote_cache=None,
         use_datastore=None,
-        memcache_timeout=None,
+        remote_cache_timeout=None,
         max_memcache_items=None,
         _options=None,
     ):
@@ -4741,12 +4741,13 @@ class Model(metaclass=MetaModel):
                 user controlled read-only periods.)
             use_cache (bool): Specifies whether to store entities in in-process
                 cache; overrides in-process cache policy for this operation.
-            use_memcache (bool): Specifies whether to store entities in
-                memcache; overrides memcache policy for this operation.
+            use_remote_cache (bool): Specifies whether to store entities in
+                remote cache; overrides remote cache policy for this operation.
             use_datastore (bool): Specifies whether to store entities in
                 Datastore; overrides Datastore policy for this operation.
-            memcache_timeout (int): Maximum lifetime for entities in memcache;
-                overrides memcache timeout policy for this operation.
+            remote_cache_timeout (int): Maximum lifetime for entities in
+                remote cache; overrides remote cache timeout policy for this
+                operation.
             max_memcache_items (int): Maximum batch size for the auto-batching
                 feature of the Context memcache methods. For example, with the
                 default size of max_memcache_items (100), up to 100 memcache
@@ -4769,9 +4770,9 @@ class Model(metaclass=MetaModel):
         deadline=None,
         force_writes=None,
         use_cache=None,
-        use_memcache=None,
+        use_remote_cache=None,
         use_datastore=None,
-        memcache_timeout=None,
+        remote_cache_timeout=None,
         max_memcache_items=None,
         _options=None,
     ):
@@ -4792,12 +4793,13 @@ class Model(metaclass=MetaModel):
                 user controlled read-only periods.)
             use_cache (bool): Specifies whether to store entities in in-process
                 cache; overrides in-process cache policy for this operation.
-            use_memcache (bool): Specifies whether to store entities in
-                memcache; overrides memcache policy for this operation.
+            use_remote_cache (bool): Specifies whether to store entities in
+                remote cache; overrides remote cache policy for this operation.
             use_datastore (bool): Specifies whether to store entities in
                 Datastore; overrides Datastore policy for this operation.
-            memcache_timeout (int): Maximum lifetime for entities in memcache;
-                overrides memcache timeout policy for this operation.
+            remote_cache_timeout (int): Maximum lifetime for entities in
+                remote cache; overrides remote cache timeout policy for this
+                operation.
             max_memcache_items (int): Maximum batch size for the auto-batching
                 feature of the Context memcache methods. For example, with the
                 default size of max_memcache_items (100), up to 100 memcache
@@ -4814,8 +4816,8 @@ class Model(metaclass=MetaModel):
         @tasklets.tasklet
         def put(self):
             context = context_module.get_context()
-            use_memcache = context._use_memcache(self.key, _options)
-            if use_memcache and self._has_complete_key():
+            use_remote_cache = context._use_remote_cache(self.key, _options)
+            if use_remote_cache and self._has_complete_key():
                 yield remote_cache.cache_set_locked(self.key)
 
             entity_pb = _entity_to_protobuf(self)
@@ -4824,7 +4826,7 @@ class Model(metaclass=MetaModel):
                 ds_key = helpers.key_from_protobuf(key_pb)
                 self._key = key_module.Key._from_ds_key(ds_key)
 
-                if use_memcache and not context.in_transaction():
+                if use_remote_cache and not context.in_transaction():
                     yield remote_cache.cache_delete(self.key)
 
                 if context._use_cache(self._key, _options):
@@ -4928,9 +4930,9 @@ class Model(metaclass=MetaModel):
         deadline=None,
         force_writes=None,
         use_cache=None,
-        use_memcache=None,
+        use_remote_cache=None,
         use_datastore=None,
-        memcache_timeout=None,
+        remote_cache_timeout=None,
         max_memcache_items=None,
         _options=None,
     ):
@@ -4952,12 +4954,13 @@ class Model(metaclass=MetaModel):
                 user controlled read-only periods.)
             use_cache (bool): Specifies whether to store entities in in-process
                 cache; overrides in-process cache policy for this operation.
-            use_memcache (bool): Specifies whether to store entities in
-                memcache; overrides memcache policy for this operation.
+            use_remote_cache (bool): Specifies whether to store entities in
+                remote cache; overrides remote cache policy for this operation.
             use_datastore (bool): Specifies whether to store entities in
                 Datastore; overrides Datastore policy for this operation.
-            memcache_timeout (int): Maximum lifetime for entities in memcache;
-                overrides memcache timeout policy for this operation.
+            remote_cache_timeout (int): Maximum lifetime for entities in
+                remote cache; overrides remote cache timeout policy for this
+                operation.
             max_memcache_items (int): Maximum batch size for the auto-batching
                 feature of the Context memcache methods. For example, with the
                 default size of max_memcache_items (100), up to 100 memcache
@@ -4985,9 +4988,9 @@ class Model(metaclass=MetaModel):
         deadline=None,
         force_writes=None,
         use_cache=None,
-        use_memcache=None,
+        use_remote_cache=None,
         use_datastore=None,
-        memcache_timeout=None,
+        remote_cache_timeout=None,
         max_memcache_items=None,
         _options=None,
     ):
@@ -5009,12 +5012,13 @@ class Model(metaclass=MetaModel):
                 user controlled read-only periods.)
             use_cache (bool): Specifies whether to store entities in in-process
                 cache; overrides in-process cache policy for this operation.
-            use_memcache (bool): Specifies whether to store entities in
-                memcache; overrides memcache policy for this operation.
+            use_remote_cache (bool): Specifies whether to store entities in
+                remote cache; overrides remote cache policy for this operation.
             use_datastore (bool): Specifies whether to store entities in
                 Datastore; overrides Datastore policy for this operation.
-            memcache_timeout (int): Maximum lifetime for entities in memcache;
-                overrides memcache timeout policy for this operation.
+            remote_cache_timeout (int): Maximum lifetime for entities in
+                remote cache; overrides remote cache timeout policy for this
+                operation.
             max_memcache_items (int): Maximum batch size for the auto-batching
                 feature of the Context memcache methods. For example, with the
                 default size of max_memcache_items (100), up to 100 memcache
@@ -5080,9 +5084,9 @@ class Model(metaclass=MetaModel):
         deadline=None,
         force_writes=None,
         use_cache=None,
-        use_memcache=None,
+        use_remote_cache=None,
         use_datastore=None,
-        memcache_timeout=None,
+        remote_cache_timeout=None,
         max_memcache_items=None,
         _options=None,
     ):
@@ -5119,12 +5123,13 @@ class Model(metaclass=MetaModel):
                 user controlled read-only periods.)
             use_cache (bool): Specifies whether to store entities in in-process
                 cache; overrides in-process cache policy for this operation.
-            use_memcache (bool): Specifies whether to store entities in
-                memcache; overrides memcache policy for this operation.
+            use_remote_cache (bool): Specifies whether to store entities in
+                remote cache; overrides remote cache policy for this operation.
             use_datastore (bool): Specifies whether to store entities in
                 Datastore; overrides Datastore policy for this operation.
-            memcache_timeout (int): Maximum lifetime for entities in memcache;
-                overrides memcache timeout policy for this operation.
+            remote_cache_timeout (int): Maximum lifetime for entities in
+                remote cache; overrides remote cache timeout policy for this
+                operation.
             max_memcache_items (int): Maximum batch size for the auto-batching
                 feature of the Context memcache methods. For example, with the
                 default size of max_memcache_items (100), up to 100 memcache
@@ -5163,9 +5168,9 @@ class Model(metaclass=MetaModel):
         deadline=None,
         force_writes=None,
         use_cache=None,
-        use_memcache=None,
+        use_remote_cache=None,
         use_datastore=None,
-        memcache_timeout=None,
+        remote_cache_timeout=None,
         max_memcache_items=None,
         _options=None,
     ):
@@ -5202,12 +5207,13 @@ class Model(metaclass=MetaModel):
                 user controlled read-only periods.)
             use_cache (bool): Specifies whether to store entities in in-process
                 cache; overrides in-process cache policy for this operation.
-            use_memcache (bool): Specifies whether to store entities in
-                memcache; overrides memcache policy for this operation.
+            use_remote_cache (bool): Specifies whether to store entities in
+                remote cache; overrides remote cache policy for this operation.
             use_datastore (bool): Specifies whether to store entities in
                 Datastore; overrides Datastore policy for this operation.
-            memcache_timeout (int): Maximum lifetime for entities in memcache;
-                overrides memcache timeout policy for this operation.
+            remote_cache_timeout (int): Maximum lifetime for entities in
+                remote cache; overrides remote cache timeout policy for this
+                operation.
             max_memcache_items (int): Maximum batch size for the auto-batching
                 feature of the Context memcache methods. For example, with the
                 default size of max_memcache_items (100), up to 100 memcache
@@ -5259,9 +5265,9 @@ class Model(metaclass=MetaModel):
         deadline=None,
         force_writes=None,
         use_cache=None,
-        use_memcache=None,
+        use_remote_cache=None,
         use_datastore=None,
-        memcache_timeout=None,
+        remote_cache_timeout=None,
         max_memcache_items=None,
         _options=None,
         **kw_model_args,
@@ -5310,12 +5316,13 @@ class Model(metaclass=MetaModel):
                 user controlled read-only periods.)
             use_cache (bool): Specifies whether to store entities in in-process
                 cache; overrides in-process cache policy for this operation.
-            use_memcache (bool): Specifies whether to store entities in
-                memcache; overrides memcache policy for this operation.
+            use_remote_cache (bool): Specifies whether to store entities in
+                remote cache; overrides remote cache policy for this operation.
             use_datastore (bool): Specifies whether to store entities in
                 Datastore; overrides Datastore policy for this operation.
-            memcache_timeout (int): Maximum lifetime for entities in memcache;
-                overrides memcache timeout policy for this operation.
+            remote_cache_timeout (int): Maximum lifetime for entities in
+                remote cache; overrides remote cache timeout policy for this
+                operation.
             max_memcache_items (int): Maximum batch size for the auto-batching
                 feature of the Context memcache methods. For example, with the
                 default size of max_memcache_items (100), up to 100 memcache
@@ -5355,9 +5362,9 @@ class Model(metaclass=MetaModel):
         deadline=None,
         force_writes=None,
         use_cache=None,
-        use_memcache=None,
+        use_remote_cache=None,
         use_datastore=None,
-        memcache_timeout=None,
+        remote_cache_timeout=None,
         max_memcache_items=None,
         _options=None,
         **kw_model_args,
@@ -5400,12 +5407,13 @@ class Model(metaclass=MetaModel):
                 user controlled read-only periods.)
             use_cache (bool): Specifies whether to store entities in in-process
                 cache; overrides in-process cache policy for this operation.
-            use_memcache (bool): Specifies whether to store entities in
-                memcache; overrides memcache policy for this operation.
+            use_remote_cache (bool): Specifies whether to store entities in
+                remote cache; overrides remote cache policy for this operation.
             use_datastore (bool): Specifies whether to store entities in
                 Datastore; overrides Datastore policy for this operation.
-            memcache_timeout (int): Maximum lifetime for entities in memcache;
-                overrides memcache timeout policy for this operation.
+            remote_cache_timeout (int): Maximum lifetime for entities in
+                remote cache; overrides remote cache timeout policy for this
+                operation.
             max_memcache_items (int): Maximum batch size for the auto-batching
                 feature of the Context memcache methods. For example, with the
                 default size of max_memcache_items (100), up to 100 memcache
@@ -5587,8 +5595,8 @@ class Expando(Model):
              'superpower': StringProperty('superpower')}
 
     Note: You can inspect the properties of an expando instance using the
-    _properties attribute, as shown above. This property exists for plain Model instances
-    too; it is just not as interesting for those.
+    _properties attribute, as shown above. This property exists for plain
+    Model instances too; it is just not as interesting for those.
     """
 
     # Set this to False (in an Expando subclass or entity) to make
@@ -5659,9 +5667,9 @@ def get_multi_async(
     deadline=None,
     force_writes=None,
     use_cache=None,
-    use_memcache=None,
+    use_remote_cache=None,
     use_datastore=None,
-    memcache_timeout=None,
+    remote_cache_timeout=None,
     max_memcache_items=None,
     _options=None,
 ):
@@ -5689,12 +5697,13 @@ def get_multi_async(
             user controlled read-only periods.)
         use_cache (bool): Specifies whether to store entities in in-process
             cache; overrides in-process cache policy for this operation.
-        use_memcache (bool): Specifies whether to store entities in
-            memcache; overrides memcache policy for this operation.
+        use_remote_cache (bool): Specifies whether to store entities in
+            remote cache; overrides remote cache policy for this operation.
         use_datastore (bool): Specifies whether to store entities in
             Datastore; overrides Datastore policy for this operation.
-        memcache_timeout (int): Maximum lifetime for entities in memcache;
-            overrides memcache timeout policy for this operation.
+        remote_cache_timeout (int): Maximum lifetime for entities in
+            remote cache; overrides remote cache timeout policy for this
+            operation.
         max_memcache_items (int): Maximum batch size for the auto-batching
             feature of the Context memcache methods. For example, with the
             default size of max_memcache_items (100), up to 100 memcache
@@ -5720,9 +5729,9 @@ def get_multi(
     deadline=None,
     force_writes=None,
     use_cache=None,
-    use_memcache=None,
+    use_remote_cache=None,
     use_datastore=None,
-    memcache_timeout=None,
+    remote_cache_timeout=None,
     max_memcache_items=None,
     _options=None,
 ):
@@ -5750,12 +5759,13 @@ def get_multi(
             user controlled read-only periods.)
         use_cache (bool): Specifies whether to store entities in in-process
             cache; overrides in-process cache policy for this operation.
-        use_memcache (bool): Specifies whether to store entities in
-            memcache; overrides memcache policy for this operation.
+        use_remote_cache (bool): Specifies whether to store entities in
+            remote cache; overrides remote cache policy for this operation.
         use_datastore (bool): Specifies whether to store entities in
             Datastore; overrides Datastore policy for this operation.
-        memcache_timeout (int): Maximum lifetime for entities in memcache;
-            overrides memcache timeout policy for this operation.
+        remote_cache_timeout (int): Maximum lifetime for entities in
+            remote cache; overrides remote cache timeout policy for this
+            operation.
         max_memcache_items (int): Maximum batch size for the auto-batching
             feature of the Context memcache methods. For example, with the
             default size of max_memcache_items (100), up to 100 memcache
@@ -5780,9 +5790,9 @@ def put_multi_async(
     deadline=None,
     force_writes=None,
     use_cache=None,
-    use_memcache=None,
+    use_remote_cache=None,
     use_datastore=None,
-    memcache_timeout=None,
+    remote_cache_timeout=None,
     max_memcache_items=None,
     _options=None,
 ):
@@ -5802,11 +5812,11 @@ def put_multi_async(
             user controlled read-only periods.)
         use_cache (bool): Specifies whether to store entities in in-process
             cache; overrides in-process cache policy for this operation.
-        use_memcache (bool): Specifies whether to store entities in
+        use_remote_cache (bool): Specifies whether to store entities in
             memcache; overrides memcache policy for this operation.
         use_datastore (bool): Specifies whether to store entities in
             Datastore; overrides Datastore policy for this operation.
-        memcache_timeout (int): Maximum lifetime for entities in memcache;
+        remote_cache_timeout (int): Maximum lifetime for entities in memcache;
             overrides memcache timeout policy for this operation.
         max_memcache_items (int): Maximum batch size for the auto-batching
             feature of the Context memcache methods. For example, with the
@@ -5829,9 +5839,9 @@ def put_multi(
     deadline=None,
     force_writes=None,
     use_cache=None,
-    use_memcache=None,
+    use_remote_cache=None,
     use_datastore=None,
-    memcache_timeout=None,
+    remote_cache_timeout=None,
     max_memcache_items=None,
     _options=None,
 ):
@@ -5851,11 +5861,11 @@ def put_multi(
             user controlled read-only periods.)
         use_cache (bool): Specifies whether to store entities in in-process
             cache; overrides in-process cache policy for this operation.
-        use_memcache (bool): Specifies whether to store entities in
-            memcache; overrides memcache policy for this operation.
+        use_remote_cache (bool): Specifies whether to store entities in
+            remote cache; overrides remote cache policy for this operation.
         use_datastore (bool): Specifies whether to store entities in
             Datastore; overrides Datastore policy for this operation.
-        memcache_timeout (int): Maximum lifetime for entities in memcache;
+        remote_cache_timeout (int): Maximum lifetime for entities in memcache;
             overrides memcache timeout policy for this operation.
         max_memcache_items (int): Maximum batch size for the auto-batching
             feature of the Context memcache methods. For example, with the
@@ -5879,9 +5889,9 @@ def delete_multi_async(
     deadline=None,
     force_writes=None,
     use_cache=None,
-    use_memcache=None,
+    use_remote_cache=None,
     use_datastore=None,
-    memcache_timeout=None,
+    remote_cache_timeout=None,
     max_memcache_items=None,
     _options=None,
 ):
@@ -5901,12 +5911,12 @@ def delete_multi_async(
             user controlled read-only periods.)
         use_cache (bool): Specifies whether to store entities in in-process
             cache; overrides in-process cache policy for this operation.
-        use_memcache (bool): Specifies whether to store entities in
-            memcache; overrides memcache policy for this operation.
+        use_remote_cache (bool): Specifies whether to store entities in
+            remote cache; overrides remote cache policy for this operation.
         use_datastore (bool): Specifies whether to store entities in
             Datastore; overrides Datastore policy for this operation.
-        memcache_timeout (int): Maximum lifetime for entities in memcache;
-            overrides memcache timeout policy for this operation.
+        remote_cache_timeout (int): Maximum lifetime for entities in remote
+            cache; overrides remote cache timeout policy for this operation.
         max_memcache_items (int): Maximum batch size for the auto-batching
             feature of the Context memcache methods. For example, with the
             default size of max_memcache_items (100), up to 100 memcache
@@ -5928,9 +5938,9 @@ def delete_multi(
     deadline=None,
     force_writes=None,
     use_cache=None,
-    use_memcache=None,
+    use_remote_cache=None,
     use_datastore=None,
-    memcache_timeout=None,
+    remote_cache_timeout=None,
     max_memcache_items=None,
     _options=None,
 ):
@@ -5950,12 +5960,12 @@ def delete_multi(
             user controlled read-only periods.)
         use_cache (bool): Specifies whether to store entities in in-process
             cache; overrides in-process cache policy for this operation.
-        use_memcache (bool): Specifies whether to store entities in
-            memcache; overrides memcache policy for this operation.
+        use_remote_cache (bool): Specifies whether to store entities in
+            remote cache; overrides remote cache policy for this operation.
         use_datastore (bool): Specifies whether to store entities in
             Datastore; overrides Datastore policy for this operation.
-        memcache_timeout (int): Maximum lifetime for entities in memcache;
-            overrides memcache timeout policy for this operation.
+        remote_cache_timeout (int): Maximum lifetime for entities in remote
+            cache; overrides remote cache timeout policy for this operation.
         max_memcache_items (int): Maximum batch size for the auto-batching
             feature of the Context memcache methods. For example, with the
             default size of max_memcache_items (100), up to 100 memcache

--- a/src/google/cloud/ndb/remote_cache.py
+++ b/src/google/cloud/ndb/remote_cache.py
@@ -20,6 +20,8 @@ __all__ = [
 ]
 
 _LOCKED = 0
+_LOCKED_STR = '0'
+_LOCKED_BYTES = b'0'
 _LOCK_TIME = 32
 _PREFIX = "NDB9"
 
@@ -92,7 +94,7 @@ def cache_delete(key, **options):
 
 
 def is_locked_value(value):
-    return value == _LOCKED
+    return value in (_LOCKED, _LOCKED_STR, _LOCKED_BYTES)
 
 
 def _get_batch(batch_cls, options):

--- a/src/google/cloud/ndb/remote_cache.py
+++ b/src/google/cloud/ndb/remote_cache.py
@@ -1,0 +1,292 @@
+"""
+Module Description
+"""
+
+from google.cloud.datastore_v1.proto import entity_pb2
+
+from google.cloud.ndb import context as context_module
+from google.cloud.ndb import _eventloop
+from google.cloud.ndb import tasklets
+
+__all__ = [
+    "RemoteCacheAdapter",
+    "cache_get",
+    "cache_set",
+    "cache_set_locked",
+    "cache_start_cas",
+    "cache_cas",
+    "cache_delete",
+    "is_locked_value",
+]
+
+_LOCKED = 0
+_LOCK_TIME = 32
+_PREFIX = "NDB9"
+
+
+class RemoteCacheAdapter:
+    def cache_key(self, key):
+        items = [_PREFIX, key.urlsafe().decode('ascii')]
+        ns = key.namespace()
+        if ns:
+            items.insert(0, ns)
+        return ':'.join(items)
+
+    def cache_get_multi(self, keys):
+        """Direct pass-through to memcache client."""
+        raise NotImplementedError
+
+    def cache_set_multi(self, values, expire=None):
+        """Direct pass-through to memcache client."""
+        raise NotImplementedError
+
+    def cache_start_cas_multi(self, keys):
+        """Direct pass-through to memcache client."""
+        raise NotImplementedError
+
+    def cache_cas_multi(self, values, expire=None):
+        """Direct pass-through to memcache client."""
+        raise NotImplementedError
+
+    def cache_delete_multi(self, keys):
+        """Direct pass-through to memcache client."""
+        raise NotImplementedError
+
+
+def cache_get(key, **options):
+    """Direct pass-through to memcache client."""
+    batch = _get_batch(_RemoteCacheGetBatch, options)
+    return batch.add(key, **options)
+
+
+def cache_set(key, value, **options):
+    """Direct pass-through to memcache client."""
+    batch = _get_batch(_RemoteCacheSetBatch, options)
+    return batch.add(key, value, **options)
+
+
+def cache_set_locked(key, **options):
+    """Direct pass-through to memcache client."""
+    value = _LOCKED
+    options = options or {}
+    options['expire'] = _LOCK_TIME
+    return cache_set(key, value, **options)
+
+
+def cache_start_cas(key, **options):
+    """Direct pass-through to memcache client."""
+    batch = _get_batch(_RemoteCacheStartCasBatch, options)
+    return batch.add(key, **options)
+
+
+def cache_cas(key, value, **options):
+    """Direct pass-through to memcache client."""
+    batch = _get_batch(_RemoteCacheCasBatch, options)
+    return batch.add(key, value, **options)
+
+
+def cache_delete(key, **options):
+    """Direct pass-through to memcache client."""
+    batch = _get_batch(_RemoteCacheDeleteBatch, options)
+    return batch.add(key, **options)
+
+
+def is_locked_value(value):
+    return value == _LOCKED
+
+
+def _get_batch(batch_cls, options):
+    """Gets a data structure for storing batched calls to Datastore Lookup.
+
+    The batch data structure is stored in the current context. If there is
+    not already a batch started, a new structure is created and an idle
+    callback is added to the current event loop which will eventually perform
+    the batch look up.
+
+    Args:
+        batch_cls (type): Class representing the kind of operation being
+            batched.
+        options (_options.ReadOptions): The options for the request. Calls with
+            different options will be placed in different batches.
+
+    Returns:
+        batch_cls: An instance of the batch class.
+    """
+    context = context_module.get_context()
+    batches = context.batches.get(batch_cls)
+    if batches is None:
+        context.batches[batch_cls] = batches = {}
+
+    options_key = tuple(
+        sorted(
+            (
+                (key, value)
+                for key, value in options.items()
+                if value is not None
+            )
+        )
+    )
+    batch = batches.get(options_key)
+    if batch is not None:
+        return batch
+
+    def idle():
+        batch = batches.pop(options_key)
+        batch.idle_callback()
+
+    batches[options_key] = batch = batch_cls(options)
+    _eventloop.add_idle(idle)
+    return batch
+
+
+class _RemoteCacheGetBatch:
+    """Batch for Lookup requests.
+
+    Attributes:
+        options (Dict[str, Any]): See Args.
+        todo (Dict[bytes, List[tasklets.Future]]: Mapping of serialized key
+            protocol buffers to dependent futures.
+
+    Args:
+        options (_options.ReadOptions): The options for the request. Calls with
+            different options will be placed in different batches.
+    """
+
+    def __init__(self, options):
+        self.options = options
+        self.todo = {}
+
+    def future_info(self, key):
+        return "cache_get({})".format(key)
+
+    def execute(self, adapter, keys):
+        return adapter.cache_get_multi(keys)
+
+    def add(self, key):
+        """Add a key to the batch to look up.
+
+        Args:
+            key (datastore.Key): The key to look up.
+
+        Returns:
+            tasklets.Future: A future for the eventual result.
+        """
+
+        future = tasklets.Future(info=self.future_info(key))
+        adapter = context_module.get_context().remote_cache
+        if not adapter:
+            future.set_result(None)
+            return future
+        todo_key = adapter.cache_key(key)
+        self.todo.setdefault(todo_key, []).append(future)
+        return future
+
+    def idle_callback(self):
+        """Perform a Datastore Lookup on all batched Lookup requests."""
+        from google.cloud.ndb import model
+
+        keys = self.todo.keys()
+
+        # Note: this causes synchronous call
+        adapter = context_module.get_context().remote_cache
+        values = self.execute(adapter, keys)
+        kvs = zip(keys, values)
+        for todo_key, value in kvs:
+            result = value
+            if (value
+                    and not is_locked_value(value)
+                    and not isinstance(value, bool)):
+                pb = entity_pb2.Entity()
+                pb.MergeFromString(value)
+                result = model._entity_from_protobuf(pb)
+            for future in self.todo[todo_key]:
+                future.set_result(result)
+
+
+class _RemoteCacheSetBatch:
+    """Batch for Lookup requests.
+
+    Attributes:
+        options (Dict[str, Any]): See Args.
+        todo (Dict[bytes, List[tasklets.Future]]: Mapping of serialized key
+            protocol buffers to dependent futures.
+
+    Args:
+        options (_options.ReadOptions): The options for the request. Calls with
+            different options will be placed in different batches.
+    """
+
+    def __init__(self, options):
+        self.options = options
+        self.todo = {}
+
+    def future_info(self, value):
+        return "cache_set({})".format(value)
+
+    def execute(self, adapter, mapping):
+        return adapter.cache_set_multi(mapping)
+
+    def add(self, key, value, expire=None):
+        """Add a key to the batch to look up.
+
+        Args:
+            key (datastore.Key): The key to look up.
+
+        Returns:
+            tasklets.Future: A future for the eventual result.
+        """
+        from google.cloud.ndb import model
+
+        future = tasklets.Future(info=self.future_info(value))
+        adapter = context_module.get_context().remote_cache
+        if not adapter:
+            future.set_result(False)
+            return future
+        todo_key = adapter.cache_key(key)
+        todo_value = value
+        if not is_locked_value(value):
+            pb = model._entity_to_protobuf(value)
+            todo_value = pb.SerializePartialToString()
+        self.todo.setdefault(todo_key, []).append((future, todo_value))
+        return future
+
+    def idle_callback(self):
+        """Perform a Datastore Lookup on all batched Lookup requests."""
+        keys = self.todo.keys()
+        adapter = context_module.get_context().remote_cache
+
+        mapping = {}
+        for todo_key in keys:
+            for future, value in self.todo[todo_key]:
+                mapping[todo_key] = value
+
+        # Note: this causes synchronous call
+        results = self.execute(adapter, mapping)
+        for todo_key in keys:
+            result = results[todo_key]
+            for future, value in self.todo[todo_key]:
+                future.set_result(result)
+
+
+class _RemoteCacheStartCasBatch(_RemoteCacheGetBatch):
+    def future_info(self, key):
+        return "cache_start_cas({})".format(key)
+
+    def execute(self, adapter, keys):
+        return adapter.cache_start_cas_multi(keys)
+
+
+class _RemoteCacheCasBatch(_RemoteCacheSetBatch):
+    def future_info(self, value):
+        return "cache_cas({})".format(value)
+
+    def execute(self, adapter, mapping):
+        return adapter.cache_cas_multi(mapping)
+
+
+class _RemoteCacheDeleteBatch(_RemoteCacheGetBatch):
+    def future_info(self, key):
+        return "cache_delete({})".format(key)
+
+    def execute(self, adapter, keys):
+        return adapter.cache_delete_multi(keys)

--- a/src/google/cloud/ndb/remote_cache.py
+++ b/src/google/cloud/ndb/remote_cache.py
@@ -196,7 +196,6 @@ class _RemoteCacheGetBatch:
         Returns:
             tasklets.Future: A future for the eventual result.
         """
-
         future = tasklets.Future(info=self.future_info(key))
         adapter = context_module.get_context().remote_cache
         todo_key = adapter.cache_key(key)
@@ -207,7 +206,7 @@ class _RemoteCacheGetBatch:
         """Perform a Datastore Lookup on all batched Lookup requests."""
         from google.cloud.ndb import model
 
-        keys = self.todo.keys()
+        keys = sorted(self.todo.keys())
 
         # Note: this causes synchronous call
         adapter = context_module.get_context().remote_cache

--- a/src/google/cloud/ndb/remote_cache.py
+++ b/src/google/cloud/ndb/remote_cache.py
@@ -36,28 +36,28 @@ class RemoteCacheAdapter:
         return ':'.join(items)
 
     def cache_get_multi(self, keys):
-        """Direct pass-through to memcache client."""
+        """Direct pass-through to remote cache client."""
         raise NotImplementedError
 
     def cache_set_multi(self, values, expire=None):
-        """Direct pass-through to memcache client."""
+        """Direct pass-through to remote cache client."""
         raise NotImplementedError
 
     def cache_start_cas_multi(self, keys):
-        """Direct pass-through to memcache client."""
+        """Direct pass-through to remote cache client."""
         raise NotImplementedError
 
     def cache_cas_multi(self, values, expire=None):
-        """Direct pass-through to memcache client."""
+        """Direct pass-through to remote cache client."""
         raise NotImplementedError
 
     def cache_delete_multi(self, keys):
-        """Direct pass-through to memcache client."""
+        """Direct pass-through to remote cache client."""
         raise NotImplementedError
 
 
 def cache_get(key, **options):
-    """Direct pass-through to memcache client."""
+    """Direct pass-through to remote cache client."""
     if not remote_cache_available():
         return _do_nothing_future()
     batch = _get_batch(_RemoteCacheGetBatch, options)
@@ -65,7 +65,7 @@ def cache_get(key, **options):
 
 
 def cache_set(key, value, **options):
-    """Direct pass-through to memcache client."""
+    """Direct pass-through to remote cache client."""
     if not remote_cache_available():
         return _do_nothing_future()
     batch = _get_batch(_RemoteCacheSetBatch, options)
@@ -73,7 +73,7 @@ def cache_set(key, value, **options):
 
 
 def cache_set_locked(key, **options):
-    """Direct pass-through to memcache client."""
+    """Direct pass-through to remote cache client."""
     if not remote_cache_available():
         return _do_nothing_future()
     value = _LOCKED
@@ -83,7 +83,7 @@ def cache_set_locked(key, **options):
 
 
 def cache_start_cas(key, **options):
-    """Direct pass-through to memcache client."""
+    """Direct pass-through to remote cache client."""
     if not remote_cache_available():
         return _do_nothing_future()
     batch = _get_batch(_RemoteCacheStartCasBatch, options)
@@ -91,7 +91,7 @@ def cache_start_cas(key, **options):
 
 
 def cache_cas(key, value, **options):
-    """Direct pass-through to memcache client."""
+    """Direct pass-through to remote cache client."""
     if not remote_cache_available():
         return _do_nothing_future()
     batch = _get_batch(_RemoteCacheCasBatch, options)
@@ -99,7 +99,7 @@ def cache_cas(key, value, **options):
 
 
 def cache_delete(key, **options):
-    """Direct pass-through to memcache client."""
+    """Direct pass-through to remote cache client."""
     if not remote_cache_available():
         return _do_nothing_future()
     batch = _get_batch(_RemoteCacheDeleteBatch, options)

--- a/tests/unit/test__options.py
+++ b/tests/unit/test__options.py
@@ -55,8 +55,8 @@ class TestOptions:
 
     @staticmethod
     def test_constructor_w_memcache_timeout():
-        with pytest.raises(NotImplementedError):
-            MyOptions(memcache_timeout=20)
+        options = MyOptions(memcache_timeout=20)
+        assert options.memcache_timeout == 20
 
     @staticmethod
     def test_constructor_w_max_memcache_items():

--- a/tests/unit/test__options.py
+++ b/tests/unit/test__options.py
@@ -39,9 +39,9 @@ class TestOptions:
             MyOptions(timeout=20, deadline=10)
 
     @staticmethod
-    def test_constructor_w_use_memcache():
-        options = MyOptions(use_memcache=20)
-        assert options.use_memcache == 20
+    def test_constructor_w_use_remote_cache():
+        options = MyOptions(use_remote_cache=20)
+        assert options.use_remote_cache == 20
 
     @staticmethod
     def test_constructor_w_use_datastore():
@@ -54,9 +54,9 @@ class TestOptions:
         assert options.use_cache == 20
 
     @staticmethod
-    def test_constructor_w_memcache_timeout():
-        options = MyOptions(memcache_timeout=20)
-        assert options.memcache_timeout == 20
+    def test_constructor_w_remote_cache_timeout():
+        options = MyOptions(remote_cache_timeout=20)
+        assert options.remote_cache_timeout == 20
 
     @staticmethod
     def test_constructor_w_max_memcache_items():

--- a/tests/unit/test__options.py
+++ b/tests/unit/test__options.py
@@ -40,8 +40,8 @@ class TestOptions:
 
     @staticmethod
     def test_constructor_w_use_memcache():
-        with pytest.raises(NotImplementedError):
-            MyOptions(use_memcache=20)
+        options = MyOptions(use_memcache=20)
+        assert options.use_memcache == 20
 
     @staticmethod
     def test_constructor_w_use_datastore():

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -21,6 +21,7 @@ from google.cloud.ndb import exceptions
 from google.cloud.ndb import key as key_module
 from google.cloud.ndb import model
 from google.cloud.ndb import remote_cache
+from google.cloud.ndb import _options
 import tests.unit.utils
 
 
@@ -142,8 +143,23 @@ class TestContext:
 
     def test_get_memcache_timeout_policy(self):
         context = self._make_one()
-        with pytest.raises(NotImplementedError):
-            context.get_memcache_timeout_policy()
+        policy = context.get_memcache_timeout_policy()
+        assert (
+            policy is context_module._default_memcache_timeout_policy
+        )
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test__memcache_timeout_with_options(context):
+        options = _options.ReadOptions(memcache_timeout=10)
+        key = key_module.Key("Simple", "b", app="c")
+        assert context._memcache_timeout(key, options) == 10
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test__memcache_timeout_without_options(context):
+        key = key_module.Key("Simple", "b", app="c")
+        assert context._memcache_timeout(key, None) is None
 
     def test_set_cache_policy(self):
         policy = object()
@@ -182,9 +198,17 @@ class TestContext:
         assert p("") == policy
 
     def test_set_memcache_timeout_policy(self):
+        policy = object()
         context = self._make_one()
-        with pytest.raises(NotImplementedError):
-            context.set_memcache_timeout_policy(None)
+        context.set_memcache_timeout_policy(policy)
+        assert context.get_memcache_timeout_policy() is policy
+
+    def test_set_memcache_timeout_policy_with_int(self):
+        policy = 10
+        context = self._make_one()
+        context.set_memcache_timeout_policy(policy)
+        p = context.get_memcache_timeout_policy()
+        assert p("") == policy
 
     def test_call_on_commit(self):
         context = self._make_one()
@@ -199,11 +223,6 @@ class TestContext:
         context = self._make_one()
         with pytest.raises(NotImplementedError):
             context.default_datastore_policy(None)
-
-    def test_default_memcache_timeout_policy(self):
-        context = self._make_one()
-        with pytest.raises(NotImplementedError):
-            context.default_memcache_timeout_policy(None)
 
     def test_memcache_add(self):
         context = self._make_one()
@@ -359,6 +378,48 @@ class Test_default_memcache_policy:
 
         key = key_module.Key("ThisKind", 0)
         assert context_module._default_memcache_policy(key) is False
+
+
+class Test_default_memcache_timeout_policy:
+    @staticmethod
+    def test_key_is_None():
+        assert context_module._default_memcache_timeout_policy(None) is None
+
+    @staticmethod
+    def test_no_model_class():
+        key = mock.Mock(kind=mock.Mock(return_value="nokind"), spec=("kind",))
+        assert context_module._default_memcache_timeout_policy(key) is None
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test_standard_model():
+        class ThisKind(model.Model):
+            pass
+
+        key = key_module.Key("ThisKind", 0)
+        assert context_module._default_memcache_timeout_policy(key) is None
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test_standard_model_defines_policy():
+        flag = object()
+
+        class ThisKind(model.Model):
+            @classmethod
+            def _memcache_timeout(cls, key):
+                return flag
+
+        key = key_module.Key("ThisKind", 0)
+        assert context_module._default_memcache_timeout_policy(key) is flag
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test_standard_model_defines_policy_as_bool():
+        class ThisKind(model.Model):
+            _memcache_timeout = 10
+
+        key = key_module.Key("ThisKind", 0)
+        assert context_module._default_memcache_timeout_policy(key) == 10
 
 
 class TestCache:

--- a/tests/unit/test_key.py
+++ b/tests/unit/test_key.py
@@ -633,7 +633,8 @@ class TestKey:
             key = key_module.Key("Simple", "b", app="c")
             remote_cache.cache_set(key, remote_cache._LOCKED)
             assert key.get(use_memcache=True) == entity
-            assert remote_cache.is_locked_value(remote_cache.cache_get(key).result())
+            value = remote_cache.cache_get(key).result()
+            assert remote_cache.is_locked_value(value)
 
         _datastore_api.lookup.assert_called_once_with(
             key._key, _options.ReadOptions(use_memcache=True)

--- a/tests/unit/test_key.py
+++ b/tests/unit/test_key.py
@@ -633,7 +633,7 @@ class TestKey:
             key = key_module.Key("Simple", "b", app="c")
             remote_cache.cache_set(key, remote_cache._LOCKED)
             assert key.get(use_memcache=True) == entity
-            assert remote_cache.cache_get(key).result() == remote_cache._LOCKED
+            assert remote_cache.is_locked_value(remote_cache.cache_get(key).result())
 
         _datastore_api.lookup.assert_called_once_with(
             key._key, _options.ReadOptions(use_memcache=True)

--- a/tests/unit/test_key.py
+++ b/tests/unit/test_key.py
@@ -549,15 +549,12 @@ class TestKey:
                 return results
 
             def cache_start_cas_multi(self, keys):
-                """Direct pass-through to memcache client."""
                 return [remote_cache._LOCKED for x in keys]
 
             def cache_cas_multi(self, values, expire=None):
-                """Direct pass-through to memcache client."""
                 return self.cache_set_multi(values, expire=expire)
 
             def cache_delete_multi(self, keys):
-                """Direct pass-through to memcache client."""
                 return [self._cache.pop(x, None) is not None for x in keys]
 
         return RemoteCacheAdapterMock()
@@ -579,10 +576,10 @@ class TestKey:
         _entity_from_protobuf.return_value = entity
 
         key = key_module.Key("Simple", "b", app="c")
-        assert key.get(use_memcache=True) == entity
+        assert key.get(use_remote_cache=True) == entity
 
         _datastore_api.lookup.assert_called_once_with(
-            key._key, _options.ReadOptions(use_memcache=True)
+            key._key, _options.ReadOptions(use_remote_cache=True)
         )
         _entity_from_protobuf.assert_called_once_with("ds_entity")
 
@@ -605,10 +602,10 @@ class TestKey:
             _entity_from_protobuf.return_value = entity
 
             key = key_module.Key("Simple", "b", app="c")
-            assert key.get(use_memcache=True) == entity
+            assert key.get(use_remote_cache=True) == entity
 
         _datastore_api.lookup.assert_called_once_with(
-            key._key, _options.ReadOptions(use_memcache=True)
+            key._key, _options.ReadOptions(use_remote_cache=True)
         )
         _entity_from_protobuf.assert_called_once_with("ds_entity")
 
@@ -632,12 +629,12 @@ class TestKey:
 
             key = key_module.Key("Simple", "b", app="c")
             remote_cache.cache_set(key, remote_cache._LOCKED)
-            assert key.get(use_memcache=True) == entity
+            assert key.get(use_remote_cache=True) == entity
             value = remote_cache.cache_get(key).result()
             assert remote_cache.is_locked_value(value)
 
         _datastore_api.lookup.assert_called_once_with(
-            key._key, _options.ReadOptions(use_memcache=True)
+            key._key, _options.ReadOptions(use_remote_cache=True)
         )
         _entity_from_protobuf.assert_called_once_with("ds_entity")
 
@@ -657,7 +654,7 @@ class TestKey:
             key = key_module.Key("Simple", "b", app="c")
             cached_entity = Simple(key=key)
             remote_cache.cache_set(key, cached_entity)
-            ent = key.get(use_memcache=True)
+            ent = key.get(use_remote_cache=True)
             assert ent == cached_entity
 
         _datastore_api.lookup.assert_not_called()
@@ -683,10 +680,10 @@ class TestKey:
             key = key_module.Key("Simple", "b", app="c")
             cached_entity = Simple(key=key)
             remote_cache.cache_set(key, cached_entity)
-            assert key.get(use_memcache=True) == entity
+            assert key.get(use_remote_cache=True) == entity
 
         _datastore_api.lookup.assert_called_once_with(
-            key._key, _options.ReadOptions(use_memcache=True)
+            key._key, _options.ReadOptions(use_remote_cache=True)
         )
         _entity_from_protobuf.assert_called_once_with("ds_entity")
 
@@ -709,7 +706,7 @@ class TestKey:
             ds_future.set_result("ds_entity")
             _datastore_api.lookup.return_value = ds_future
             _entity_from_protobuf.return_value = entity
-            key.get(use_memcache=True)
+            key.get(use_remote_cache=True)
             assert remote_cache.cache_get(key).result() is not None
 
     @staticmethod
@@ -875,9 +872,9 @@ class TestKey:
             key = key_module.Key("Simple", "b", app="c")
             entity = Simple(key=key)
             remote_cache.cache_set(key, entity).wait()
-            assert key.delete(use_memcache=False) == "result"
+            assert key.delete(use_remote_cache=False) == "result"
             assert remote_cache.cache_get(key).result() == entity
-            key.delete(use_memcache=True)
+            key.delete(use_remote_cache=True)
             assert remote_cache.cache_get(key).result() is None
 
     @staticmethod

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -3652,7 +3652,6 @@ class TestModel:
                 return results
 
             def cache_delete_multi(self, keys):
-                """Direct pass-through to memcache client."""
                 return [self._cache.pop(x, None) is not None for x in keys]
 
         return RemoteCacheAdapterMock()
@@ -3670,10 +3669,10 @@ class TestModel:
             future.set_result(key._key.to_protobuf())
 
             entity_pb = model._entity_to_protobuf(entity)
-            assert entity._put(use_memcache=False) == key
+            assert entity._put(use_remote_cache=False) == key
             assert cache.cache_get(key.urlsafe()) is None
             _datastore_api.put.assert_called_once_with(
-                entity_pb, _options.Options(use_memcache=False)
+                entity_pb, _options.Options(use_remote_cache=False)
             )
 
     @staticmethod
@@ -3689,10 +3688,10 @@ class TestModel:
 
             cache.cache_set(key.urlsafe(), "cache")
             entity_pb = model._entity_to_protobuf(entity)
-            assert entity._put(use_memcache=True) == key
+            assert entity._put(use_remote_cache=True) == key
             assert remote_cache.cache_get(key).result() is None
             _datastore_api.put.assert_called_once_with(
-                entity_pb, _options.Options(use_memcache=True)
+                entity_pb, _options.Options(use_remote_cache=True)
             )
 
     @staticmethod

--- a/tests/unit/test_remote_cache.py
+++ b/tests/unit/test_remote_cache.py
@@ -1,0 +1,94 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+
+from google.cloud.ndb import key as key_module
+from google.cloud.ndb import remote_cache
+import tests.unit.utils
+
+
+def test___all__():
+    tests.unit.utils.verify___all__(remote_cache)
+
+
+class TestAdapter:
+    @staticmethod
+    def test_constructor():
+        adapter = remote_cache.RemoteCacheAdapter()
+        assert isinstance(adapter, remote_cache.RemoteCacheAdapter)
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test_cache_key():
+        adapter = remote_cache.RemoteCacheAdapter()
+        key = key_module.Key("SomeKind", 123)
+        assert adapter.cache_key(key) == "NDB9:agd0ZXN0aW5ncg4LEghTb21lS2luZBh7DA"
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test_cache_key_with_ns():
+        adapter = remote_cache.RemoteCacheAdapter()
+        key = key_module.Key("SomeKind", 123, namespace="ns")
+        assert adapter.cache_key(key) == "ns:NDB9:agd0ZXN0aW5ncg4LEghTb21lS2luZBh7DKIBAm5z"
+
+    @staticmethod
+    def test_cache_get_multi():
+        adapter = remote_cache.RemoteCacheAdapter()
+        with pytest.raises(NotImplementedError):
+            adapter.cache_get_multi(["a"])
+
+    @staticmethod
+    def test_cache_set_multi():
+        adapter = remote_cache.RemoteCacheAdapter()
+        with pytest.raises(NotImplementedError):
+            adapter.cache_set_multi({"a": "b"})
+
+    @staticmethod
+    def test_cache_start_cas_multi():
+        adapter = remote_cache.RemoteCacheAdapter()
+        with pytest.raises(NotImplementedError):
+            adapter.cache_start_cas_multi(["a"])
+
+    @staticmethod
+    def test_cache_cas_multi():
+        adapter = remote_cache.RemoteCacheAdapter()
+        with pytest.raises(NotImplementedError):
+            adapter.cache_cas_multi({"a": "b"})
+
+    @staticmethod
+    def test_cache_delete_multi():
+        adapter = remote_cache.RemoteCacheAdapter()
+        with pytest.raises(NotImplementedError):
+            adapter.cache_delete_multi(["a"])
+
+
+class Test__get_batch:
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test_get_new_batch():
+        kls = remote_cache._RemoteCacheGetBatch
+        options = {"a": "b"}
+        assert isinstance(remote_cache._get_batch(kls, options), kls)
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test_get_cached_batch(in_context):
+        kls = remote_cache._RemoteCacheGetBatch
+        options = {"a": "b"}
+        batch = kls(options)
+        in_context.batches[kls] = {(("a", "b"), ): batch}
+
+        assert remote_cache._get_batch(kls, options) == batch

--- a/tests/unit/test_remote_cache.py
+++ b/tests/unit/test_remote_cache.py
@@ -35,14 +35,16 @@ class TestAdapter:
     def test_cache_key():
         adapter = remote_cache.RemoteCacheAdapter()
         key = key_module.Key("SomeKind", 123)
-        assert adapter.cache_key(key) == "NDB9:agd0ZXN0aW5ncg4LEghTb21lS2luZBh7DA"
+        key_str = "NDB9:agd0ZXN0aW5ncg4LEghTb21lS2luZBh7DA"
+        assert adapter.cache_key(key) == key_str
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
     def test_cache_key_with_ns():
         adapter = remote_cache.RemoteCacheAdapter()
         key = key_module.Key("SomeKind", 123, namespace="ns")
-        assert adapter.cache_key(key) == "ns:NDB9:agd0ZXN0aW5ncg4LEghTb21lS2luZBh7DKIBAm5z"
+        key_str = "ns:NDB9:agd0ZXN0aW5ncg4LEghTb21lS2luZBh7DKIBAm5z"
+        assert adapter.cache_key(key) == key_str
 
     @staticmethod
     def test_cache_get_multi():
@@ -92,3 +94,29 @@ class Test__get_batch:
         in_context.batches[kls] = {(("a", "b"), ): batch}
 
         assert remote_cache._get_batch(kls, options) == batch
+
+
+class Test_remote_cache_available:
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test_remote_cache_unavailable(in_context):
+        assert not remote_cache.remote_cache_available()
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test_remote_cache_available(in_context):
+        with in_context.new(remote_cache="remote_cache").use():
+            assert remote_cache.remote_cache_available()
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test_cache_action_done_with_remote_cache_unavailable(in_context):
+        key = "key"
+        value = "value"
+        assert remote_cache.cache_get(key).done()
+        assert remote_cache.cache_set(key, value).done()
+        assert remote_cache.cache_set_locked(key).done()
+        assert remote_cache.cache_start_cas(key).done()
+        assert remote_cache.cache_cas(key, value).done()
+        assert remote_cache.cache_delete(key).done()
+


### PR DESCRIPTION
PR for remote caching

Overview
===
This PR is based on the premise that we now cannot rely on any specific remote cache backend (unlike memcache for GAE standard 1st generation).
So this PR defines the adapter class (```ndb.RemoteCacheAdapter```) to allow developers to implement their own logic to handle actual operation with their backend. (memcache, redis, and so on)

Below is a sample adapter implementation for Cloud Memorystore.
https://gist.github.com/takashi8/06f2ab86451c6c96862e8f1d2e0b4966

Topics
===
This is kind of large change, and I felt like many things need discussion.

Threading
---
For simplicity I didn't implement any threading for remote cache operation.
Developers should implement background fetching, or it blocks current thread in eventloop.idle or eventloop.current. (Sample is just blocking)
If cache fetch is much faster than datastore fetch, it can be omitted, maybe.

Context.batch
---
Currently all batches are added to context.batches.
Maybe making dedicated property is better.

Ignored Features
---
I ignored several features that seems to be redundant or difficult to support.

* Context.memcache_* functions
* Options.use_datastore
* Options.max_memcache_items
* Options.memcache_deadline
* memcache.MAX_VALUE_SIZE
* Autobatcher.add_once

Renamed "memcache"
---
Now that remote cache is not always memcache, I replaced many "memcache" words with "remote_cache" for integrity.
Still there are room to 
* cascade them (e.g. apply use_memcache value to use_remote_cache automatically).
* just define and raise NoLongerImplementedError.
* do not replace and keep compatible interface as much as we can.

Thanks in advance