### PR TITLE
Fix handling of repeated properties with projection queries.

### DIFF
--- a/tests/system/index.yaml
+++ b/tests/system/index.yaml
@@ -21,3 +21,8 @@ indexes:
   - name: foo
   - name: bar.one
   - name: bar.two
+
+- kind: Animal
+  properties:
+  - name: class
+  - name: foo


### PR DESCRIPTION
This fixes issues, generally, with the handling of repeated properties
with projection queries, but also specifically for the "class" property
of PolyModel entities.

Fixes #248