### PR TITLE
Enforce naive datetimes for ``DateTimeProperty``.

### DIFF
--- a/src/google/cloud/ndb/_datastore_api.py
+++ b/src/google/cloud/ndb/_datastore_api.py
@@ -251,6 +251,7 @@ class _LookupBatch:
 
         # Process results, which are divided into found, missing, and deferred
         results = rpc.result()
+        log.debug(results)
 
         # For all deferred keys, batch them up again with their original
         # futures

--- a/src/google/cloud/ndb/model.py
+++ b/src/google/cloud/ndb/model.py
@@ -3426,6 +3426,13 @@ class DateTimeProperty(Property):
                 "Expected datetime, got {!r}".format(value)
             )
 
+        if value.tzinfo is not None:
+            raise exceptions.BadValueError(
+                "DatetimeProperty {} can only support naive datetimes "
+                "(presumed UTC). Please derive a new Property to support "
+                "alternate timezones.".format(self._name)
+            )
+
     @staticmethod
     def _now():
         """datetime.datetime: Return current datetime.
@@ -3453,6 +3460,19 @@ class DateTimeProperty(Property):
         ):
             value = self._now()
             self._store_value(entity, value)
+
+    def _from_base_type(self, value):
+        """Convert a value from the "base" value type for this property.
+
+        Args:
+            value (datetime.datetime): The value to be converted.
+
+        Returns:
+            Optional[datetime.datetime]: The value without ``tzinfo`` or
+                ``None`` if value did not have ``tzinfo`` set.
+        """
+        if value.tzinfo is not None:
+            return value.replace(tzinfo=None)
 
 
 class DateProperty(DateTimeProperty):

--- a/tests/system/test_crud.py
+++ b/tests/system/test_crud.py
@@ -227,6 +227,20 @@ def test_insert_entity(dispose_of, ds_client):
     dispose_of(key._key)
 
 
+@pytest.mark.usefixtures("client_context")
+def test_insert_roundtrip_naive_datetime(dispose_of, ds_client):
+    class SomeKind(ndb.Model):
+        foo = ndb.DateTimeProperty()
+
+    entity = SomeKind(foo=datetime.datetime(2010, 5, 12, 2, 42))
+    key = entity.put()
+
+    retrieved = key.get()
+    assert retrieved.foo == datetime.datetime(2010, 5, 12, 2, 42)
+
+    dispose_of(key._key)
+
+
 def test_parallel_threads(dispose_of, namespace):
     client = ndb.Client(namespace=namespace)
 

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -14,6 +14,7 @@
 
 import datetime
 import pickle
+import pytz
 import types
 import unittest.mock
 import zlib
@@ -2427,6 +2428,13 @@ class TestDateTimeProperty:
             prop._validate(None)
 
     @staticmethod
+    def test__validate_with_tz():
+        prop = model.DateTimeProperty(name="dt_val")
+        value = datetime.datetime.now(tz=pytz.utc)
+        with pytest.raises(exceptions.BadValueError):
+            prop._validate(value)
+
+    @staticmethod
     def test__now():
         dt_val = model.DateTimeProperty._now()
         assert isinstance(dt_val, datetime.datetime)
@@ -2485,6 +2493,18 @@ class TestDateTimeProperty:
         prop = model.DateTimeProperty(name="dt_val")
         with pytest.raises(NotImplementedError):
             prop._db_get_value(None, None)
+
+    @staticmethod
+    def test__from_base_type_no_timezone():
+        prop = model.DateTimeProperty(name="dt_val")
+        value = datetime.datetime.now()
+        assert prop._from_base_type(value) is None
+
+    @staticmethod
+    def test__from_base_type_timezone():
+        prop = model.DateTimeProperty(name="dt_val")
+        value = datetime.datetime(2010, 5, 12, tzinfo=pytz.utc)
+        assert prop._from_base_type(value) == datetime.datetime(2010, 5, 12)
 
 
 class TestDateProperty:


### PR DESCRIPTION
Legacy NDB enforced that only naive datetimes could be set for a
DateTime property and it always returned naive datetimes.
This adds a validation exception if the user tries to set a datetime
with a timezone on a DateTimeProperty and also strips datetimes of
``tzinfo`` as they're being read from Datastore, as Datastore adds the
UTC timezone to datetimes when reading out from the database.

Fixes #165.