### PR TITLE
fix: use `skipped_results` from query results to adjust offset

### DIFF
--- a/google/cloud/ndb/_datastore_query.py
+++ b/google/cloud/ndb/_datastore_query.py
@@ -316,8 +316,15 @@ class _QueryIteratorImpl(QueryIterator):
             limit = self._query.limit
             if limit is not None:
                 limit -= len(self._batch)
+
+            offset = self._query.offset
+            if offset:
+                offset -= response.batch.skipped_results
+
             self._query = self._query.copy(
-                start_cursor=Cursor(batch.end_cursor), offset=None, limit=limit
+                start_cursor=Cursor(batch.end_cursor),
+                offset=offset,
+                limit=limit,
             )
 
     def next(self):

--- a/tests/unit/test__datastore_query.py
+++ b/tests/unit/test__datastore_query.py
@@ -393,6 +393,7 @@ class Test_QueryIteratorImpl:
                     entity_result_type=query_pb2.EntityResult.FULL,
                     entity_results=entity_results,
                     end_cursor=b"abc",
+                    skipped_results=5,
                     more_results=query_pb2.QueryResultBatch.NOT_FINISHED,
                 )
             )
@@ -408,7 +409,7 @@ class Test_QueryIteratorImpl:
         assert iterator._batch[0].order_by is None
         assert iterator._has_next_batch
         assert iterator._query.start_cursor.cursor == b"abc"
-        assert iterator._query.offset is None
+        assert iterator._query.offset == 0
         assert iterator._query.limit == 2
 
     @staticmethod


### PR DESCRIPTION
Fixes a bug where we blithely assumed that if we sent
Datastore/Firestore a query with an offset, that the first batch returned
would skip the entire offset. In practice, for high offsets, it's possible
for Datastore/Firestore to return a results batch that is empty and
which has `skipped_results` set to some number less than the value of
`offset` that we sent it. In this case, we still need to send a value
for `offset` when retreiving the next batch. This patch uses
`skipped_results` to compute a new `offset` for the follow up batch.

Fixes #392