### PR TITLE
fix: fix bug with `yield` of empty list in tasklets

### DIFF
--- a/google/cloud/ndb/tasklets.py
+++ b/google/cloud/ndb/tasklets.py
@@ -411,6 +411,9 @@ class _MultiFuture(Future):
         for dependency in dependencies:
             dependency.add_done_callback(self._dependency_done)
 
+        if not dependencies:
+            self.set_result(())
+
     def __repr__(self):
         return "{}({}) <{}>".format(
             type(self).__name__,

--- a/tests/system/test_misc.py
+++ b/tests/system/test_misc.py
@@ -56,3 +56,19 @@ def test_pickle_roundtrip_structured_property(dispose_of):
     assert entity.other.key is None or entity.other.key.id() is None
     entity = pickle.loads(pickle.dumps(entity))
     assert entity.other.foo == 1
+
+
+@pytest.mark.usefixtures("client_context")
+def test_tasklet_yield_emtpy_list():
+    """
+    Regression test for Issue #353.
+
+    https://github.com/googleapis/python-ndb/issues/353
+    """
+
+    @ndb.tasklet
+    def test_it():
+        nothing = yield []
+        raise ndb.Return(nothing)
+
+    assert test_it().result() == ()

--- a/tests/unit/test_tasklets.py
+++ b/tests/unit/test_tasklets.py
@@ -453,6 +453,11 @@ class Test_MultiFuture:
         with pytest.raises(exceptions.Cancelled):
             future.result()
 
+    @staticmethod
+    def test_no_dependencies():
+        future = tasklets._MultiFuture(())
+        assert future.result() == ()
+
 
 class Test__get_return_value:
     @staticmethod


### PR DESCRIPTION
`yield` of an empty list will no longer cause a tasklet to hang forever.

Fixes #353.