### PR TITLE
Key property fix

### DIFF
--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -3284,8 +3284,6 @@ class KeyProperty(Property):
             temp = kind
             kind = name
             name = temp
-        if isinstance(kind, six.string_types) and name is None:
-            pass
         if isinstance(name, type) and kind is None:
             temp = kind
             kind = name

--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -3285,9 +3285,7 @@ class KeyProperty(Property):
             kind = name
             name = temp
         if isinstance(kind, six.string_types) and name is None:
-            temp = kind
-            kind = name
-            name = temp
+            pass
         if isinstance(name, type) and kind is None:
             temp = kind
             kind = name

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -2405,13 +2405,13 @@ class TestKeyProperty:
         assert prop._name is None
         assert prop._kind is None
 
-        name_only_args = [("keyp",), (None, "keyp"), ("keyp", None)]
+        name_only_args = [("keyp",), ("keyp", None)]
         for args in name_only_args:
             prop = model.KeyProperty(*args)
             assert prop._name == "keyp"
             assert prop._kind is None
 
-        kind_only_args = [(Simple,), (None, Simple), (Simple, None)]
+        kind_only_args = [(Simple,), (None, "Simple"), (None, Simple), (Simple, None)]
         for args in kind_only_args:
             prop = model.KeyProperty(*args)
             assert prop._name is None


### PR DESCRIPTION
Looks like Key properties were trying to assign the name of a property to the Kind when passing the Kind as a string.  This prevented multiple Key properties of the same kind on the same model from being saved 