### PR TITLE
fix: Add `ABORTED` to retryable status codes.

### DIFF
--- a/google/cloud/ndb/_retry.py
+++ b/google/cloud/ndb/_retry.py
@@ -99,7 +99,11 @@ def retry_async(callback, retries=_DEFAULT_RETRIES):
 # that a DEADLINE_EXCEEDED status code guarantees the operation was cancelled,
 # then we can add DEADLINE_EXCEEDED to our retryable status codes. Not knowing
 # the answer, it's best not to take that risk.
-TRANSIENT_CODES = (grpc.StatusCode.UNAVAILABLE, grpc.StatusCode.INTERNAL)
+TRANSIENT_CODES = (
+    grpc.StatusCode.UNAVAILABLE,
+    grpc.StatusCode.INTERNAL,
+    grpc.StatusCode.ABORTED,
+)
 
 
 def is_transient_error(error):

--- a/tests/unit/test__retry.py
+++ b/tests/unit/test__retry.py
@@ -177,3 +177,11 @@ class Test_is_transient_error:
         core_retry.if_transient_error.return_value = False
         assert _retry.is_transient_error(error) is False
         core_retry.if_transient_error.assert_called_once_with(error)
+
+    @staticmethod
+    @mock.patch("google.cloud.ndb._retry.core_retry")
+    def test_aborted(core_retry):
+        error = mock.Mock(code=mock.Mock(return_value=grpc.StatusCode.ABORTED))
+        core_retry.if_transient_error.return_value = False
+        assert _retry.is_transient_error(error) is True
+        core_retry.if_transient_error.assert_called_once_with(error)


### PR DESCRIPTION
Fixes #383.