### PR TITLE
Store Structured Properties in backwards compatible way

### DIFF
--- a/google/cloud/ndb/client.py
+++ b/google/cloud/ndb/client.py
@@ -114,6 +114,7 @@ class Client(google_client.ClientWithProject):
         global_cache=None,
         global_cache_policy=None,
         global_cache_timeout_policy=None,
+        legacy_data=True,
     ):
         """Establish a context for a set of NDB calls.
 
@@ -157,6 +158,8 @@ class Client(google_client.ClientWithProject):
             global_cache_timeout_policy (Optional[Callable[[key.Key], int]]):
                 The global cache timeout to use in this context. See:
                 :meth:`~google.cloud.ndb.context.Context.set_global_cache_timeout_policy`.
+            legacy_data (bool): Set to ``True`` (the default) to write data in
+                a way that can be read by the legacy version of NDB.
         """
         context = context_module.Context(
             self,
@@ -164,6 +167,7 @@ class Client(google_client.ClientWithProject):
             global_cache=global_cache,
             global_cache_policy=global_cache_policy,
             global_cache_timeout_policy=global_cache_timeout_policy,
+            legacy_data=legacy_data,
         )
         with context.use():
             yield context

--- a/google/cloud/ndb/context.py
+++ b/google/cloud/ndb/context.py
@@ -144,6 +144,7 @@ _ContextTuple = collections.namedtuple(
         "cache",
         "global_cache",
         "on_commit_callbacks",
+        "legacy_data",
     ],
 )
 
@@ -180,6 +181,7 @@ class _Context(_ContextTuple):
         global_cache_timeout_policy=None,
         datastore_policy=None,
         on_commit_callbacks=None,
+        legacy_data=True,
     ):
         if eventloop is None:
             eventloop = _eventloop.EventLoop()
@@ -210,6 +212,7 @@ class _Context(_ContextTuple):
             cache=new_cache,
             global_cache=global_cache,
             on_commit_callbacks=on_commit_callbacks,
+            legacy_data=legacy_data,
         )
 
         context.set_cache_policy(cache_policy)

--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -647,6 +647,18 @@ def _entity_from_protobuf(protobuf):
 
 
 def _properties_of(entity):
+    """Get the model properties for an entity.
+
+    Will traverse the entity's MRO (class hierarchy) up from the entity's class
+    through all of its ancestors, collecting an ``Property`` instances defined
+    for those classes.
+
+    Args:
+        entity (model.Model): The entity to get properties for.
+
+    Returns:
+        Iterator[Property]: Iterator over the entity's properties.
+    """
     seen = set()
 
     for cls in type(entity).mro():

--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -3900,7 +3900,7 @@ class StructuredProperty(Property):
         return len(values)
 
     def _to_datastore(self, entity, data, prefix="", repeated=False):
-        """Override of :method:`StructuredProperty._to_datastore`.
+        """Override of :method:`Property._to_datastore`.
 
         If ``legacy_data`` is ``True``, then we need to override the default
         behavior to store everything in a single Datastore entity that uses

--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -646,6 +646,25 @@ def _entity_from_protobuf(protobuf):
     return _entity_from_ds_entity(ds_entity)
 
 
