### PR TITLE
fix: fix missing __ne__ methods

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ nitpick_ignore = [
     ("py:meth", "_datastore_query.Cursor.urlsafe"),
     ("py:class", "google.cloud.ndb.context._Context"),
     ("py:class", "google.cloud.ndb.metadata._BaseMetadata"),
+    ("py:class", "google.cloud.ndb.model._NotEqualMixin"),
     ("py:class", "google.cloud.ndb._options.ReadOptions"),
     ("py:class", "QueryIterator"),
     ("py:class", ".."),

--- a/google/cloud/ndb/_datastore_query.py
+++ b/google/cloud/ndb/_datastore_query.py
@@ -649,10 +649,6 @@ class _Result(object):
 
         return self._compare(other) == 0
 
-    def __ne__(self, other):
-        """For total ordering. Python 2.7 only."""
-        return self._compare(other) != 0
-
     def _compare(self, other):
         """Compare this result to another result for sorting.
 

--- a/google/cloud/ndb/key.py
+++ b/google/cloud/ndb/key.py
@@ -380,6 +380,12 @@ class Key(object):
 
         return self._tuple() == other._tuple()
 
+    def __ne__(self, other):
+        """The opposite of __eq__."""
+        if not isinstance(other, Key):
+            return NotImplemented
+        return not self.__eq__(other)
+
     def __lt__(self, other):
         """Less than ordering."""
         if not isinstance(other, Key):

--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -374,7 +374,18 @@ class UserNotFoundError(exceptions.Error):
     """No email argument was specified, and no user is logged in."""
 
 
-class IndexProperty(object):
+class _NotEqualMixin(object):
+    """Mix-in class that implements __ne__ in terms of __eq__."""
+
+    def __ne__(self, other):
+        """Implement self != other as not(self == other)."""
+        eq = self.__eq__(other)
+        if eq is NotImplemented:
+            return NotImplemented
+        return not eq
+
+
+class IndexProperty(_NotEqualMixin):
     """Immutable object representing a single property in an index."""
 
     __slots__ = ("_name", "_direction")
@@ -412,7 +423,7 @@ class IndexProperty(object):
         return hash((self.name, self.direction))
 
 
-class Index(object):
+class Index(_NotEqualMixin):
     """Immutable object representing an index."""
 
     __slots__ = ("_kind", "_properties", "_ancestor")
@@ -461,7 +472,7 @@ class Index(object):
         return hash((self.kind, self.properties, self.ancestor))
 
 
-class IndexState(object):
+class IndexState(_NotEqualMixin):
     """Immutable object representing an index and its state."""
 
     __slots__ = ("_definition", "_state", "_id")
@@ -795,7 +806,7 @@ class ModelAttribute(object):
         """
 
 
-class _BaseValue(object):
+class _BaseValue(_NotEqualMixin):
     """A marker object wrapping a "base type" value.
 
     This is used to be able to tell whether ``entity._values[name]`` is a
@@ -4295,7 +4306,7 @@ class MetaModel(type):
 
 
 @six.add_metaclass(MetaModel)
-class Model(object):
+class Model(_NotEqualMixin):
     """A class describing Cloud Datastore entities.
 
     Model instances are usually called entities. All model classes

--- a/google/cloud/ndb/query.py
+++ b/google/cloud/ndb/query.py
@@ -422,7 +422,10 @@ class Node(object):
 
     def __ne__(self, other):
         # Python 2.7 requires this method to be implemented.
-        raise NotImplementedError
+        eq = self.__eq__(other)
+        if eq is not NotImplemented:
+            eq = not eq
+        return eq
 
     def __le__(self, unused_other):
         raise TypeError("Nodes cannot be ordered")
@@ -702,9 +705,6 @@ class FilterNode(Node):
             and self._opsymbol == other._opsymbol
             and self._value == other._value
         )
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
 
     def _to_filter(self, post=False):
         """Helper to convert to low-level filter.

--- a/tests/unit/test_key.py
+++ b/tests/unit/test_key.py
@@ -318,11 +318,13 @@ class TestKey:
         key3 = key_module.Key("X", 11, app="bar", namespace="n")
         key4 = key_module.Key("X", 11, app="foo", namespace="m")
         key5 = mock.sentinel.key
+        key6 = key_module.Key("X", 11, app="foo", namespace="n")
         assert not key1 != key1
         assert key1 != key2
         assert key1 != key3
         assert key1 != key4
         assert key1 != key5
+        assert not key1 != key6
 
     @staticmethod
     def test___lt__():

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -111,9 +111,11 @@ class TestIndexProperty:
         index_prop1 = model.IndexProperty(name="d", direction="asc")
         index_prop2 = model.IndexProperty(name="d", direction="desc")
         index_prop3 = mock.sentinel.index_prop
+        index_prop4 = model.IndexProperty(name="d", direction="asc")
         assert not index_prop1 != index_prop1
         assert index_prop1 != index_prop2
         assert index_prop1 != index_prop3
+        assert not index_prop1 != index_prop4
 
     @staticmethod
     def test___hash__():
@@ -186,11 +188,13 @@ class TestIndex:
         index3 = model.Index(kind="d", properties=index_props, ancestor=True)
         index4 = model.Index(kind="e", properties=index_props, ancestor=False)
         index5 = mock.sentinel.index
+        index6 = model.Index(kind="d", properties=index_props, ancestor=False)
         assert not index1 != index1
         assert index1 != index2
         assert index1 != index3
         assert index1 != index4
         assert index1 != index5
+        assert not index1 != index6
 
     @staticmethod
     def test___hash__():
@@ -280,11 +284,15 @@ class TestIndexState:
             definition=self.INDEX, state="error", id=80
         )
         index_state5 = mock.sentinel.index_state
+        index_state6 = model.IndexState(
+            definition=self.INDEX, state="error", id=20
+        )
         assert not index_state1 != index_state1
         assert index_state1 != index_state2
         assert index_state1 != index_state3
         assert index_state1 != index_state4
         assert index_state1 != index_state5
+        assert not index_state1 != index_state6
 
     def test___hash__(self):
         index_state1 = model.IndexState(
@@ -354,9 +362,11 @@ class Test_BaseValue:
         wrapped1 = model._BaseValue("one val")
         wrapped2 = model._BaseValue(25.5)
         wrapped3 = mock.sentinel.base_value
+        wrapped4 = model._BaseValue("one val")
         assert not wrapped1 != wrapped1
         assert wrapped1 != wrapped2
         assert wrapped1 != wrapped3
+        assert not wrapped1 != wrapped4
 
     @staticmethod
     def test___hash__():
@@ -1621,9 +1631,11 @@ class Test_CompressedValue:
         z_val2 = zlib.compress(b"12345678901234567890abcde\x00")
         compressed_value2 = model._CompressedValue(z_val2)
         compressed_value3 = mock.sentinel.compressed_value
+        compressed_value4 = model._CompressedValue(z_val1)
         assert not compressed_value1 != compressed_value1
         assert compressed_value1 != compressed_value2
         assert compressed_value1 != compressed_value3
+        assert not compressed_value1 != compressed_value4
 
     @staticmethod
     def test___hash__():
@@ -4032,11 +4044,10 @@ class TestModel:
             foo = model.StructuredProperty(OtherKind)
             hi = model.StringProperty()
 
-        # entity1 = SomeKind(hi="mom", foo=OtherKind(bar=42))
-        # entity2 = SomeKind(hi="mom", foo=OtherKind(bar=42))
+        entity1 = SomeKind(hi="mom", foo=OtherKind(bar=42))
+        entity2 = SomeKind(hi="mom", foo=OtherKind(bar=42))
 
-        # TODO: can't figure out why this one fails
-        # assert entity1 == entity2
+        assert entity1 == entity2
 
     @staticmethod
     def test__eq__structured_property_differs():
@@ -4093,11 +4104,13 @@ class TestModel:
         entity3 = ManyFields(self=-9, id="bye")
         entity4 = ManyFields(self=-9, id="bye", projection=("self", "id"))
         entity5 = None
+        entity6 = ManyFields(self=-9, id="hi")
         assert not entity1 != entity1
         assert entity1 != entity2
         assert entity1 != entity3
         assert entity1 != entity4
         assert entity1 != entity5
+        assert not entity1 != entity6
 
     @staticmethod
     def test___lt__():

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -445,6 +445,15 @@ class TestFalseNode:
         assert not false_node1 == false_node3
 
     @staticmethod
+    def test___ne__():
+        false_node1 = query_module.FalseNode()
+        false_node2 = query_module.FalseNode()
+        false_node3 = mock.sentinel.false_node
+        assert not false_node1 != false_node1
+        assert not false_node1 != false_node2
+        assert false_node1 != false_node3
+
+    @staticmethod
     def test__to_filter():
         false_node = query_module.FalseNode()
         with pytest.raises(exceptions.BadQueryError):
@@ -521,6 +530,24 @@ class TestParameterNode:
         assert not parameter_node1 == parameter_node3
         assert not parameter_node1 == parameter_node4
         assert not parameter_node1 == parameter_node5
+
+    @staticmethod
+    def test___ne__():
+        prop1 = model.Property(name="val")
+        param1 = query_module.Parameter("abc")
+        parameter_node1 = query_module.ParameterNode(prop1, "=", param1)
+        prop2 = model.Property(name="ue")
+        parameter_node2 = query_module.ParameterNode(prop2, "=", param1)
+        parameter_node3 = query_module.ParameterNode(prop1, "<", param1)
+        param2 = query_module.Parameter(900)
+        parameter_node4 = query_module.ParameterNode(prop1, "=", param2)
+        parameter_node5 = mock.sentinel.parameter_node
+
+        assert not parameter_node1 != parameter_node1
+        assert parameter_node1 != parameter_node2
+        assert parameter_node1 != parameter_node3
+        assert parameter_node1 != parameter_node4
+        assert parameter_node1 != parameter_node5
 
     @staticmethod
     def test__to_filter():
@@ -711,6 +738,17 @@ class TestPostFilterNode:
         assert post_filter_node1 == post_filter_node1
         assert not post_filter_node1 == post_filter_node2
         assert not post_filter_node1 == post_filter_node3
+
+    @staticmethod
+    def test___ne__():
+        predicate1 = mock.sentinel.predicate1
+        post_filter_node1 = query_module.PostFilterNode(predicate1)
+        predicate2 = mock.sentinel.predicate2
+        post_filter_node2 = query_module.PostFilterNode(predicate2)
+        post_filter_node3 = mock.sentinel.post_filter_node
+        assert not post_filter_node1 != post_filter_node1
+        assert post_filter_node1 != post_filter_node2
+        assert post_filter_node1 != post_filter_node3
 
     @staticmethod
     def test__to_filter_post():
@@ -912,6 +950,22 @@ class TestConjunctionNode:
         assert not and_node1 == and_node4
 
     @staticmethod
+    def test___ne__():
+        filter_node1 = query_module.FilterNode("a", "=", 7)
+        filter_node2 = query_module.FilterNode("b", ">", 7.5)
+        filter_node3 = query_module.FilterNode("c", "<", "now")
+
+        and_node1 = query_module.ConjunctionNode(filter_node1, filter_node2)
+        and_node2 = query_module.ConjunctionNode(filter_node2, filter_node1)
+        and_node3 = query_module.ConjunctionNode(filter_node1, filter_node3)
+        and_node4 = mock.sentinel.and_node
+
+        assert not and_node1 != and_node1
+        assert and_node1 != and_node2
+        assert and_node1 != and_node3
+        assert and_node1 != and_node4
+
+    @staticmethod
     def test__to_filter_empty():
         node1 = query_module.FilterNode("a", "=", 7)
         node2 = query_module.FilterNode("b", "<", 6)
@@ -1099,6 +1153,22 @@ class TestDisjunctionNode:
         assert not or_node1 == or_node2
         assert not or_node1 == or_node3
         assert not or_node1 == or_node4
+
+    @staticmethod
+    def test___ne__():
+        filter_node1 = query_module.FilterNode("a", "=", 7)
+        filter_node2 = query_module.FilterNode("b", ">", 7.5)
+        filter_node3 = query_module.FilterNode("c", "<", "now")
+
+        or_node1 = query_module.DisjunctionNode(filter_node1, filter_node2)
+        or_node2 = query_module.DisjunctionNode(filter_node2, filter_node1)
+        or_node3 = query_module.DisjunctionNode(filter_node1, filter_node3)
+        or_node4 = mock.sentinel.or_node
+
+        assert not or_node1 != or_node1
+        assert or_node1 != or_node2
+        assert or_node1 != or_node3
+        assert or_node1 != or_node4
 
     @staticmethod
     def test_resolve():


### PR DESCRIPTION
Removed unnecessary `_datastore_query._Result.__ne__` since
`functools.total_ordering` defines it from `__eq__`.

Added `key.Key.__ne__` from App Engine NDB for Python 2 compatibility.

Added `model._NotEqualMixin` from App Engine NDB and used it in
`model.IndexProperty`, `model.Index`, `model.IndexState`,
`model._BaseValue` and `model.Model` for Python 2 compatibility.

Added `query.Node.__ne__` from App Engine NDB so that it is used by
all subclasses and removed unnecessary `query.FilterNode.__ne__`.