### PR TITLE
Fix typo in MIGRATION_NOTES.md

### DIFF
--- a/MIGRATION_NOTES.md
+++ b/MIGRATION_NOTES.md
@@ -62,7 +62,7 @@ client = ndb.Client()
 # Assume REDIS_CACHE_URL is set in environment (or not).
 # If left unset, this will return `None`, which effectively allows you to turn
 # global cache on or off using the environment.
-global_cache = ndb.RedisCache().from_environment()
+global_cache = ndb.RedisCache.from_environment()
 
 with client.context(global_cache=global_cache) as context:
     do_stuff_with_ndb()


### PR DESCRIPTION
This typo was leading users astray.