### PR TITLE
fix: disuse `__slots__` in most places

### DIFF
--- a/google/cloud/ndb/_datastore_types.py
+++ b/google/cloud/ndb/_datastore_types.py
@@ -51,8 +51,6 @@ class BlobKey(object):
             :class:`bytes` instance.
     """
 
-    __slots__ = ("_blob_key",)
-
     def __init__(self, blob_key):
         if isinstance(blob_key, bytes):
             if len(blob_key) > _MAX_STRING_LENGTH:

--- a/google/cloud/ndb/_eventloop.py
+++ b/google/cloud/ndb/_eventloop.py
@@ -135,15 +135,6 @@ class EventLoop(object):
             get added to this queue and then processed by the event loop.
     """
 
-    __slots__ = (
-        "current",
-        "idlers",
-        "inactive",
-        "queue",
-        "rpcs",
-        "rpc_results",
-    )
-
     def __init__(self):
         self.current = collections.deque()
         self.idlers = collections.deque()

--- a/google/cloud/ndb/blobstore.py
+++ b/google/cloud/ndb/blobstore.py
@@ -78,8 +78,6 @@ class BlobFetchSizeTooLargeError(object):
 
 
 class BlobInfo(object):
-    __slots__ = ()
-
     def __init__(self, *args, **kwargs):
         raise exceptions.NoLongerImplementedError()
 
@@ -111,8 +109,6 @@ class BlobNotFoundError(object):
 
 
 class BlobReader(object):
-    __slots__ = ()
-
     def __init__(self, *args, **kwargs):
         raise exceptions.NoLongerImplementedError()
 

--- a/google/cloud/ndb/context.py
+++ b/google/cloud/ndb/context.py
@@ -546,21 +546,15 @@ class Context(_Context):
 
 
 class ContextOptions(object):
-    __slots__ = ()
-
     def __init__(self, *args, **kwargs):
         raise exceptions.NoLongerImplementedError()
 
 
 class TransactionOptions(object):
-    __slots__ = ()
-
     def __init__(self, *args, **kwargs):
         raise exceptions.NoLongerImplementedError()
 
 
 class AutoBatcher(object):
-    __slots__ = ()
-
     def __init__(self, *args, **kwargs):
         raise exceptions.NoLongerImplementedError()

--- a/google/cloud/ndb/django_middleware.py
+++ b/google/cloud/ndb/django_middleware.py
@@ -19,7 +19,5 @@ __all__ = ["NdbDjangoMiddleware"]
 
 
 class NdbDjangoMiddleware(object):
-    __slots__ = ()
-
     def __init__(self, *args, **kwargs):
         raise NotImplementedError