+def _properties_of(entity):
+    seen = set()
+
+    for cls in type(entity).mro():
+        if not hasattr(cls, "_properties"):
+            continue
+
+        for prop in cls._properties.values():
+            if (
+                not isinstance(prop, Property)
+                or isinstance(prop, ModelKey)
+                or prop._name in seen
+            ):
+                continue
+
+            seen.add(prop._name)
+            yield prop
+
+
 def _entity_to_ds_entity(entity, set_key=True):
     """Convert an NDB entity to Datastore entity.
 
@@ -662,33 +681,20 @@ def _entity_to_ds_entity(entity, set_key=True):
     uninitialized = []
     exclude_from_indexes = []
 
-    for cls in type(entity).mro():
-        if not hasattr(cls, "_properties"):
-            continue
+    for prop in _properties_of(entity):
+        if not prop._is_initialized(entity):
+            uninitialized.append(prop._name)
 
-        for prop in cls._properties.values():
-            if (
-                not isinstance(prop, Property)
-                or isinstance(prop, ModelKey)
-                or prop._name in data
-            ):
-                continue
+        names = prop._to_datastore(entity, data)
 
-            if not prop._is_initialized(entity):
-                uninitialized.append(prop._name)
-
-            value = prop._get_base_value_unwrapped_as_list(entity)
-            if not prop._repeated:
-                value = value[0]
-            data[prop._name] = value
-
-            if not prop._indexed:
-                exclude_from_indexes.append(prop._name)
+        if not prop._indexed:
+            for name in names:
+                exclude_from_indexes.append(name)
 
     if uninitialized:
-        names = ", ".join(uninitialized)
+        missing = ", ".join(uninitialized)
         raise exceptions.BadValueError(
-            "Entity has uninitialized properties: {}".format(names)
+            "Entity has uninitialized properties: {}".format(missing)
         )
 
     ds_entity = None
@@ -1983,6 +1989,38 @@ class Property(ModelAttribute):
             Any: The user value stored for the current property.
         """
         return self._get_value(entity)
+
+    def _to_datastore(self, entity, data, prefix="", repeated=False):
+        """Helper to convert property to Datastore serializable data.
+
+        Called to help assemble a Datastore entity prior to serialization for
+        storage. Subclasses (like StructuredProperty) may need to override the
+        default behavior.
+
+        Args:
+            entity (entity.Entity): The NDB entity to convert.
+            data (dict): The data that will eventually be used to construct the
+                Datastore entity. This method works by updating ``data``.
+            prefix (str): Optional name prefix used for StructuredProperty (if
+                present, must end in ".".
+            repeated (bool): `True` if values should be repeated because an
+                ancestor node is repeated property.
+
+        Return:
+            Sequence[str]: Any keys that were set on ``data`` by this method
+                call.
+        """
+        value = self._get_base_value_unwrapped_as_list(entity)
+        if not self._repeated:
+            value = value[0]
+
+        key = prefix + self._name
+        if repeated:
+            data.setdefault(key, []).append(value)
+        else:
+            data[key] = value
+
+        return (key,)
 
 
 def _validate_key(value, entity=None):
@@ -3860,6 +3898,46 @@ class StructuredProperty(Property):
         if not isinstance(values, list):
             values = [values]
         return len(values)
+
+    def _to_datastore(self, entity, data, prefix="", repeated=False):
+        """Override of :method:`StructuredProperty._to_datastore`.
+
+        If ``legacy_data`` is ``True``, then we need to override the default
+        behavior to store everything in a single Datastore entity that uses
+        dotted attribute names, rather than nesting entities.
+        """
+        context = context_module.get_context()
+
+        # The easy way
+        if not context.legacy_data:
+            return super(StructuredProperty, self)._to_datastore(
+                entity, data, prefix=prefix, repeated=repeated
+            )
+
+        # The hard way
+        next_prefix = prefix + self._name + "."
+        next_repeated = repeated or self._repeated
+        keys = []
+
+        values = self._get_user_value(entity)
+        if not self._repeated:
+            values = (values,)
+
+        for value in values:
+            if value is None:
+                keys.extend(
+                    super(StructuredProperty, self)._to_datastore(
+                        entity, data, prefix=prefix, repeated=repeated
+                    )
+                )
+                continue
+
+            for prop in _properties_of(value):
+                keys.extend(prop._to_datastore(
+                    value, data, prefix=next_prefix, repeated=next_repeated
+                ))
+
+        return keys
 
 
 class LocalStructuredProperty(BlobProperty):

--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -3933,11 +3933,13 @@ class StructuredProperty(Property):
                 continue
 
             for prop in _properties_of(value):
