### PR TITLE
Check context

### DIFF
--- a/google/cloud/ndb/client.py
+++ b/google/cloud/ndb/client.py
@@ -161,6 +161,10 @@ class Client(google_client.ClientWithProject):
             legacy_data (bool): Set to ``True`` (the default) to write data in
                 a way that can be read by the legacy version of NDB.
         """
+        context = context_module.get_context(False)
+        if context is not None:
+            raise RuntimeError("Context is already created for this thread.")
+
         context = context_module.Context(
             self,
             cache_policy=cache_policy,

--- a/google/cloud/ndb/context.py
+++ b/google/cloud/ndb/context.py
@@ -51,12 +51,19 @@ def get_context(raise_context_error=True):
     This function should be called within a context established by
     :meth:`google.cloud.ndb.client.Client.context`.
 
+    Args:
+        raise_context_error (bool): If set to :data:`True`, will raise an
+            exception if called outside of a context. Set this to :data:`False`
+            in order to have it just return :data:`None` if called outside of a
+            context. Default: :data:`True`
+
     Returns:
         Context: The current context.
 
     Raises:
         .ContextError: If called outside of a context
-            established by :meth:`google.cloud.ndb.client.Client.context`.
+            established by :meth:`google.cloud.ndb.client.Client.context` and
+            ``raise_context_error`` is :data:`True`.
     """
     context = _state.context
     if context:

--- a/google/cloud/ndb/context.py
+++ b/google/cloud/ndb/context.py
@@ -45,7 +45,7 @@ class _LocalState(threading.local):
 _state = _LocalState()
 
 
-def get_context():
+def get_context(raise_context_error=True):
     """Get the current context.
 
     This function should be called within a context established by
@@ -62,7 +62,8 @@ def get_context():
     if context:
         return context
 
-    raise exceptions.ContextError()
+    if raise_context_error:
+        raise exceptions.ContextError()
 
 
 def _default_policy(attr_name, value_type):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -113,6 +113,7 @@ class TestClient:
             with pytest.raises(RuntimeError):
                 client.context().__enter__()
 
+    @staticmethod
     def test_context_unfinished_business():
         """Regression test for #213.
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -95,10 +95,19 @@ class TestClient:
             client._http
 
     @staticmethod
-    def test__context():
+    def test_context():
         with patch_credentials("testing"):
             client = client_module.Client()
 
         with client.context():
             context = context_module.get_context()
             assert context.client is client
+
+    @staticmethod
+    def test_context_double_jeopardy():
+        with patch_credentials("testing"):
+            client = client_module.Client()
+
+        with client.context():
+            with pytest.raises(RuntimeError):
+                client.context().__enter__()


### PR DESCRIPTION
When creating a top level context, check to make sure there isn't already a running context for this thread. This is an attempt to root a possible weird concurrency problem. Related to #182, but not a fix.
