### PR TITLE
fix: make sure reads happen in transaction if there is a transaction

### DIFF
--- a/google/cloud/ndb/_options.py
+++ b/google/cloud/ndb/_options.py
@@ -215,6 +215,7 @@ class ReadOptions(Options):
         if not kwargs.get("transaction"):
             # Avoid circular import in Python 2.7
             from google.cloud.ndb import context as context_module
+
             context = context_module.get_context(False)
             if context:
                 kwargs["transaction"] = context.transaction

--- a/google/cloud/ndb/_options.py
+++ b/google/cloud/ndb/_options.py
@@ -212,4 +212,11 @@ class ReadOptions(Options):
                 )
             kwargs["read_consistency"] = read_policy
 
+        if not kwargs.get("transaction"):
+            # Avoid circular import in Python 2.7
+            from google.cloud.ndb import context as context_module
+            context = context_module.get_context(False)
+            if context:
+                kwargs["transaction"] = context.transaction
+
         super(ReadOptions, self).__init__(config=config, **kwargs)

--- a/tests/system/test_misc.py
+++ b/tests/system/test_misc.py
@@ -125,12 +125,12 @@ def test_parallel_transactions(dispose_of):
         foo = ndb.IntegerProperty()
 
     @ndb.transactional_tasklet()
-    def update(id, add):
+    def update(id, add, delay=0):
         entity = yield SomeKind.get_by_id_async(id)
         foo = entity.foo
         foo += add
 
-        yield ndb.sleep(1)
+        yield ndb.sleep(delay)
         entity.foo = foo
 
         yield entity.put_async()
@@ -139,7 +139,7 @@ def test_parallel_transactions(dispose_of):
     def concurrent_tasks(id):
         yield [
             update(id, 100),
-            update(id, 100),
+            update(id, 100, 0.01),
         ]
 
     key = SomeKind(foo=42).put()

--- a/tests/system/test_misc.py
+++ b/tests/system/test_misc.py
@@ -112,3 +112,41 @@ def test_transactional_composable(dispose_of):
 
     results = get_entities(entity_key, other_keys[0])
     assert [result.bar for result in results] == [42, 1, 2, 3, 4, 0]
+
+
+@pytest.mark.usefixtures("client_context")
+def test_parallel_transactions(dispose_of):
+    """Regression test for Issue #394
+
+    https://github.com/googleapis/python-ndb/issues/394
+    """
+
+    class SomeKind(ndb.Model):
+        foo = ndb.IntegerProperty()
+
+    @ndb.transactional_tasklet()
+    def update(id, add):
+        entity = yield SomeKind.get_by_id_async(id)
+        foo = entity.foo
+        foo += add
+
+        yield ndb.sleep(1)
+        entity.foo = foo
+
+        yield entity.put_async()
+
+    @ndb.tasklet
+    def concurrent_tasks(id):
+        yield [
+            update(id, 100),
+            update(id, 100),
+        ]
+
+    key = SomeKind(foo=42).put()
+    dispose_of(key._key)
+    id = key.id()
+
+    concurrent_tasks(id).get_result()
+
+    entity = SomeKind.get_by_id(id)
+    assert entity.foo == 242

--- a/tests/unit/test__datastore_api.py
+++ b/tests/unit/test__datastore_api.py
@@ -191,7 +191,9 @@ class Test_lookup:
             _api.lookup(_mock_key("foo"), _options.ReadOptions())
             _api.lookup(_mock_key("bar"), _options.ReadOptions())
 
-            batch = new_context.batches[_api._LookupBatch][()]
+            batch = new_context.batches[_api._LookupBatch][
+                (("transaction", b"tx123"),)
+            ]
             assert len(batch.todo["foo"]) == 2
             assert len(batch.todo["bar"]) == 1
             assert new_context.eventloop.add_idle.call_count == 1


### PR DESCRIPTION
Fixes a bug where reads during a transaction wouldn't necessarily happen
in the context of the transaction.

Fixes #394