### PR TITLE
fix: clear context cache on rollback

### DIFF
--- a/google/cloud/ndb/_transaction.py
+++ b/google/cloud/ndb/_transaction.py
@@ -144,6 +144,7 @@ def _transaction_async(context, callback, read_only=False):
 
         # Rollback if there is an error
         except Exception as e:  # noqa: E722
+            tx_context.cache.clear()
             yield _datastore_api.rollback(transaction_id)
             raise e
 


### PR DESCRIPTION
When a transaction fails, clear the local context cache for the
transaction to prevent leaking inconsistent data.

Fixes #398