-                keys.extend(prop._to_datastore(
-                    value, data, prefix=next_prefix, repeated=next_repeated
-                ))
+                keys.extend(
+                    prop._to_datastore(
+                        value, data, prefix=next_prefix, repeated=next_repeated
+                    )
+                )
 
-        return keys
+        return set(keys)
 
 
 class LocalStructuredProperty(BlobProperty):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,6 +90,7 @@ def context():
         stub=mock.Mock(spec=()),
         eventloop=TestingEventLoop(),
         datastore_policy=True,
+        legacy_data=False,
     )
     return context
 

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -107,5 +107,8 @@ def namespace():
 @pytest.fixture
 def client_context(namespace):
     client = ndb.Client(namespace=namespace)
-    with client.context(cache_policy=False) as the_context:
+    with client.context(
+        cache_policy=False,
+        legacy_data=False,
+    ) as the_context:
         yield the_context

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -107,8 +107,5 @@ def namespace():
 @pytest.fixture
 def client_context(namespace):
     client = ndb.Client(namespace=namespace)
-    with client.context(
-        cache_policy=False,
-        legacy_data=False,
-    ) as the_context:
+    with client.context(cache_policy=False, legacy_data=False) as the_context:
         yield the_context

--- a/tests/system/test_query.py
+++ b/tests/system/test_query.py
@@ -1168,9 +1168,9 @@ def test_query_repeated_structured_property_with_projection_legacy_data(
             SomeKind.foo < 2
         )
 
-        # This counter-intuitive result is consistent with Legacy NDB behavior and
-        # is a result of the odd way Datastore handles projection queries with
-        # array valued properties:
+        # This counter-intuitive result is consistent with Legacy NDB behavior
+        # and is a result of the odd way Datastore handles projection queries
+        # with array valued properties:
         #
         # https://cloud.google.com/datastore/docs/concepts/queries#projections_and_array-valued_properties
         #

--- a/tests/system/test_query.py
+++ b/tests/system/test_query.py
@@ -628,6 +628,54 @@ def test_query_structured_property(dispose_of):
     assert results[1].foo == 2
 
 
+def test_query_structured_property_legacy_data(client_context, dispose_of):
+    class OtherKind(ndb.Model):
+        one = ndb.StringProperty()
+        two = ndb.StringProperty()
+        three = ndb.StringProperty()
+
+    class SomeKind(ndb.Model):
+        foo = ndb.IntegerProperty()
+        bar = ndb.StructuredProperty(OtherKind)
+
+    @ndb.synctasklet
+    def make_entities():
+        entity1 = SomeKind(
+            foo=1, bar=OtherKind(one="pish", two="posh", three="pash")
+        )
+        entity2 = SomeKind(
+            foo=2, bar=OtherKind(one="pish", two="posh", three="push")
+        )
+        entity3 = SomeKind(
+            foo=3,
+            bar=OtherKind(one="pish", two="moppish", three="pass the peas"),
+        )
+
+        keys = yield (
+            entity1.put_async(),
+            entity2.put_async(),
+            entity3.put_async(),
+        )
+        raise ndb.Return(keys)
+
+    with client_context.new(legacy_data=True).use():
+        keys = make_entities()
+        eventually(SomeKind.query().fetch, _length_equals(3))
+        for key in keys:
+            dispose_of(key._key)
+
+        query = (
+            SomeKind.query()
+            .filter(SomeKind.bar.one == "pish", SomeKind.bar.two == "posh")
+            .order(SomeKind.foo)
+        )
+
+        results = query.fetch()
+        assert len(results) == 2
+        assert results[0].foo == 1
+        assert results[1].foo == 2
+
+
 @pytest.mark.usefixtures("client_context")
 def test_query_legacy_structured_property(ds_entity):
     class OtherKind(ndb.Model):
@@ -796,6 +844,67 @@ def test_query_repeated_structured_property_with_properties(dispose_of):
     assert results[1].foo == 2
 
 
