### PR TITLE
fix: handle empty batches from Firestore

### DIFF
--- a/google/cloud/ndb/_datastore_query.py
+++ b/google/cloud/ndb/_datastore_query.py
@@ -266,9 +266,12 @@ class _QueryIteratorImpl(QueryIterator):
         if self._index < len(self._batch):
             raise tasklets.Return(True)
 
-        elif self._has_next_batch:
+        while self._has_next_batch:
+            # Firestore will sometimes send us empty batches when there are
+            # still more results to go. This `while` loop skips those.
             yield self._next_batch()
-            raise tasklets.Return(self._index < len(self._batch))
+            if self._batch:
+                raise tasklets.Return(self._index < len(self._batch))
 
         raise tasklets.Return(False)
 

--- a/tests/unit/test__datastore_query.py
+++ b/tests/unit/test__datastore_query.py
@@ -255,6 +255,24 @@ class Test_QueryIteratorImpl:
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
+    def test_has_next_async_next_batch_is_empty():
+        iterator = _datastore_query._QueryIteratorImpl("foo")
+        iterator._index = 3
+        iterator._batch = ["a", "b", "c"]
+        iterator._has_next_batch = True
+
+        batches = [[], ["d", "e", "f"]]
+
+        def dummy_next_batch():
+            iterator._index = 0
+            iterator._batch = batches.pop(0)
+            return utils.future_result(None)
+
+        iterator._next_batch = dummy_next_batch
+        assert iterator.has_next_async().result()
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
     def test_has_next_async_next_batch_finished():
         iterator = _datastore_query._QueryIteratorImpl("foo")
         iterator._index = 3


### PR DESCRIPTION
For some queries, when paging through batches of results, Firestore will
return a batch that has no results, even though there are still results
left to return for the query. Previously, this would cause
`QueryIterator` to prematurely stop iterating over results. Empty
batches are now handled and skipped so that `QueryIterator` doesn't stop
retrieving results prematurely.

Fixes #386