### PR TITLE
Fix `Model._gql`.

### DIFF
--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -4860,11 +4860,8 @@ class Model(metaclass=MetaModel):
         # import late to avoid circular import problems
         from google.cloud.ndb import query
 
-        return query.gql(
-            "SELECT * FROM {} {}".format(cls._class_name(), query_string),
-            *args,
-            **kwargs,
-        )
+        gql = "SELECT * FROM {} {}".format(cls._class_name(), query_string)
+        return query.gql(gql, *args, **kwargs)
 
     gql = _gql
 

--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -4861,9 +4861,9 @@ class Model(metaclass=MetaModel):
         from google.cloud.ndb import query
 
         return query.gql(
-            "SELECT * FROM {} {}".format(
-                cls._class_name(), query_string, *args, *kwargs
-            )
+            "SELECT * FROM {} {}".format(cls._class_name(), query_string),
+            *args,
+            **kwargs,
         )
 
     gql = _gql

--- a/tests/system/test_query.py
+++ b/tests/system/test_query.py
@@ -1321,3 +1321,23 @@ def test_map(dispose_of):
 
     query = SomeKind.query().order(SomeKind.foo)
     assert query.map(get_other_foo) == foos
+
+
+@pytest.mark.usefixtures("client_context")
+def test_gql(ds_entity):
+    for i in range(5):
+        entity_id = test_utils.system.unique_resource_id()
+        ds_entity(KIND, entity_id, foo=i)
+
+    class SomeKind(ndb.Model):
+        foo = ndb.IntegerProperty()
+
+    eventually(SomeKind.query().fetch, _length_equals(5))
+
+    query = ndb.gql("SELECT * FROM SomeKind WHERE foo = :1", 2)
+    results = query.fetch()
+    assert results[0].foo == 2
+
+    query = SomeKind.gql("WHERE foo = :1", 2)
+    results = query.fetch()
+    assert results[0].foo == 2

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -4260,11 +4260,25 @@ class TestModel:
         class Simple(model.Model):
             x = model.IntegerProperty()
 
-        entity = Simple()
-        query = entity.gql("WHERE x=1")
+        query = Simple.gql("WHERE x=1")
         assert isinstance(query, query_module.Query)
         assert query.kind == "Simple"
         assert query.filters == query_module.FilterNode("x", "=", 1)
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test_gql_binding():
+        class Simple(model.Model):
+            x = model.IntegerProperty()
+            y = model.StringProperty()
+
+        query = Simple.gql("WHERE x=:1 and y=:foo", 2, foo="bar")
+        assert isinstance(query, query_module.Query)
+        assert query.kind == "Simple"
+        assert query.filters == query_module.AND(
+            query_module.FilterNode("x", "=", 2),
+            query_module.FilterNode("y", "=", "bar"),
+        )
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")


### PR DESCRIPTION
Binding parameters in `Model._gql` was broken due to a misplaced
parenthesis. Fixes #222.