### PR TITLE
fix: Preserve `QueryIterator.cursor_after`.

### DIFF
--- a/google/cloud/ndb/_datastore_query.py
+++ b/google/cloud/ndb/_datastore_query.py
@@ -216,11 +216,11 @@ class QueryIterator(object):
 
         Raises:
             exceptions.BadArgumentError: If there is no cursor to return. This
-                will happen if the iterator hasn't returned a result yet or if
-                the iterator has been exhausted. Also, if query uses ``OR``,
-                ``!=``, or ``IN``, since those are composites of multiple
-                Datastore queries each with their own cursors—it is impossible
-                to return a cursor for the composite query.
+                will happen if the iterator hasn't returned a result yet. Also,
+                if query uses ``OR``, ``!=``, or ``IN``, since those are
+                composites of multiple Datastore queries each with their own
+                cursors—it is impossible to return a cursor for the composite
+                query.
         """
         raise NotImplementedError()
 
@@ -275,10 +275,9 @@ class _QueryIteratorImpl(QueryIterator):
     def probably_has_next(self):
         """Implements :meth:`QueryIterator.probably_has_next`."""
         return (
-            self._batch is None
-            or self._has_next_batch  # Haven't even started yet
-            or self._index  # There's another batch to fetch
-            < len(self._batch)  # Not done with current batch
+            self._batch is None  # Haven't even started yet
+            or self._has_next_batch  # There's another batch to fetch
+            or self._index < len(self._batch)  # Not done with current batch
         )
 
     @tasklets.tasklet
@@ -322,7 +321,7 @@ class _QueryIteratorImpl(QueryIterator):
         """Implements :meth:`QueryIterator.next`."""
         # May block
         if not self.has_next():
-            self._cursor_before = self._cursor_after = None
+            self._cursor_before = None
             raise StopIteration
 
         # Won't block

--- a/tests/unit/test__datastore_query.py
+++ b/tests/unit/test__datastore_query.py
@@ -405,8 +405,7 @@ class Test_QueryIteratorImpl:
         with pytest.raises(exceptions.BadArgumentError):
             iterator.cursor_before()
 
-        with pytest.raises(exceptions.BadArgumentError):
-            iterator.cursor_after()
+        assert iterator.cursor_after() == b"bcd"
 
     @staticmethod
     def test_next_raw():


### PR DESCRIPTION
In an overabundance of caution, we were deleting `cursor_after` from
QueryIterator after exhausting the iterator. This was found to differ
from the original implementation, however, and break some customer's
code.

Fixes #292