--- a/google/cloud/ndb/key.py
+++ b/google/cloud/ndb/key.py
@@ -272,8 +272,6 @@ class Key(object):
             arguments were given with the path.
     """
 
-    __slots__ = ("_key", "_reference")
-
     def __new__(cls, *path_args, **kwargs):
         # Avoid circular import in Python 2.7
         from google.cloud.ndb import context as context_module

--- a/google/cloud/ndb/metadata.py
+++ b/google/cloud/ndb/metadata.py
@@ -59,8 +59,6 @@ __all__ = [
 class _BaseMetadata(model.Model):
     """Base class for all metadata models."""
 
-    __slots__ = ()
-
     _use_cache = False
     _use_global_cache = False
 
@@ -80,8 +78,6 @@ class _BaseMetadata(model.Model):
 
 class Namespace(_BaseMetadata):
     """Model for __namespace__ metadata query results."""
-
-    __slots__ = ()
 
     KIND_NAME = "__namespace__"
     EMPTY_NAMESPACE_ID = 1
@@ -127,8 +123,6 @@ class Namespace(_BaseMetadata):
 class Kind(_BaseMetadata):
     """Model for __kind__ metadata query results."""
 
-    __slots__ = ()
-
     KIND_NAME = "__kind__"
 
     @property
@@ -167,8 +161,6 @@ class Kind(_BaseMetadata):
 
 class Property(_BaseMetadata):
     """Model for __property__ metadata query results."""
-
-    __slots__ = ()
 
     KIND_NAME = "__property__"
 

--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -388,8 +388,6 @@ class _NotEqualMixin(object):
 class IndexProperty(_NotEqualMixin):
     """Immutable object representing a single property in an index."""
 
-    __slots__ = ("_name", "_direction")
-
     @utils.positional(1)
     def __new__(cls, name, direction):
         instance = super(IndexProperty, cls).__new__(cls)
@@ -425,8 +423,6 @@ class IndexProperty(_NotEqualMixin):
 
 class Index(_NotEqualMixin):
     """Immutable object representing an index."""
-
-    __slots__ = ("_kind", "_properties", "_ancestor")
 
     @utils.positional(1)
     def __new__(cls, kind, properties, ancestor):
@@ -474,8 +470,6 @@ class Index(_NotEqualMixin):
 
 class IndexState(_NotEqualMixin):
     """Immutable object representing an index and its state."""
-
-    __slots__ = ("_definition", "_state", "_id")
 
     @utils.positional(1)
     def __new__(cls, definition, state, id):
@@ -526,8 +520,6 @@ class IndexState(_NotEqualMixin):
 
 
 class ModelAdapter(object):
-    __slots__ = ()
-
     def __new__(self, *args, **kwargs):
         raise exceptions.NoLongerImplementedError()
 
@@ -796,8 +788,6 @@ def make_connection(*args, **kwargs):
 class ModelAttribute(object):
     """Base for classes that implement a ``_fix_up()`` method."""
 
-    __slots__ = ()
-
     def _fix_up(self, cls, code_name):
         """Fix-up property name. To be implemented by subclasses.
 
@@ -823,8 +813,6 @@ class _BaseValue(_NotEqualMixin):
         TypeError: If ``b_val`` is :data:`None`.
         TypeError: If ``b_val`` is a list.
     """
-
-    __slots__ = ("b_val",)
 
     def __init__(self, b_val):
         if b_val is None:
@@ -2169,8 +2157,6 @@ class ModelKey(Property):
     .. automethod:: _validate
     """
 
-    __slots__ = ()
-
     def __init__(self):
         super(ModelKey, self).__init__()
         self._name = "__key__"
@@ -2253,8 +2239,6 @@ class BooleanProperty(Property):
     .. automethod:: _validate
     """
 
-    __slots__ = ()
-
     def _validate(self, value):
         """Validate a ``value`` before setting it.
 
@@ -2284,8 +2268,6 @@ class IntegerProperty(Property):
 
     .. automethod:: _validate
     """
-
-    __slots__ = ()
 
     def _validate(self, value):
         """Validate a ``value`` before setting it.
@@ -2317,8 +2299,6 @@ class FloatProperty(Property):
 
     .. automethod:: _validate
     """
-
-    __slots__ = ()
 
     def _validate(self, value):
         """Validate a ``value`` before setting it.
@@ -2602,8 +2582,6 @@ class TextProperty(Property):
         NotImplementedError: If ``indexed=True`` is provided.
     """
 
-    __slots__ = ()
-
     def __init__(self, *args, **kwargs):
         indexed = kwargs.pop("indexed", False)
         if indexed:
@@ -2732,8 +2710,6 @@ class StringProperty(TextProperty):
         NotImplementedError: If ``indexed=False`` is provided.
     """
 
-    __slots__ = ()
-
     def __init__(self, *args, **kwargs):
         indexed = kwargs.pop("indexed", True)
         if not indexed:
@@ -2756,8 +2732,6 @@ class GeoPtProperty(Property):
 
     .. automethod:: _validate
     """
-
-    __slots__ = ()
 
     def _validate(self, value):
         """Validate a ``value`` before setting it.
@@ -2966,8 +2940,6 @@ class User(object):
         ValueError: If the ``_auth_domain`` is not passed in.
         UserNotFoundError: If ``email`` is empty.
     """
-
-    __slots__ = ("_auth_domain", "_email", "_user_id")
 
     def __init__(self, email=None, _auth_domain=None, _user_id=None):
         if _auth_domain is None:
@@ -3465,8 +3437,6 @@ class BlobKeyProperty(Property):
     .. automethod:: _validate
     """
 
