### PR TITLE
fix: support nested sequences in parallel `yield` for tasklets

### DIFF
--- a/google/cloud/ndb/tasklets.py
+++ b/google/cloud/ndb/tasklets.py
@@ -406,9 +406,15 @@ class _MultiFuture(Future):
 
     def __init__(self, dependencies):
         super(_MultiFuture, self).__init__()
-        self._dependencies = dependencies
-
+        futures = []
         for dependency in dependencies:
+            if isinstance(dependency, (list, tuple)):
+                dependency = _MultiFuture(dependency)
+            futures.append(dependency)
+
+        self._dependencies = futures
+
+        for dependency in futures:
             dependency.add_done_callback(self._dependency_done)
 
         if not dependencies:

--- a/tests/unit/test_tasklets.py
+++ b/tests/unit/test_tasklets.py
@@ -458,6 +458,15 @@ class Test_MultiFuture:
         future = tasklets._MultiFuture(())
         assert future.result() == ()
 
+    @staticmethod
+    def test_nested():
+        dependencies = [tasklets.Future() for _ in range(3)]
+        future = tasklets._MultiFuture((dependencies[0], dependencies[1:]))
+        for i, dependency in enumerate(dependencies):
+            dependency.set_result(i)
+
+        assert future.result() == (0, (1, 2))
+
 
 class Test__get_return_value:
     @staticmethod


### PR DESCRIPTION
This adds backwards compatibility with the legacy code.

Fixes #357.