### PR TITLE
fix: Handle `int` for DateTimeProperty

### DIFF
--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -3601,7 +3601,10 @@ class DateTimeProperty(Property):
         """Convert a value from the "base" value type for this property.
 
         Args:
-            value (datetime.datetime): The value to be converted.
+            value (Union[int, datetime.datetime]): The value to be converted.
+                The value will be `int` for entities retrieved by a projection
+                query and is a timestamp as the number of nanoseconds since the
+                epoch.
 
         Returns:
             Optional[datetime.datetime]: If ``tzinfo`` is set on this property,
@@ -3609,6 +3612,11 @@ class DateTimeProperty(Property):
                 returns the value without ``tzinfo`` or ``None`` if value did
                 not have ``tzinfo`` set.
         """
+        if isinstance(value, six.integer_types):
+            # Projection query, value is integer nanoseconds
+            seconds = value / 1e6
+            value = datetime.datetime.fromtimestamp(seconds, pytz.utc)
+
         if self._tzinfo is not None:
             return value.astimezone(self._tzinfo)
 

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -2708,6 +2708,14 @@ class TestDateTimeProperty:
         )
 
     @staticmethod
+    def test__from_base_type_int():
+        prop = model.DateTimeProperty(name="dt_val")
+        value = 1273632120000000
+        assert prop._from_base_type(value) == datetime.datetime(
+            2010, 5, 12, 2, 42
+        )
+
+    @staticmethod
     def test__to_base_type_noop():
         prop = model.DateTimeProperty(name="dt_val", tzinfo=timezone(-4))
         value = datetime.datetime(2010, 5, 12)


### PR DESCRIPTION
In Datastore, projection queries involving entities with DateTime
properties return integer timestamps instead of `datetime.datetime`
objects. This fix handles that case and returns `datetime.datetime`
objects regardless of the query type.

Fixes #261.