### PR TITLE
Implement ``_prepare_for_put`` for ``StructuredProperty`` and ``LocalStructuredProperty``.

### DIFF
--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -4035,6 +4035,14 @@ class StructuredProperty(Property):
 
         return set(keys)
 
+    def _prepare_for_put(self, entity):
+        values = self._get_user_value(entity)
+        if not self._repeated:
+            values = [values]
+        for value in values:
+            if value is not None:
+                value._prepare_for_put()
+
 
 class LocalStructuredProperty(BlobProperty):
     """A property that contains ndb.Model value.
@@ -4129,6 +4137,14 @@ class LocalStructuredProperty(BlobProperty):
         if not self._keep_keys and value.key:
             value.key = None
         return _entity_from_ds_entity(value, model_class=self._model_class)
+
+    def _prepare_for_put(self, entity):
+        values = self._get_user_value(entity)
+        if not self._repeated:
+            values = [values]
+        for value in values:
+            if value is not None:
+                value._prepare_for_put()
 
 
 class GenericProperty(Property):

--- a/tests/system/test_crud.py
+++ b/tests/system/test_crud.py
@@ -913,6 +913,26 @@ def test_insert_autonow_property(dispose_of):
 
 
 @pytest.mark.usefixtures("client_context")
+def test_insert_nested_autonow_property(dispose_of):
+    class OtherKind(ndb.Model):
+        created_at = ndb.DateTimeProperty(indexed=True, auto_now_add=True)
+        updated_at = ndb.DateTimeProperty(indexed=True, auto_now=True)
+
+    class SomeKind(ndb.Model):
+        other = ndb.StructuredProperty(OtherKind)
+
+    entity = SomeKind(other=OtherKind())
+    key = entity.put()
+
+    retrieved = key.get()
+
+    assert isinstance(retrieved.other.created_at, datetime.datetime)
+    assert isinstance(retrieved.other.updated_at, datetime.datetime)
+
+    dispose_of(key._key)
+
+
+@pytest.mark.usefixtures("client_context")
 def test_uninitialized_property(dispose_of):
     class SomeKind(ndb.Model):
         foo = ndb.StringProperty(required=True)

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -3295,6 +3295,45 @@ class TestStructuredProperty:
             assert SomeKind.foo._to_datastore(entity, data) == {"foo.bar"}
             assert data == {"foo.bar": ["baz", "boz"]}
 
+    @staticmethod
+    def test__prepare_for_put():
+        class SubKind(model.Model):
+            bar = model.Property()
+
+        class SomeKind(model.Model):
+            foo = model.StructuredProperty(SubKind)
+
+        entity = SomeKind(foo=SubKind())
+        entity.foo._prepare_for_put = unittest.mock.Mock()
+        SomeKind.foo._prepare_for_put(entity)
+        entity.foo._prepare_for_put.assert_called_once_with()
+
+    @staticmethod
+    def test__prepare_for_put_repeated():
+        class SubKind(model.Model):
+            bar = model.Property()
+
+        class SomeKind(model.Model):
+            foo = model.StructuredProperty(SubKind, repeated=True)
+
+        entity = SomeKind(foo=[SubKind(), SubKind()])
+        entity.foo[0]._prepare_for_put = unittest.mock.Mock()
+        entity.foo[1]._prepare_for_put = unittest.mock.Mock()
+        SomeKind.foo._prepare_for_put(entity)
+        entity.foo[0]._prepare_for_put.assert_called_once_with()
+        entity.foo[1]._prepare_for_put.assert_called_once_with()
+
+    @staticmethod
+    def test__prepare_for_put_repeated_None():
+        class SubKind(model.Model):
+            bar = model.Property()
+
+        class SomeKind(model.Model):
+            foo = model.StructuredProperty(SubKind)
+
+        entity = SomeKind()
+        SomeKind.foo._prepare_for_put(entity)  # noop
+
 
 class TestLocalStructuredProperty:
     @staticmethod
@@ -3396,6 +3435,45 @@ class TestLocalStructuredProperty:
         entity.key = "key"
         expected = Simple()
         assert prop._from_base_type(entity) == expected
+
+    @staticmethod
+    def test__prepare_for_put():
+        class SubKind(model.Model):
+            bar = model.Property()
+
+        class SomeKind(model.Model):
+            foo = model.LocalStructuredProperty(SubKind)
+
+        entity = SomeKind(foo=SubKind())
+        entity.foo._prepare_for_put = unittest.mock.Mock()
+        SomeKind.foo._prepare_for_put(entity)
+        entity.foo._prepare_for_put.assert_called_once_with()
+
+    @staticmethod
+    def test__prepare_for_put_repeated():
+        class SubKind(model.Model):
+            bar = model.Property()
+
+        class SomeKind(model.Model):
+            foo = model.LocalStructuredProperty(SubKind, repeated=True)
+
+        entity = SomeKind(foo=[SubKind(), SubKind()])
+        entity.foo[0]._prepare_for_put = unittest.mock.Mock()
+        entity.foo[1]._prepare_for_put = unittest.mock.Mock()
+        SomeKind.foo._prepare_for_put(entity)
+        entity.foo[0]._prepare_for_put.assert_called_once_with()
+        entity.foo[1]._prepare_for_put.assert_called_once_with()
+
+    @staticmethod
+    def test__prepare_for_put_repeated_None():
+        class SubKind(model.Model):
+            bar = model.Property()
+
+        class SomeKind(model.Model):
+            foo = model.LocalStructuredProperty(SubKind)
+
+        entity = SomeKind()
+        SomeKind.foo._prepare_for_put(entity)  # noop
 
 
 class TestGenericProperty:


### PR DESCRIPTION
This was in the original code, but was overlooked when porting. Fixes #216 