### PR TITLE
fix: accept `bytes` or `str` as base value for `JsonProperty`

### DIFF
--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -2033,7 +2033,7 @@ class Property(ModelAttribute):
         """
         if require_indexed and not self._indexed:
             raise InvalidPropertyError(
-                "Property is unindexed {}".format(self._name)
+                "Property is unindexed: {}".format(self._name)
             )
 
         if rest:
@@ -3049,12 +3049,16 @@ class JsonProperty(BlobProperty):
         """Convert a value from the "base" value type for this property.
 
         Args:
-            value (bytes): The value to be converted.
+            value (Union[bytes, str]): The value to be converted.
 
         Returns:
             Any: The ``value`` (ASCII bytes or string) loaded as JSON.
         """
-        return json.loads(value.decode("ascii"))
+        # We write and retrieve `bytes` normally, but for some reason get back
+        # `str` from a projection query.
+        if not isinstance(value, six.text_type):
+            value = value.decode("ascii")
+        return json.loads(value)
 
 
 @functools.total_ordering

--- a/tests/system/test_query.py
+++ b/tests/system/test_query.py
@@ -1627,3 +1627,22 @@ def test_IN(ds_entity):
     assert len(results) == 2
     assert results[0].foo == 2
     assert results[1].foo == 3
+
+
+@pytest.mark.usefixtures("client_context")
+def test_projection_with_json_property(dispose_of):
+    """Regression test for #378
+
+    https://github.com/googleapis/python-ndb/issues/378
+    """
+
+    class SomeKind(ndb.Model):
+        foo = ndb.JsonProperty(indexed=True)
+
+    key = SomeKind(foo={"hi": "mom!"}).put()
+    dispose_of(key._key)
+
+    eventually(SomeKind.query().fetch, _length_equals(1))
+
+    results = SomeKind.query().fetch(projection=[SomeKind.foo])
+    assert results[0].foo == {"hi": "mom!"}

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -2253,11 +2253,11 @@ class TestJsonProperty:
         assert prop._from_base_type(value) == expected
 
     @staticmethod
-    def test__from_base_type_invalid():
+    def test__from_base_type_str():
         prop = model.JsonProperty(name="json-val")
-        if six.PY3:  # pragma: NO PY2 COVER  # pragma: NO BRANCH
-            with pytest.raises(AttributeError):
-                prop._from_base_type("{}")
+        value = u'[14,true,{"a":null,"b":"\\u2603"}]'
+        expected = [14, True, {"a": None, "b": u"\N{snowman}"}]
+        assert prop._from_base_type(value) == expected
 
 
 class TestUser:


### PR DESCRIPTION
For `JsonProperty`, even though we write and normally read `bytes`, when
retrieving a `JsonProperty` in a projection query, for some reason, we
get an already decoded string, which cause NDB to file with projection
queries that read JSON properties.

Fixes #378