### PR TITLE
fix: move stub (grpc communication channel) to client

### DIFF
--- a/google/cloud/ndb/_datastore_api.py
+++ b/google/cloud/ndb/_datastore_api.py
@@ -17,12 +17,8 @@
 import itertools
 import logging
 
-import grpc
-
-from google.cloud import _helpers
 from google.cloud.datastore import helpers
 from google.cloud.datastore_v1.proto import datastore_pb2
-from google.cloud.datastore_v1.proto import datastore_pb2_grpc
 from google.cloud.datastore_v1.proto import entity_pb2
 
 from google.cloud.ndb import context as context_module
@@ -54,28 +50,7 @@ def stub():
             The stub instance.
     """
     context = context_module.get_context()
-    return context.stub
-
-
-def make_stub(client):
-    """Create the stub for the `Google Datastore` API.
-
-    Args:
-        client (client.Client): The NDB client.
-
-    Returns:
-        :class:`~google.cloud.datastore_v1.proto.datastore_pb2_grpc.DatastoreStub`:
-            The stub instance.
-    """
-    if client.secure:
-        user_agent = client.client_info.to_user_agent()
-        channel = _helpers.make_secure_channel(
-            client._credentials, user_agent, client.host
-        )
-    else:
-        channel = grpc.insecure_channel(client.host)
-
-    return datastore_pb2_grpc.DatastoreStub(channel)
+    return context.client.stub
 
 
 def make_call(rpc_name, request, retries=None, timeout=None):

--- a/google/cloud/ndb/context.py
+++ b/google/cloud/ndb/context.py
@@ -146,7 +146,6 @@ _ContextTuple = collections.namedtuple(
     [
         "client",
         "eventloop",
-        "stub",
         "batches",
         "commit_batches",
         "transaction",
@@ -179,7 +178,6 @@ class _Context(_ContextTuple):
         cls,
         client,
         eventloop=None,
-        stub=None,
         batches=None,
         commit_batches=None,
         transaction=None,
@@ -194,13 +192,9 @@ class _Context(_ContextTuple):
     ):
         # Prevent circular import in Python 2.7
         from google.cloud.ndb import _cache
-        from google.cloud.ndb import _datastore_api
 
         if eventloop is None:
             eventloop = _eventloop.EventLoop()
-
-        if stub is None:
-            stub = _datastore_api.make_stub(client)
 
         if batches is None:
             batches = {}
@@ -218,7 +212,6 @@ class _Context(_ContextTuple):
             cls,
             client=client,
             eventloop=eventloop,
-            stub=stub,
             batches=batches,
             commit_batches=commit_batches,
             transaction=transaction,

--- a/google/cloud/ndb/key.py
+++ b/google/cloud/ndb/key.py
@@ -147,8 +147,13 @@ class Key(object):
 
         from unittest import mock
         from google.cloud.ndb import context as context_module
-        client = mock.Mock(project="testing", spec=("project",), namespace="")
-        context = context_module.Context(client, stub=mock.Mock(spec=())).use()
+        client = mock.Mock(
+            project="testing",
+            namespace="",
+            stub=mock.Mock(spec=()),
+            spec=("project", "namespace", "stub"),
+        )
+        context = context_module.Context(client).use()
         context.__enter__()
         kind1, id1 = "Parent", "C"
         kind2, id2 = "Child", 42

--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -20,8 +20,13 @@
     from google.cloud import ndb
     from google.cloud.ndb import context as context_module
 
-    client = mock.Mock(project="testing", spec=("project",), namespace="")
-    context = context_module.Context(client, stub=mock.Mock(spec=())).use()
+    client = mock.Mock(
+        project="testing",
+        namespace="",
+        stub=mock.Mock(spec=()),
+        spec=("project", "namespace", "stub"),
+    )
+    context = context_module.Context(client).use()
     context.__enter__()
 
 .. testcleanup:: *

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,11 +87,13 @@ def initialize_environment(request, environ):
 @pytest.fixture
 def context():
     client = mock.Mock(
-        project="testing", namespace=None, spec=("project", "namespace")
+        project="testing",
+        namespace=None,
+        spec=("project", "namespace"),
+        stub=mock.Mock(spec=()),
     )
     context = context_module.Context(
         client,
-        stub=mock.Mock(spec=()),
         eventloop=TestingEventLoop(),
         datastore_policy=True,
         legacy_data=False,

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -37,17 +37,16 @@ def test___all__():
 class TestContext:
     def _make_one(self, **kwargs):
         client = mock.Mock(
-            namespace=None, project="testing", spec=("namespace", "project")
+            namespace=None,
+            project="testing",
+            spec=("namespace", "project"),
+            stub=mock.Mock(spec=()),
         )
-        stub = mock.Mock(spec=())
-        return context_module.Context(client, stub=stub, **kwargs)
+        return context_module.Context(client, **kwargs)
 
-    @mock.patch("google.cloud.ndb._datastore_api.make_stub")
-    def test_constructor_defaults(self, make_stub):
+    def test_constructor_defaults(self):
         context = context_module.Context("client")
         assert context.client == "client"
-        assert context.stub is make_stub.return_value
-        make_stub.assert_called_once_with("client")
         assert isinstance(context.eventloop, _eventloop.EventLoop)
         assert context.batches == {}
         assert context.transaction is None
@@ -55,13 +54,11 @@ class TestContext:
     def test_constructor_overrides(self):
         context = context_module.Context(
             client="client",
-            stub="stub",
             eventloop="eventloop",
             batches="batches",
             transaction="transaction",
         )
         assert context.client == "client"
-        assert context.stub == "stub"
         assert context.eventloop == "eventloop"
         assert context.batches == "batches"
         assert context.transaction == "transaction"


### PR DESCRIPTION
This brings our practice in line with `google.cloud.datastore`, which
also creates one channel per client. This works around a resource leak issue
by not requiring the channel to clean up after itself properly in normal
usage. The root cause of that issue seems to lie somewhere in
`google.auth`, which is where I will follow up.

Fixes #343