### PR TITLE
Fix unstable order bug in unit test.

### DIFF
--- a/tests/unit/test__datastore_query.py
+++ b/tests/unit/test__datastore_query.py
@@ -1079,7 +1079,9 @@ class Test_Result:
 
         assert result.entity() is entity
         model._entity_from_protobuf.assert_called_once_with(entity_pb)
-        entity._set_projection.assert_called_once_with(("a", "b"))
+        projection = entity._set_projection.call_args[0][0]
+        assert sorted(projection) == ["a", "b"]
+        entity._set_projection.assert_called_once_with(projection)
 
 
 @pytest.mark.usefixtures("in_context")


### PR DESCRIPTION
A unit test was relying on a call to `dict.keys()` to return keys in a
specific order. Strangely this test never failed for us, but was
reported by @simonff.

Fixes #244.