### PR TITLE
Fix argument handling for `KeyProperty` constructor.

### DIFF
--- a/google/cloud/ndb/utils.py
+++ b/google/cloud/ndb/utils.py
@@ -99,24 +99,19 @@ def positional(max_pos_args):
 
         @functools.wraps(wrapped)
         def positional_wrapper(*args, **kwds):
-            check_positional_args(wrapped, max_pos_args, args)
+            if len(args) > max_pos_args:
+                plural_s = ""
+                if max_pos_args != 1:
+                    plural_s = "s"
+                raise TypeError(
+                    "%s() takes at most %d positional argument%s (%d given)"
+                    % (wrapped.__name__, max_pos_args, plural_s, len(args))
+                )
             return wrapped(*args, **kwds)
 
         return positional_wrapper
 
     return positional_decorator
-
-
-def check_positional_args(wrapped, max_pos_args, args):
-    """Raise an appropriate error if len(args) > max_pos_args"""
-    if len(args) > max_pos_args:
-        plural_s = ""
-        if max_pos_args != 1:
-            plural_s = "s"
-        raise TypeError(
-            "%s() takes at most %d positional argument%s (%d given)"
-            % (wrapped.__name__, max_pos_args, plural_s, len(args))
-        )
 
 
 threading_local = threading.local

--- a/google/cloud/ndb/utils.py
+++ b/google/cloud/ndb/utils.py
@@ -91,26 +91,32 @@ def positional(max_pos_args):
     """
 
     def positional_decorator(wrapped):
+        root = getattr(wrapped, "_wrapped", wrapped)
         wrapped._positional_args = max_pos_args
-        argspec = inspect.getargspec(wrapped)
+        argspec = inspect.getargspec(root)
         wrapped._argspec = argspec
         wrapped._positional_names = argspec.args[:max_pos_args]
 
         @functools.wraps(wrapped)
         def positional_wrapper(*args, **kwds):
-            if len(args) > max_pos_args:
-                plural_s = ""
-                if max_pos_args != 1:
-                    plural_s = "s"
-                raise TypeError(
-                    "%s() takes at most %d positional argument%s (%d given)"
-                    % (wrapped.__name__, max_pos_args, plural_s, len(args))
-                )
+            check_positional_args(wrapped, max_pos_args, args)
             return wrapped(*args, **kwds)
 
         return positional_wrapper
 
     return positional_decorator
+
+
+def check_positional_args(wrapped, max_pos_args, args):
+    """Raise an appropriate error if len(args) > max_pos_args"""
+    if len(args) > max_pos_args:
+        plural_s = ""
+        if max_pos_args != 1:
+            plural_s = "s"
+        raise TypeError(
+            "%s() takes at most %d positional argument%s (%d given)"
+            % (wrapped.__name__, max_pos_args, plural_s, len(args))
+        )
 
 
 threading_local = threading.local

--- a/tests/system/test_crud.py
+++ b/tests/system/test_crud.py
@@ -411,6 +411,24 @@ def test_key_property(dispose_of, ds_client):
     assert retrieved.foo == key_value
 
 
+@pytest.mark.usefixtures("client_context")
+def test_multiple_key_properties(dispose_of, ds_client):
+    class SomeKind(ndb.Model):
+        foo = ndb.KeyProperty(kind="Whatevs")
+        bar = ndb.KeyProperty(kind="Whatevs")
+
+    foo = ndb.Key("Whatevs", 123)
+    bar = ndb.Key("Whatevs", 321)
+    entity = SomeKind(foo=foo, bar=bar)
+    key = entity.put()
+    dispose_of(key._key)
+
+    retrieved = key.get()
+    assert retrieved.foo == foo
+    assert retrieved.bar == bar
+    assert retrieved.foo != retrieved.bar
+
+
 def test_insert_entity_with_caching(client_context):
     class SomeKind(ndb.Model):
         foo = ndb.IntegerProperty()


### PR DESCRIPTION
The changes for Python 2.7 compatibility broke the constructor for
KeyProperty, making it so you could no longer pass in a string for the
`kind` argument as a keyword. This reverts back to something more like
what was used in the original version of NDB, but preserving the
documented method signature.

I'm not a huge fan of this style of argument handling. (Maybe the first
argument is `name`, or maybe it's `kind`, let's figure it out!) But I
guess we're stuck with it for backwards compatibility.

Thanks to @epluntze for pointing me in the right direction.

Fixes #240.