### PR TITLE
Implement ``Query.map`` and ``Query.map_async``.

### DIFF
--- a/MIGRATION_NOTES.md
+++ b/MIGRATION_NOTES.md
@@ -213,8 +213,11 @@ that are affected are: `memcache_add`, `memcache_cas`, `memcache_decr`,
   from GAE to GCP.
 - The `max_memcache_items` option is no longer supported. 
 - The `force_writes` option is no longer supported.
-- `Query.map` and `Query.map_async` are no longer supported.
 - The `blobstore` module is no longer supported.
+- The `pass_batch_into_callback` argument to `Query.map` and `Query.map_async`
+  is no longer supported.
+- The `merge_future` argument to `Query.map` and `Query.map_async` is no longer
+  supported.
 
 ## Privatization
 

--- a/tests/system/test_query.py
+++ b/tests/system/test_query.py
@@ -1289,3 +1289,35 @@ def test_query_legacy_repeated_structured_property(ds_entity):
     results = query.fetch()
     assert len(results) == 1
     assert results[0].foo == 1
+
+
+@pytest.mark.usefixtures("client_context")
+def test_map(dispose_of):
+    class SomeKind(ndb.Model):
+        foo = ndb.StringProperty()
+        ref = ndb.KeyProperty()
+
+    class OtherKind(ndb.Model):
+        foo = ndb.StringProperty()
+
+    foos = ("aa", "bb", "cc", "dd", "ee")
+    others = [OtherKind(foo=foo) for foo in foos]
+    other_keys = ndb.put_multi(others)
+    for key in other_keys:
+        dispose_of(key._key)
+
+    things = [SomeKind(foo=foo, ref=key) for foo, key in zip(foos, other_keys)]
+    keys = ndb.put_multi(things)
+    for key in keys:
+        dispose_of(key._key)
+
+    eventually(SomeKind.query().fetch, _length_equals(5))
+    eventually(OtherKind.query().fetch, _length_equals(5))
+
+    @ndb.tasklet
+    def get_other_foo(thing):
+        other = yield thing.ref.get_async()
+        return other.foo
+
+    query = SomeKind.query().order(SomeKind.foo)
+    assert query.map(get_other_foo) == foos


### PR DESCRIPTION
Fixes #210 .

A couple of features didn't come along with this implementation:

1) The `pass_batch_into_callback` argument: This wouldn't make a lot of sense in a query that uses an in-memory post filter and is impossible to do in MultiQuery (a logical query that merges the results of more than one Datastore query). While we could conceivably implement this in the case where a query maps directly onto a Datastore query, the details of the batching seem like an implementation detail that needn't really be exposed to the user. The utility of such a feature is uncertain, as well.

2) The `merge_future` argument: This seems to be difficult enough to use that it likely isn't being used. The uses cases it *seems* to be targeting could probably be better handled by adding some user friendly methods, like ``Query.reduce`` or ``Query.map_iter``. At this time we are not aware of anyone using this or needing a work-around.


