### PR TITLE
fix: attempt to have fewer transient errors in continuous integration

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --log-cli-level=WARN

--- a/tests/system/__init__.py
+++ b/tests/system/__init__.py
@@ -16,10 +16,9 @@ import time
 
 KIND = "SomeKind"
 OTHER_KIND = "OtherKind"
-OTHER_NAMESPACE = "other-namespace"
 
 
-def eventually(f, predicate, timeout=60, interval=2):
+def eventually(f, predicate, timeout=120, interval=2):
     """Runs `f` in a loop, hoping for eventual success.
 
     Some things we're trying to test in Datastore are eventually

--- a/tests/system/test_query.py
+++ b/tests/system/test_query.py
@@ -28,7 +28,7 @@ import test_utils.system
 
 from google.cloud import ndb
 
-from tests.system import KIND, OTHER_NAMESPACE, eventually
+from tests.system import KIND, eventually
 
 
 def _length_equals(n):
@@ -278,12 +278,12 @@ def test_distinct_on(ds_entity):
 
 
 @pytest.mark.usefixtures("client_context")
-def test_namespace(dispose_of):
+def test_namespace(dispose_of, other_namespace):
     class SomeKind(ndb.Model):
         foo = ndb.IntegerProperty()
         bar = ndb.StringProperty()
 
-    entity1 = SomeKind(foo=1, bar="a", namespace=OTHER_NAMESPACE)
+    entity1 = SomeKind(foo=1, bar="a", namespace=other_namespace)
     entity1.put()
     dispose_of(entity1.key._key)
 
@@ -293,12 +293,12 @@ def test_namespace(dispose_of):
 
     eventually(SomeKind.query().fetch, _length_equals(1))
 
-    query = SomeKind.query(namespace=OTHER_NAMESPACE)
+    query = SomeKind.query(namespace=other_namespace)
     results = eventually(query.fetch, _length_equals(1))
 
     assert results[0].foo == 1
     assert results[0].bar == "a"
-    assert results[0].key.namespace() == OTHER_NAMESPACE
+    assert results[0].key.namespace() == other_namespace
 
 
 @pytest.mark.usefixtures("client_context")


### PR DESCRIPTION
We have been having more transient errors in the system tests run by
Kokoro. This patch:

1) Increased timeout used by `eventually` fixture from 60 seconds to 120
seconds.

2) Randomizes "other namespace", like we were already doing with the
primary namespace used by tests. This should make it vanishingly
unlikely that a test can have its initial state polluted by a previously
run test, as each test will be run in its own namespace.

3) Relaxes the checks for undeleted entities during test cleanup.
Instead of a failing assertion, now, we'll just log a warning if there
are any leftover entities at the end of a test.