### PR TITLE
fix: IntegerProperty now accepts `long` type for Python 2.7.

### DIFF
--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -2272,7 +2272,7 @@ class IntegerProperty(Property):
             .BadValueError: If ``value`` is not an :class:`int` or convertible
                 to one.
         """
-        if not isinstance(value, int):
+        if not isinstance(value, six.integer_types):
             raise exceptions.BadValueError(
                 "Expected integer, got {!r}".format(value)
             )

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -1518,6 +1518,13 @@ class TestIntegerProperty:
         assert prop._validate(value) is value
 
     @staticmethod
+    @pytest.mark.skipif(six.PY3, reason="Test for Python 2 only.")
+    def test__validate_long():  # pragma: NO PY3 COVER
+        prop = model.IntegerProperty(name="count")
+        value = long(829038402384)  # noqa F821
+        assert prop._validate(value) is not value
+
+    @staticmethod
     def test__validate_bool():
         prop = model.IntegerProperty(name="count")
         value = True


### PR DESCRIPTION
Fixes #250.