### PR TITLE
Fix #273 : Local Structured Property population via .populate(**kwargs)

### DIFF
--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -4099,7 +4099,7 @@ class LocalStructuredProperty(BlobProperty):
         """
         if isinstance(value, dict):
             # A dict is assumed to be the result of a _to_dict() call.
-            value = self._model_class(**value)
+            return self._model_class(**value)
 
         if not isinstance(value, self._model_class):
             raise exceptions.BadValueError(

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -3433,7 +3433,7 @@ class TestLocalStructuredProperty:
 
         prop = model.LocalStructuredProperty(Simple, name="ent")
         value = {}
-        assert prop._validate(value) is Simple
+        assert isinstance(prop._validate(value), Simple)
 
     @staticmethod
     def test__validate_dict_invalid():

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -3433,7 +3433,7 @@ class TestLocalStructuredProperty:
 
         prop = model.LocalStructuredProperty(Simple, name="ent")
         value = {}
-        assert prop._validate(value) is None
+        assert prop._validate(value) is Simple
 
     @staticmethod
     def test__validate_dict_invalid():


### PR DESCRIPTION
If LocalStructureProperty contains other Structured/LocalStructured Properties, the created model must be returned from the _validate(self, value) function.

This mirrors exactly how this is done in StructuredProperty._validate()