### PR TITLE
Fixes the page title for the global cache documentation.

### DIFF
--- a/docs/global_cache.rst
+++ b/docs/global_cache.rst
@@ -1,6 +1,6 @@
-#######
-Context
-#######
+############
+Global Cache
+############
 
 .. automodule:: google.cloud.ndb.global_cache
     :members:


### PR DESCRIPTION
Small fix for the global cache documentation, which appears in the table of contents as "Context".

See https://googleapis.dev/python/python-ndb/latest/global_cache.html

![Screenshot 2019-12-12 at 13 57 49](https://user-images.githubusercontent.com/334087/70718464-2e1f1200-1ce8-11ea-80da-feb4c34baf0a.png)
