### PR TITLE
fix: use true `keys_only` query for `Query.count()`

### DIFF
--- a/google/cloud/ndb/query.py
+++ b/google/cloud/ndb/query.py
@@ -2233,7 +2233,7 @@ class Query(object):
         from google.cloud.ndb import _datastore_query
 
         _options = kwargs["_options"]
-        options = _options.copy(keys_only=True)
+        options = _options.copy(projection=["__key__"])
         results = _datastore_query.iterate(options, raw=True)
         count = 0
         limit = options.limit

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -2121,7 +2121,9 @@ class TestQuery:
         query = query_module.Query()
         assert query.count() == 5
         _datastore_query.iterate.assert_called_once_with(
-            query_module.QueryOptions(project="testing", keys_only=True),
+            query_module.QueryOptions(
+                project="testing", projection=["__key__"]
+            ),
             raw=True,
         )
 
@@ -2144,7 +2146,7 @@ class TestQuery:
         assert query.count(3) == 3
         _datastore_query.iterate.assert_called_once_with(
             query_module.QueryOptions(
-                project="testing", keys_only=True, limit=3
+                project="testing", projection=["__key__"], limit=3
             ),
             raw=True,
         )
@@ -2168,7 +2170,9 @@ class TestQuery:
         future = query.count_async()
         assert future.result() == 5
         _datastore_query.iterate.assert_called_once_with(
-            query_module.QueryOptions(project="testing", keys_only=True),
+            query_module.QueryOptions(
+                project="testing", projection=["__key__"]
+            ),
             raw=True,
         )
 


### PR DESCRIPTION
@gaborfeher pointed at that while we were trying to use a `keys_only`
query for `Query.count()` we were failing to actually do so. This is
@gaborfeher's proposed fix from PR #400, fleshed out with unit tests.

Fixes #404.