-    __slots__ = ()
-
     def _validate(self, value):
         """Validate a ``value`` before setting it.
 
@@ -3685,8 +3655,6 @@ class DateProperty(DateTimeProperty):
     .. automethod:: _validate
     """
 
-    __slots__ = ()
-
     def _validate(self, value):
         """Validate a ``value`` before setting it.
 
@@ -3746,8 +3714,6 @@ class TimeProperty(DateTimeProperty):
     .. automethod:: _from_base_type
     .. automethod:: _validate
     """
-
-    __slots__ = ()
 
     def _validate(self, value):
         """Validate a ``value`` before setting it.

--- a/google/cloud/ndb/msgprop.py
+++ b/google/cloud/ndb/msgprop.py
@@ -19,14 +19,10 @@ __all__ = ["EnumProperty", "MessageProperty"]
 
 
 class EnumProperty(object):
-    __slots__ = ()
-
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class MessageProperty(object):
-    __slots__ = ()
-
     def __init__(self, *args, **kwargs):
         raise NotImplementedError

--- a/google/cloud/ndb/query.py
+++ b/google/cloud/ndb/query.py
@@ -183,8 +183,6 @@ class PropertyOrder(object):
                or not (ascending). Default is False.
     """
 
-    __slots__ = ["name", "reverse"]
-
     def __init__(self, name, reverse=False):
         self.name = name
         self.reverse = reverse
@@ -226,8 +224,6 @@ class RepeatedStructuredPropertyPredicate(object):
             match in a subentity of the repeated structured property. Should
             contain a value for each key in ``match_keys``.
     """
-
-    __slots__ = ["name", "match_keys", "match_values"]
 
     def __init__(self, name, match_keys, entity_pb):
         self.name = name
@@ -304,8 +300,6 @@ class Parameter(ParameterizedThing):
     Raises:
         TypeError: If the ``key`` is not a string or integer.
     """
-
-    __slots__ = ("_key",)
 
     def __init__(self, key):
         if not isinstance(key, six.integer_types + six.string_types):
@@ -411,8 +405,6 @@ class Node(object):
 
     _multiquery = False
 
-    __slots__ = ()
-
     def __new__(cls):
         if cls is Node:
             raise TypeError("Cannot instantiate Node, only a subclass.")
@@ -479,8 +471,6 @@ class Node(object):
 class FalseNode(Node):
     """Tree node for an always-failing filter."""
 
-    __slots__ = ()
-
     def __eq__(self, other):
         """Equality check.
 
@@ -523,8 +513,6 @@ class ParameterNode(Node):
         TypeError: If ``param`` is not a :class:`.Parameter` or
             :class:`.ParameterizedFunction`.
     """
-
-    __slots__ = ("_prop", "_op", "_param")
 
     def __new__(cls, prop, op, param):
         # Avoid circular import in Python 2.7
@@ -643,7 +631,9 @@ class FilterNode(Node):
             :class:`frozenset`)
     """
 
-    __slots__ = ("_name", "_opsymbol", "_value")
+    _name = None
+    _opsymbol = None
+    _value = None
 
     def __new__(cls, name, opsymbol, value):
         # Avoid circular import in Python 2.7
@@ -754,8 +744,6 @@ class PostFilterNode(Node):
             the given filter.
     """
 
-    __slots__ = ("predicate",)
-
     def __new__(cls, predicate):
         instance = super(PostFilterNode, cls).__new__(cls)
         instance.predicate = predicate
@@ -825,8 +813,6 @@ class _BooleanClauses(object):
         combine_or (bool): Indicates if new nodes will be combined
             with the current boolean expression via ``AND`` or ``OR``.
     """
-
-    __slots__ = ("name", "combine_or", "or_parts")
 
     def __init__(self, name, combine_or):
         self.name = name
@@ -918,8 +904,6 @@ class ConjunctionNode(Node):
         RuntimeError: If the ``nodes`` combine to an "empty" boolean
             expression.
     """