+def test_query_repeated_structured_property_with_properties_legacy_data(
+    client_context, dispose_of
+):
+    class OtherKind(ndb.Model):
+        one = ndb.StringProperty()
+        two = ndb.StringProperty()
+        three = ndb.StringProperty()
+
+    class SomeKind(ndb.Model):
+        foo = ndb.IntegerProperty()
+        bar = ndb.StructuredProperty(OtherKind, repeated=True)
+
+    @ndb.synctasklet
+    def make_entities():
+        entity1 = SomeKind(
+            foo=1,
+            bar=[
+                OtherKind(one="pish", two="posh", three="pash"),
+                OtherKind(one="bish", two="bosh", three="bash"),
+            ],
+        )
+        entity2 = SomeKind(
+            foo=2,
+            bar=[
+                OtherKind(one="pish", two="bosh", three="bass"),
+                OtherKind(one="bish", two="posh", three="pass"),
+            ],
+        )
+        entity3 = SomeKind(
+            foo=3,
+            bar=[
+                OtherKind(one="fish", two="fosh", three="fash"),
+                OtherKind(one="bish", two="bosh", three="bash"),
+            ],
+        )
+
+        keys = yield (
+            entity1.put_async(),
+            entity2.put_async(),
+            entity3.put_async(),
+        )
+        raise ndb.Return(keys)
+
+    with client_context.new(legacy_data=True).use():
+        keys = make_entities()
+        eventually(SomeKind.query().fetch, _length_equals(3))
+        for key in keys:
+            dispose_of(key._key)
+
+        query = (
+            SomeKind.query()
+            .filter(SomeKind.bar.one == "pish", SomeKind.bar.two == "posh")
+            .order(SomeKind.foo)
+        )
+
+        results = query.fetch()
+        assert len(results) == 2
+        assert results[0].foo == 1
+        assert results[1].foo == 2
+
+
 @pytest.mark.usefixtures("client_context")
 def test_query_repeated_structured_property_with_entity_twice(dispose_of):
     class OtherKind(ndb.Model):
@@ -855,6 +964,69 @@ def test_query_repeated_structured_property_with_entity_twice(dispose_of):
     results = query.fetch()
     assert len(results) == 1
     assert results[0].foo == 1
+
+
+def test_query_repeated_structured_property_with_entity_twice_legacy_data(
+    client_context, dispose_of
+):
+    class OtherKind(ndb.Model):
+        one = ndb.StringProperty()
+        two = ndb.StringProperty()
+        three = ndb.StringProperty()
+
+    class SomeKind(ndb.Model):
+        foo = ndb.IntegerProperty()
+        bar = ndb.StructuredProperty(OtherKind, repeated=True)
+
+    @ndb.synctasklet
+    def make_entities():
+        entity1 = SomeKind(
+            foo=1,
+            bar=[
+                OtherKind(one="pish", two="posh", three="pash"),
+                OtherKind(one="bish", two="bosh", three="bash"),
+            ],
+        )
+        entity2 = SomeKind(
+            foo=2,
+            bar=[
+                OtherKind(one="bish", two="bosh", three="bass"),
+                OtherKind(one="pish", two="posh", three="pass"),
+            ],
+        )
+        entity3 = SomeKind(
+            foo=3,
+            bar=[
+                OtherKind(one="pish", two="fosh", three="fash"),
+                OtherKind(one="bish", two="posh", three="bash"),
+            ],
+        )
+
+        keys = yield (
+            entity1.put_async(),
+            entity2.put_async(),
+            entity3.put_async(),
+        )
+        raise ndb.Return(keys)
+
+    with client_context.new(legacy_data=True).use():
+        keys = make_entities()
+        eventually(SomeKind.query().fetch, _length_equals(3))
+        for key in keys:
+            dispose_of(key._key)
+
+        query = (
+            SomeKind.query()
+            .filter(
+                SomeKind.bar == OtherKind(one="pish", two="posh"),
+                SomeKind.bar == OtherKind(two="posh", three="pash"),
+            )
+            .order(SomeKind.foo)
+        )
+
+        results = query.fetch()
+        assert len(results) == 1
+        assert results[0].foo == 1
 
 
 @pytest.mark.usefixtures("client_context")
