### PR TITLE
fix: allow empty yields

### DIFF
--- a/tests/unit/test_tasklets.py
+++ b/tests/unit/test_tasklets.py
@@ -578,6 +578,33 @@ class Test_tasklet:
         task_foo.check_success()
         task_bar.check_success()
 
+    @staticmethod
+    def test_empty_yield(in_context):
+        @tasklets.tasklet
+        def some_task():
+            value = yield []
+            return value
+
+        assert some_task().result() == ()
+
+    @staticmethod
+    def test_multiple_empty_yield(in_context):
+        @tasklets.tasklet
+        def some_task():
+            (value1, value2) = yield [], []
+            return value1, value2
+
+        assert some_task().result() == ((), ())
+
+    @staticmethod
+    def test_multiple_empty_yield_tuple(in_context):
+        @tasklets.tasklet
+        def some_task():
+            (value1, value2) = yield ([], [])
+            return value1, value2
+
+        assert some_task().result() == ((), ())
+
 
 class Test_wait_any:
     @staticmethod


### PR DESCRIPTION
This fixes an issue we've found in the process of migrating our backend codebase from appengine ndb to python ndb: Tasklet yields on empty tuples/lists do not work.

Say you have code that looks like:

```py
things = yield [bla.get_async() for bla in blahs]
```

This doesn't work if `blahs == []`. NDB hangs indefinitely because there are no futures to finish and tell the event loop to stop.

This issue also affects yields on multiple expressions. Something like this fails too (when `blahs == []`):

```py
@ndb.synctasklet
def do_things_a_b(ids):
    (a, b) = yield \
        a_future, \
        [foo(id).get_async() for id in ids]

    return do_things(a, b)

# somewhere else
do_things_a_b([])
```

This latter example does not hang indefinitely but crashes immediately on [this line](https://github.com/googleapis/python-ndb/blob/master/google/cloud/ndb/tasklets.py#L412):
```
AttributeError: 'list' object has no attribute 'add_done_callback'
```