### PR TITLE
Finish unfinished business in context.

### DIFF
--- a/google/cloud/ndb/client.py
+++ b/google/cloud/ndb/client.py
@@ -172,8 +172,8 @@ class Client(google_client.ClientWithProject):
         with context.use():
             yield context
 
-        # Finish up any work left to do on the event loop
-        context.eventloop.run()
+            # Finish up any work left to do on the event loop
+            context.eventloop.run()
 
     @property
     def _http(self):


### PR DESCRIPTION
Fixes #213. At the end of ``Client.context()`` there's a call to
``context.eventloop.run()`` that used to flush the event queue and
finish any unfinished business on the loop before exiting the context.
Due to an indentation error this call was not occurring with the context
active, so you could get a ``ContextError`` in any handlers run at this
time. This fixes that error.