### PR TITLE
Finish implementation of `query.ParameterizedFunction`.

### DIFF
--- a/tests/system/test_query.py
+++ b/tests/system/test_query.py
@@ -1421,3 +1421,27 @@ def test_gql(ds_entity):
     query = SomeKind.gql("WHERE foo = :1", 2)
     results = query.fetch()
     assert results[0].foo == 2
+
+
+@pytest.mark.usefixtures("client_context")
+def test_IN(ds_entity):
+    for i in range(5):
+        entity_id = test_utils.system.unique_resource_id()
+        ds_entity(KIND, entity_id, foo=i)
+
+    class SomeKind(ndb.Model):
+        foo = ndb.IntegerProperty()
+
+    eventually(SomeKind.query().fetch, _length_equals(5))
+
+    query = SomeKind.gql("where foo in (2, 3)").order(SomeKind.foo)
+    results = query.fetch()
+    assert len(results) == 2
+    assert results[0].foo == 2
+    assert results[1].foo == 3
+
+    query = SomeKind.gql("where foo in :1", [2, 3]).order(SomeKind.foo)
+    results = query.fetch()
+    assert len(results) == 2
+    assert results[0].foo == 2
+    assert results[1].foo == 3

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -299,29 +299,34 @@ class TestParameterizedFunction:
     @staticmethod
     def test_constructor():
         query = query_module.ParameterizedFunction(
-            "user", query_module.Parameter(1)
+            "user", [query_module.Parameter(1)]
         )
         assert query.func == "user"
-        assert query.values == query_module.Parameter(1)
+        assert query.values == [query_module.Parameter(1)]
+
+    @staticmethod
+    def test_constructor_bad_function():
+        with pytest.raises(ValueError):
+            query_module.ParameterizedFunction("notafunc", ())
 
     @staticmethod
     def test___repr__():
         query = query_module.ParameterizedFunction(
-            "user", query_module.Parameter(1)
+            "user", [query_module.Parameter(1)]
         )
         assert (
-            query.__repr__() == "ParameterizedFunction('user', Parameter(1))"
+            query.__repr__() == "ParameterizedFunction('user', [Parameter(1)])"
         )
 
     @staticmethod
     def test___eq__parameter():
         query = query_module.ParameterizedFunction(
-            "user", query_module.Parameter(1)
+            "user", [query_module.Parameter(1)]
         )
         assert (
             query.__eq__(
                 query_module.ParameterizedFunction(
-                    "user", query_module.Parameter(1)
+                    "user", [query_module.Parameter(1)]
                 )
             )
             is True
@@ -330,9 +335,36 @@ class TestParameterizedFunction:
     @staticmethod
     def test___eq__no_parameter():
         query = query_module.ParameterizedFunction(
-            "user", query_module.Parameter(1)
+            "user", [query_module.Parameter(1)]
         )
         assert query.__eq__(42) is NotImplemented
+
+    @staticmethod
+    def test_is_parameterized_True():
+        query = query_module.ParameterizedFunction(
+            "user", [query_module.Parameter(1)]
+        )
+        assert query.is_parameterized()
+
+    @staticmethod
+    def test_is_parameterized_False():
+        query = query_module.ParameterizedFunction("user", [1])
+        assert not query.is_parameterized()
+
+    @staticmethod
+    def test_is_parameterized_no_arguments():
+        query = query_module.ParameterizedFunction("user", ())
+        assert not query.is_parameterized()
+
+    @staticmethod
+    def test_resolve():
+        query = query_module.ParameterizedFunction(
+            "list", [1, query_module.Parameter(2), query_module.Parameter(3)]
+        )
+        used = {}
+        resolved = query.resolve({2: 4, 3: 6}, used)
+        assert resolved == [1, 4, 6]
+        assert used == {2: True, 3: True}
 
 
 class TestNode:


### PR DESCRIPTION
It turns out that `query.ParameterizedFunction` wasn't finished in its
implementation. It is meant to deal with the case, in GQL, where GQL
functions are called.

This PR also adds an implementation for the `LIST` GQL function and
stubs for future implementations of `USER` and `KEY`. Remaining GQL
functions needing to be implemented are unknown at this time.

Fixes #258.