@@ -941,6 +1113,94 @@ def test_query_repeated_structured_property_with_projection(dispose_of):
     assert results[3].bar[0].two == "dangle"
     with pytest.raises(ndb.UnprojectedPropertyError):
         results[3].bar[0].three
+
+
+def test_query_repeated_structured_property_with_projection_legacy_data(
+    client_context, dispose_of
+):
+    class OtherKind(ndb.Model):
+        one = ndb.StringProperty()
+        two = ndb.StringProperty()
+        three = ndb.StringProperty()
+
+    class SomeKind(ndb.Model):
+        foo = ndb.IntegerProperty()
+        bar = ndb.StructuredProperty(OtherKind, repeated=True)
+
+    @ndb.synctasklet
+    def make_entities():
+        entity1 = SomeKind(
+            foo=1,
+            bar=[
+                OtherKind(one="angle", two="cankle", three="pash"),
+                OtherKind(one="bangle", two="dangle", three="bash"),
+            ],
+        )
+        entity2 = SomeKind(
+            foo=2,
+            bar=[
+                OtherKind(one="bish", two="bosh", three="bass"),
+                OtherKind(one="pish", two="posh", three="pass"),
+            ],
+        )
+        entity3 = SomeKind(
+            foo=3,
+            bar=[
+                OtherKind(one="pish", two="fosh", three="fash"),
+                OtherKind(one="bish", two="posh", three="bash"),
+            ],
+        )
+
+        keys = yield (
+            entity1.put_async(),
+            entity2.put_async(),
+            entity3.put_async(),
+        )
+        raise ndb.Return(keys)
+
+    with client_context.new(legacy_data=True).use():
+        keys = make_entities()
+        eventually(SomeKind.query().fetch, _length_equals(3))
+        for key in keys:
+            dispose_of(key._key)
+
+        query = SomeKind.query(projection=("bar.one", "bar.two")).filter(
+            SomeKind.foo < 2
+        )
+
+        # This counter-intuitive result is consistent with Legacy NDB behavior and
+        # is a result of the odd way Datastore handles projection queries with
+        # array valued properties:
+        #
+        # https://cloud.google.com/datastore/docs/concepts/queries#projections_and_array-valued_properties
+        #
+        results = query.fetch()
+        assert len(results) == 4
+
+        def sort_key(result):
+            return (result.bar[0].one, result.bar[0].two)
+
+        results = sorted(results, key=sort_key)
+
+        assert results[0].bar[0].one == "angle"
+        assert results[0].bar[0].two == "cankle"
+        with pytest.raises(ndb.UnprojectedPropertyError):
+            results[0].bar[0].three
+
+        assert results[1].bar[0].one == "angle"
+        assert results[1].bar[0].two == "dangle"
+        with pytest.raises(ndb.UnprojectedPropertyError):
+            results[1].bar[0].three
+
+        assert results[2].bar[0].one == "bangle"
+        assert results[2].bar[0].two == "cankle"
+        with pytest.raises(ndb.UnprojectedPropertyError):
+            results[2].bar[0].three
+
+        assert results[3].bar[0].one == "bangle"
+        assert results[3].bar[0].two == "dangle"
+        with pytest.raises(ndb.UnprojectedPropertyError):
+            results[3].bar[0].three
 
 
 @pytest.mark.usefixtures("client_context")


### PR DESCRIPTION
The NDB rewrite, when storing values for structured properties, has been taking advantage of the native Datastore capability to arbitrarily nest entities as property values. Data written using the new NDB, however, would not be compatible with the legacy (Python 2) version, which always only stores a single entity in Datastore, using dotted property names to store the values of structured properties.

This patch introduces a new context flag, ``legacy_data``, which, when ``True``, causes NDB to store data in such a way as to be backwards compatible with the old version. The flag is ``True`` by default, requiring users to make a conscious decision to break backwards compatibility.

Fixes #178