-
-    __slots__ = ("_nodes",)
 
     def __new__(cls, *nodes):
         if not nodes:
@@ -1075,7 +1059,6 @@ class DisjunctionNode(Node):
     """
 
     _multiquery = True
-    __slots__ = ("_nodes",)
 
     def __new__(cls, *nodes):
         if not nodes:

--- a/google/cloud/ndb/stats.py
+++ b/google/cloud/ndb/stats.py
@@ -58,8 +58,6 @@ class BaseStatistic(model.Model):
             written to Cloud Datastore.
     """
 
-    __slots__ = ()
-
     # This is necessary for the _get_kind() classmethod override.
     STORED_KIND_NAME = "__BaseStatistic__"
 
@@ -85,8 +83,6 @@ class BaseKindStatistic(BaseStatistic):
             in Cloud Datastore minus the cost of storing indices.
     """
 
-    __slots__ = ()
-
     STORED_KIND_NAME = "__BaseKindStatistic__"
 
     kind_name = model.StringProperty()
@@ -111,8 +107,6 @@ class GlobalStat(BaseStatistic):
             composite index entries.
         composite_index_count (int): the number of composite index entries.
     """
-
-    __slots__ = ()
 
     STORED_KIND_NAME = "__Stat_Total__"
 
@@ -148,8 +142,6 @@ class NamespaceStat(BaseStatistic):
         composite_index_count (int): the number of composite index entries.
     """
 
-    __slots__ = ()
-
     STORED_KIND_NAME = "__Stat_Namespace__"
 
     subject_namespace = model.StringProperty()
@@ -180,8 +172,6 @@ class KindStat(BaseKindStatistic):
         composite_index_count (int): the number of composite index entries.
     """
 
-    __slots__ = ()
-
     STORED_KIND_NAME = "__Stat_Kind__"
 
     builtin_index_bytes = model.IntegerProperty(default=0)
@@ -201,8 +191,6 @@ class KindRootEntityStat(BaseKindStatistic):
     stat contains statistics regarding these root entity instances.
     """
 
-    __slots__ = ()
-
     STORED_KIND_NAME = "__Stat_Kind_IsRootEntity__"
 
 
@@ -213,8 +201,6 @@ class KindNonRootEntityStat(BaseKindStatistic):
     the application's datastore that is a not a root entity.  This stat
     contains statistics regarding these non root entity instances.
     """
-
-    __slots__ = ()
 
     STORED_KIND_NAME = "__Stat_Kind_NotRootEntity__"
 
@@ -235,8 +221,6 @@ class PropertyTypeStat(BaseStatistic):
         built-in index entries.
         builtin_index_count (int): the number of built-in index entries.
     """
-
-    __slots__ = ()
 
     STORED_KIND_NAME = "__Stat_PropertyType__"
 
@@ -263,8 +247,6 @@ class KindPropertyTypeStat(BaseKindStatistic):
         builtin_index_count (int): the number of built-in index entries.
     """
 
-    __slots__ = ()
-
     STORED_KIND_NAME = "__Stat_PropertyType_Kind__"
 
     property_type = model.StringProperty()
@@ -287,8 +269,6 @@ class KindPropertyNameStat(BaseKindStatistic):
             built-in index entries.
         builtin_index_count (int): the number of built-in index entries.
     """
-
-    __slots__ = ()
 
     STORED_KIND_NAME = "__Stat_PropertyName_Kind__"
 
@@ -316,8 +296,6 @@ class KindPropertyNamePropertyTypeStat(BaseKindStatistic):
       builtin_index_count (int): the number of built-in index entries.
     """
 
-    __slots__ = ()
-
     STORED_KIND_NAME = "__Stat_PropertyType_PropertyName_Kind__"
 
     property_type = model.StringProperty()
