### PR TITLE
feat: add `namespace` property to `context.Context`

### DIFF
--- a/google/cloud/ndb/client.py
+++ b/google/cloud/ndb/client.py
@@ -28,6 +28,7 @@ from google.cloud.datastore_v1.proto import datastore_pb2_grpc
 
 from google.cloud.ndb import __version__
 from google.cloud.ndb import context as context_module
+from google.cloud.ndb import key as key_module
 
 
 _CLIENT_INFO = client_info.ClientInfo(
@@ -131,6 +132,7 @@ class Client(google_client.ClientWithProject):
     @contextlib.contextmanager
     def context(
         self,
+        namespace=key_module.UNDEFINED,
         cache_policy=None,
         global_cache=None,
         global_cache_policy=None,
@@ -188,6 +190,7 @@ class Client(google_client.ClientWithProject):
 
         context = context_module.Context(
             self,
+            namespace=namespace,
             cache_policy=cache_policy,
             global_cache=global_cache,
             global_cache_policy=global_cache_policy,

--- a/google/cloud/ndb/context.py
+++ b/google/cloud/ndb/context.py
@@ -22,6 +22,7 @@ import threading
 
 from google.cloud.ndb import _eventloop
 from google.cloud.ndb import exceptions
+from google.cloud.ndb import key as key_module
 from google.cloud.ndb import tasklets
 
 
@@ -145,6 +146,7 @@ _ContextTuple = collections.namedtuple(
     "_ContextTuple",
     [
         "client",
+        "namespace",
         "eventloop",
         "batches",
         "commit_batches",
@@ -177,6 +179,7 @@ class _Context(_ContextTuple):
     def __new__(
         cls,
         client,
+        namespace=key_module.UNDEFINED,
         eventloop=None,
         batches=None,
         commit_batches=None,
@@ -211,6 +214,7 @@ class _Context(_ContextTuple):
         context = super(_Context, cls).__new__(
             cls,
             client=client,
+            namespace=namespace,
             eventloop=eventloop,
             batches=batches,
             commit_batches=commit_batches,
@@ -328,6 +332,20 @@ class Context(_Context):
     def flush(self):
         """Force any pending batch operations to go ahead and run."""
         self.eventloop.run()
+
+    def get_namespace(self):
+        """Return the current context namespace.
+
+        If `namespace` isn't set on the context, the client's namespace will be
+        returned.
+
+        Returns:
+            str: The namespace, or `None`.
+        """
+        if self.namespace is key_module.UNDEFINED:
+            return self.client.namespace
+
+        return self.namespace
 
     def get_cache_policy(self):
         """Return the current context cache policy function.

--- a/google/cloud/ndb/key.py
+++ b/google/cloud/ndb/key.py
@@ -74,15 +74,11 @@ Other constraints:
 * Integer IDs must be at least ``1`` and at most ``2**63 - 1`` (i.e. the
   positive part of the range for a 64-bit signed integer)
 
-For more info about namespaces, see the multitenancy `overview`_.
 In the "legacy" Google App Engine runtime, the default namespace could be
 set via the namespace manager (``google.appengine.api.namespace_manager``).
 On the gVisor Google App Engine runtime (e.g. Python 3.7), the namespace
 manager is not available so the default is to have an unset or empty
 namespace. To explicitly select the empty namespace pass ``namespace=""``.
-
-.. _overview:
-  https://cloud.google.com/appengine/docs/standard/python/multitenancy/
 """
 
 
@@ -149,7 +145,7 @@ class Key(object):
         from google.cloud.ndb import context as context_module
         client = mock.Mock(
             project="testing",
-            namespace="",
+            namespace=None,
             stub=mock.Mock(spec=()),
             spec=("project", "namespace", "stub"),
         )
@@ -294,11 +290,8 @@ class Key(object):
 
         # Make sure to pass in the namespace if it's not explicitly set.
         if kwargs.get("namespace", UNDEFINED) is UNDEFINED:
-            client = context_module.get_context().client
-            if client.namespace:
-                kwargs["namespace"] = client.namespace
-            else:
-                kwargs["namespace"] = None  # default namespace
+            context = context_module.get_context()
+            kwargs["namespace"] = context.get_namespace()
 
         if (
             "reference" in kwargs

--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -22,7 +22,7 @@
 
     client = mock.Mock(
         project="testing",
-        namespace="",
+        namespace=None,
         stub=mock.Mock(spec=()),
         spec=("project", "namespace", "stub"),
     )

--- a/google/cloud/ndb/query.py
+++ b/google/cloud/ndb/query.py
@@ -1230,8 +1230,8 @@ def _query_options(wrapped):
         # sort out. Some might be synonyms or shorthand for other options.
         query_arguments.update(kwargs)
 
-        client = context_module.get_context().client
-        query_options = QueryOptions(client=client, **query_arguments)
+        context = context_module.get_context()
+        query_options = QueryOptions(context=context, **query_arguments)
 
         return wrapped(self, *dummy_args, _options=query_options)
 
@@ -1262,7 +1262,7 @@ class QueryOptions(_options.ReadOptions):
         "callback",
     )
 
-    def __init__(self, config=None, client=None, **kwargs):
+    def __init__(self, config=None, context=None, **kwargs):
         if kwargs.get("batch_size"):
             raise exceptions.NoLongerImplementedError()
 
@@ -1284,12 +1284,12 @@ class QueryOptions(_options.ReadOptions):
 
         super(QueryOptions, self).__init__(config=config, **kwargs)
 
-        if client:
+        if context:
             if not self.project:
-                self.project = client.project
+                self.project = context.client.project
 
             if not self.namespace:
-                self.namespace = client.namespace
+                self.namespace = context.get_namespace()
 
 
 class Query(object):

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -123,9 +123,12 @@ def other_namespace():
 
 @pytest.fixture
 def client_context(namespace):
-    client = ndb.Client(namespace=namespace)
-    with client.context(cache_policy=False, legacy_data=False) as the_context:
-        yield the_context
+    client = ndb.Client()
+    context_manager = client.context(
+        cache_policy=False, legacy_data=False, namespace=namespace,
+    )
+    with context_manager as context:
+        yield context
 
 
 @pytest.fixture

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -348,6 +348,16 @@ class TestContext:
         context = self._make_one()
         assert context.in_transaction() is False
 
+    def test_get_namespace_from_client(self):
+        context = self._make_one()
+        context.client.namespace = "hamburgers"
+        assert context.get_namespace() == "hamburgers"
+
+    def test_get_namespace_from_context(self):
+        context = self._make_one(namespace="hotdogs")
+        context.client.namespace = "hamburgers"
+        assert context.get_namespace() == "hotdogs"
+
     def test_memcache_add(self):
         context = self._make_one()
         with pytest.raises(NotImplementedError):


### PR DESCRIPTION
It is now possible to set the namespace on the context, overriding the
namespace set on the client. This makes it easier to write multi-homed
applications which might access different namespaces depending on which
user is logged in or other variable only known at request time.

`client.Client.context` has a new argument, `namespace`, which can be
used to set the namespace at request time. Here is an example of you
might do this in a WSGI middleware:

~~~~
def ndb_wsgi_middleware(wsgi_app):
    client = ndb.Client()

    def middleware(environ, start_response):
        global_cache = ndb.RedisCache.from_environment()
        namespace = get_namespace_from_request(environ)
        with client.context(global_cache=global_cache, namespace=namespace):
            return wsgi_app(environ, start_response)

    return middleware

app = flask.Flask("NDB Example")
app.wsgi_app = ndb_wsgi_middleware(app.wsgi_app)  # Wrap the app in middleware.
~~~~

Closes #385.