### PR TITLE
build: integrate changes from autosynth PR

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -23,11 +23,6 @@ sudo apt-get update
 sudo apt-get -y install dictionaries-common aspell aspell-en \
                         hunspell-en-us libenchant1c2a enchant
 
-# Need enchant for spell check
-sudo apt-get update
-sudo apt-get -y install dictionaries-common aspell aspell-en \
-                        hunspell-en-us libenchant1c2a enchant
-
 # Disable buffering, so that the logs stream through.
 export PYTHONUNBUFFERED=1
 

--- a/.kokoro/publish-docs.sh
+++ b/.kokoro/publish-docs.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 set -eo pipefail
 
@@ -6,11 +20,6 @@ set -eo pipefail
 export PYTHONUNBUFFERED=1
 
 cd github/python-ndb
-
-# Need enchant for spell check
-sudo apt-get update
-sudo apt-get -y install dictionaries-common aspell aspell-en \
-                        hunspell-en-us libenchant1c2a enchant
 
 # Need enchant for spell check
 sudo apt-get update

--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 set -eo pipefail
 


### PR DESCRIPTION
This basically just merges the changes from #393, except it does not destroy our redis config. Turns out the spellcheck setup was duplicated, so it's OK to remove it.