@@ -342,8 +320,6 @@ class KindCompositeIndexStat(BaseStatistic):
             instance.
     """
 
-    __slots__ = ()
-
     STORED_KIND_NAME = "__Stat_Kind_CompositeIndex__"
 
     index_id = model.IntegerProperty()
@@ -364,8 +340,6 @@ class NamespaceGlobalStat(GlobalStat):
     particular namespace.
     """
 
-    __slots__ = ()
-
     STORED_KIND_NAME = "__Stat_Ns_Total__"
 
 
@@ -375,8 +349,6 @@ class NamespaceKindStat(KindStat):
     These may be found in each specific namespace and represent stats for that
     particular namespace.
     """
-
-    __slots__ = ()
 
     STORED_KIND_NAME = "__Stat_Ns_Kind__"
 
@@ -388,8 +360,6 @@ class NamespaceKindRootEntityStat(KindRootEntityStat):
     particular namespace.
     """
 
-    __slots__ = ()
-
     STORED_KIND_NAME = "__Stat_Ns_Kind_IsRootEntity__"
 
 
@@ -399,8 +369,6 @@ class NamespaceKindNonRootEntityStat(KindNonRootEntityStat):
     These may be found in each specific namespace and represent stats for that
     particular namespace.
     """
-
-    __slots__ = ()
 
     STORED_KIND_NAME = "__Stat_Ns_Kind_NotRootEntity__"
 
@@ -412,8 +380,6 @@ class NamespacePropertyTypeStat(PropertyTypeStat):
     particular namespace.
     """
 
-    __slots__ = ()
-
     STORED_KIND_NAME = "__Stat_Ns_PropertyType__"
 
 
@@ -424,8 +390,6 @@ class NamespaceKindPropertyTypeStat(KindPropertyTypeStat):
     particular namespace.
     """
 
-    __slots__ = ()
-
     STORED_KIND_NAME = "__Stat_Ns_PropertyType_Kind__"
 
 
@@ -435,8 +399,6 @@ class NamespaceKindPropertyNameStat(KindPropertyNameStat):
     These may be found in each specific namespace and represent stats for that
     particular namespace.
     """
-
-    __slots__ = ()
 
     STORED_KIND_NAME = "__Stat_Ns_PropertyName_Kind__"
 
@@ -450,8 +412,6 @@ class NamespaceKindPropertyNamePropertyTypeStat(
     particular namespace.
     """
 
-    __slots__ = ()
-
     STORED_KIND_NAME = "__Stat_Ns_PropertyType_PropertyName_Kind__"
 
 
@@ -461,8 +421,6 @@ class NamespaceKindCompositeIndexStat(KindCompositeIndexStat):
     These may be found in each specific namespace and represent stats for that
     particular namespace.
     """
-
-    __slots__ = ()
 
     STORED_KIND_NAME = "__Stat_Ns_Kind_CompositeIndex__"
 

--- a/google/cloud/ndb/tasklets.py
+++ b/google/cloud/ndb/tasklets.py
@@ -579,22 +579,16 @@ def make_default_context(*args, **kwargs):
 
 
 class QueueFuture(object):
-    __slots__ = ()
-
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class ReducingFuture(object):
-    __slots__ = ()
-
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class SerialQueueFuture(object):
-    __slots__ = ()
-
     def __init__(self, *args, **kwargs):
         raise NotImplementedError
 

--- a/tests/system/test_misc.py
+++ b/tests/system/test_misc.py
@@ -18,7 +18,6 @@ Difficult to classify regression tests.
 import pickle
 
 import pytest
-import six
 
 from google.cloud import ndb
 
@@ -40,9 +39,6 @@ class PickleSomeKind(ndb.Model):
         return "SomeKind"
 
 
-@pytest.mark.skipif(
-    six.PY2, reason="Pickling doesn't work in Python 2. See: Issue #311"
-)
 @pytest.mark.usefixtures("client_context")
 def test_pickle_roundtrip_structured_property(dispose_of):
     """Regression test for Issue #281.


### PR DESCRIPTION
In Python 2.7, classes which use `__slots__` can't be pickled. Users
have reported problems trying to pickle NDB entities, indicating there
is some perceived use case for pickling entities.

Fixes #311