### PR TITLE
Fix ineffective keys_only setting for Query.count()

### DIFF
--- a/google/cloud/ndb/query.py
+++ b/google/cloud/ndb/query.py
@@ -2247,7 +2247,7 @@ class Query(object):
         from google.cloud.ndb import _datastore_query
 
         _options = kwargs["_options"]
-        options = _options.copy(keys_only=True)
+        options = _options.copy(projection=['__key__'])
         results = _datastore_query.iterate(options, raw=True)
         count = 0
         limit = options.limit


### PR DESCRIPTION
This is a tentative PR to make sure that counting results of a query does not involve fetching the entire entities. This should improve the "test1" performance in #360 (I did not re-check that but I've made other similar checks.)

The intent of the changed code was already what I want, but `keys_only=True` does not work in this context, because I think the following line does not get invoked:
https://github.com/googleapis/python-ndb/blob/1a054cadff07074de9395cb99ae2c40f987aed2e/google/cloud/ndb/query.py#L1188
You can see the difference before/after this change if you follow the debug-level logs.

Maybe a unit test would be nice, but sorry, I didn't figure out how to do that. Feel free to take over this PR or just start a new one from scratch.
