### PR TITLE
fix: make properties hashable in python 3

### DIFF
--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -1233,6 +1233,14 @@ class Property(ModelAttribute):
         """FilterNode: Represents the ``=`` comparison."""
         return self._comparison("=", value)
 
+    # Because we are overriding ``__eq__``, we need to override ``__hash__``,
+    # to avoid an error on Python 3 when calling ``hash`` on a property. Using
+    # ``id`` makes ``hash`` behave the same on both Python 3 and Python 2. See
+    # https://github.com/googleapis/python-ndb/issues/389.
+
+    def __hash__(self):
+        return id(self)
+
     def __ne__(self, value):
         """FilterNode: Represents the ``!=`` comparison."""
         return self._comparison("!=", value)

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -1364,6 +1364,12 @@ class TestProperty:
         ) == ("pre.prop",)
         assert data == {"pre.prop": ["foo"]}
 
+    @staticmethod
+    def test___hash__():
+        prop = model.Property()
+
+        assert hash(prop) == id(prop)
+
 
 class Test__validate_key:
     @staticmethod


### PR DESCRIPTION
refs #389.

This is a very simple fix to make the ``hash`` call for a Property behave the same on both Python 3 and Python 2. At least one user has experienced problems with this call.