### PR TITLE
feat: `Key.to_legacy_urlsafe()`

### DIFF
--- a/google/cloud/ndb/key.py
+++ b/google/cloud/ndb/key.py
@@ -739,20 +739,24 @@ class Key(object):
         raw_bytes = self.serialized()
         return base64.urlsafe_b64encode(raw_bytes).strip(b"=")
 
-    def to_legacy_urlsafe(self, location_prefix=None):
-        """A ``Reference`` protobuf serialized and encoded as urlsafe base 64.
+    def to_legacy_urlsafe(self, location_prefix):
+        """
+        A urlsafe serialized ``Reference`` protobuf with an App Engine prefix.
+
+        This will produce a urlsafe string which includes an App Engine
+        location prefix ("partition"), compatible with the Google Datastore
+        admin console.
 
         Arguments:
-            location_prefix (Optional[str]): A prefix to be prepended to the
-                key's `project` when serializing the key. Required (at the time
-                of this writing) for producing strings compatible with the
-                Google Datastore admin console. Eventually this shouldn't be
-                needed. A typical value is "s~".
+            location_prefix (str): A location prefix ("partition") to be
+                prepended to the key's `project` when serializing the key. A
+                typical value is "s~", but "e~" or other partitions are
+                possible depending on the project's region and other factors.
 
         .. doctest:: key-legacy-urlsafe
 
             >>> key = ndb.Key("Kind", 1337, project="example")
-            >>> key.to_legacy_urlsafe(location_prefix="s~")
+            >>> key.to_legacy_urlsafe("s~")
             b'aglzfmV4YW1wbGVyCwsSBEtpbmQYuQoM'
         """
         return google.cloud.datastore.Key(

--- a/google/cloud/ndb/key.py
+++ b/google/cloud/ndb/key.py
@@ -739,6 +739,22 @@ class Key(object):
         raw_bytes = self.serialized()
         return base64.urlsafe_b64encode(raw_bytes).strip(b"=")
 
+    def legacy_urlsafe(self, location_prefix=None):
+        """A ``Reference`` protobuf encoded as urlsafe base 64.
+
+        .. doctest:: key-urlsafe
+
+            >>> key = ndb.Key("Kind", 1337, project="example")
+            >>> key.legacy_urlsafe()
+            b'agdleGFtcGxlcgsLEgRLaW5kGLkKDA'
+        """
+        return google.cloud.datastore.Key(
+            self._key.kind,
+            self._key.id,
+            namespace=self._key.namespace,
+            project=self._key.project,
+        ).to_legacy_urlsafe(location_prefix=location_prefix)
+
     @_options.ReadOptions.options
     @utils.positional(1)
     def get(

--- a/google/cloud/ndb/key.py
+++ b/google/cloud/ndb/key.py
@@ -728,7 +728,7 @@ class Key(object):
         return reference.SerializeToString()
 
     def urlsafe(self):
-        """A ``Reference`` protobuf encoded as urlsafe base 64.
+        """A ``Reference`` protobuf serialized and encoded as urlsafe base 64.
 
         .. doctest:: key-urlsafe
 
@@ -739,14 +739,21 @@ class Key(object):
         raw_bytes = self.serialized()
         return base64.urlsafe_b64encode(raw_bytes).strip(b"=")
 
-    def legacy_urlsafe(self, location_prefix=None):
-        """A ``Reference`` protobuf encoded as urlsafe base 64.
+    def to_legacy_urlsafe(self, location_prefix=None):
+        """A ``Reference`` protobuf serialized and encoded as urlsafe base 64.
 
-        .. doctest:: key-urlsafe
+        Arguments:
+            location_prefix (Optional[str]): A prefix to be prepended to the
+                key's `project` when serializing the key. Required (at the time
+                of this writing) for producing strings compatible with the
+                Google Datastore admin console. Eventually this shouldn't be
+                needed. A typical value is "s~".
+
+        .. doctest:: key-legacy-urlsafe
 
             >>> key = ndb.Key("Kind", 1337, project="example")
-            >>> key.legacy_urlsafe()
-            b'agdleGFtcGxlcgsLEgRLaW5kGLkKDA'
+            >>> key.to_legacy_urlsafe(location_prefix="s~")
+            b'aglzfmV4YW1wbGVyCwsSBEtpbmQYuQoM'
         """
         return google.cloud.datastore.Key(
             self._key.kind,

--- a/tests/unit/test_key.py
+++ b/tests/unit/test_key.py
@@ -569,10 +569,11 @@ class TestKey:
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
-    def test_legacy_urlsafe():
+    def test_to_legacy_urlsafe():
         key = key_module.Key("d", 123, app="f")
         assert (
-            key.legacy_urlsafe(location_prefix="s~") == b"agNzfmZyBwsSAWQYeww"
+            key.to_legacy_urlsafe(location_prefix="s~")
+            == b"agNzfmZyBwsSAWQYeww"
         )
 
     @staticmethod

--- a/tests/unit/test_key.py
+++ b/tests/unit/test_key.py
@@ -569,6 +569,14 @@ class TestKey:
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
+    def test_legacy_urlsafe():
+        key = key_module.Key("d", 123, app="f")
+        assert (
+            key.legacy_urlsafe(location_prefix="s~") == b"agNzfmZyBwsSAWQYeww"
+        )
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
     @mock.patch("google.cloud.ndb._datastore_api")
     @mock.patch("google.cloud.ndb.model._entity_from_protobuf")
     def test_get_with_cache_miss(_entity_from_protobuf, _datastore_api):


### PR DESCRIPTION
Workaround the fact that Google has deprecated the location prefix, but it is still required by the Google Datastore admin console, by allowing users to manually provide a location prefix when generating urlsafe keys.

Fixes #264.
