### PR TITLE
fix: location prefix support

### DIFF
--- a/google/cloud/ndb/key.py
+++ b/google/cloud/ndb/key.py
@@ -733,6 +733,22 @@ class Key(object):
         raw_bytes = self.serialized()
         return base64.urlsafe_b64encode(raw_bytes).strip(b"=")
 
+    def legacy_urlsafe(self, location_prefix=None):
+        """A ``Reference`` protobuf encoded as urlsafe base 64.
+
+        .. doctest:: key-urlsafe
+
+            >>> key = ndb.Key("Kind", 1337, project="example")
+            >>> key.legacy_urlsafe()
+            b'agdleGFtcGxlcgsLEgRLaW5kGLkKDA'
+        """
+        return google.cloud.datastore.Key(
+            self._key.kind,
+            self._key.id,
+            namespace=self._key.namespace,
+            project=self._key.project,
+        ).to_legacy_urlsafe(location_prefix=location_prefix)
+
     @_options.ReadOptions.options
     @utils.positional(1)
     def get(

--- a/noxfile.py
+++ b/noxfile.py
@@ -76,7 +76,7 @@ def cover(session):
     session.run("coverage", "erase")
 
 
-def run_black(session, use_check=False):
+def run_black(use_check=False):
     args = ["black"]
     if use_check:
         args.append("--check")

--- a/tests/system/test_crud.py
+++ b/tests/system/test_crud.py
@@ -1034,7 +1034,7 @@ def test_computed_key_property(dispose_of):
         s_foobar = ndb.StringProperty()
         key_b = ndb.KeyProperty(kind="BModel", indexed=True)
         key_a = ndb.ComputedProperty(  # Issue here
-            lambda self: self.key_b.get().key_a if self.key_b else None,
+            lambda self: self.key_b.get().key_a if self.key_b else None
         )
 
     key_a = AModel(s_foo="test").put()

--- a/tests/unit/test_key.py
+++ b/tests/unit/test_key.py
@@ -833,6 +833,29 @@ class Test__project_from_app:
             assert key_module._project_from_app(None) == "jectpro"
 
 
+class Test__location_prefix_from_app:
+    @staticmethod
+    def test_has_prefix():
+        app = "my-prahjekt"
+        prefix = ""
+        assert key_module._location_prefix_from_app(app) == prefix
+
+    @staticmethod
+    def test_no_prefix():
+        project = "my-prahjekt"
+        for prefix in ("s", "e", "dev"):
+            app = "{}~{}".format(prefix, project)
+            assert key_module._location_prefix_from_app(app) == prefix
+
+    @staticmethod
+    def test_app_fallback(context):
+        prefix = "s"
+        context.client.project = "{}~jectpro".format(prefix)
+
+        with context.use():
+            assert key_module._location_prefix_from_app(None) == "s"
+
+
 class Test__from_reference:
     def test_basic(self):
         reference = make_reference()

--- a/tests/unit/test_key.py
+++ b/tests/unit/test_key.py
@@ -555,6 +555,14 @@ class TestKey:
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
+    def test_legacy_urlsafe():
+        key = key_module.Key("d", 123, app="f")
+        assert (
+            key.legacy_urlsafe(location_prefix="s~") == b"agNzfmZyBwsSAWQYeww"
+        )
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
     @mock.patch("google.cloud.ndb._datastore_api")
     @mock.patch("google.cloud.ndb.model._entity_from_protobuf")
     def test_get_with_cache_miss(_entity_from_protobuf, _datastore_api):

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -2346,7 +2346,7 @@ class TestUserProperty:
     @staticmethod
     def test__to_base_type():
         prop = model.UserProperty(name="u")
-        entity = prop._to_base_type(model.User("email", "auth_domain",))
+        entity = prop._to_base_type(model.User("email", "auth_domain"))
         assert entity["email"] == "email"
         assert "email" in entity.exclude_from_indexes
         assert entity["auth_domain"] == "auth_domain"

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -2213,7 +2213,7 @@ class TestQuery:
         _datastore_query.iterate.return_value = DummyQueryIterator()
         query = query_module.Query()
         query.filters = mock.Mock(
-            _multiquery=False, _post_filters=mock.Mock(return_value=False),
+            _multiquery=False, _post_filters=mock.Mock(return_value=False)
         )
         results, cursor, more = query.fetch_page(5)
         assert results == [0, 1, 2, 3, 4]


### PR DESCRIPTION
This PR has two ideas implemented, only one may need to be pulled.  

Commit 1 - optionally include location prefix when creating `ndb.Key` instances
Commit 2 - use a secondary method `legacy_urlsafe` to include location prefix in urlsafe key.

Thanks for the support and updates.  We look forward to communicating the best way to include location prefix.

NOTE: I noticed that adding location prefix caused tests that expect the location prefix to be stripped away to fail.  We can help resolve these tests by anticipating the prefix to be kept.

Fixes: #264 