### PR TITLE
fix: Correctly handle `limit` and `offset` when batching query results.

### DIFF
--- a/google/cloud/ndb/_datastore_query.py
+++ b/google/cloud/ndb/_datastore_query.py
@@ -311,8 +311,11 @@ class _QueryIteratorImpl(QueryIterator):
 
         if more_results:
             # Fix up query for next batch
+            limit = self._query.limit
+            if limit is not None:
+                limit -= len(self._batch)
             self._query = self._query.copy(
-                start_cursor=Cursor(batch.end_cursor)
+                start_cursor=Cursor(batch.end_cursor), offset=None, limit=limit
             )
 
     def next(self):


### PR DESCRIPTION
Fixes #236. It was found that when a result set spanned multiple
batches, we weren't updating `limit` and `offset` on subsequent queries.
Now we do.