### PR TITLE
fix: don't rely on duck typing for `_retry.is_transient_error`

### DIFF
--- a/google/cloud/ndb/_retry.py
+++ b/google/cloud/ndb/_retry.py
@@ -115,9 +115,10 @@ def is_transient_error(error):
     if core_retry.if_transient_error(error):
         return True
 
-    method = getattr(error, "code", None)
-    if method is not None:
-        code = method()
-        return code in TRANSIENT_CODES
+    if isinstance(error, grpc.Call):
+        method = getattr(error, "code", None)
+        if method is not None and callable(method):
+            code = method()
+            return code in TRANSIENT_CODES
 
     return False

--- a/google/cloud/ndb/_retry.py
+++ b/google/cloud/ndb/_retry.py
@@ -117,7 +117,7 @@ def is_transient_error(error):
 
     if isinstance(error, grpc.Call):
         method = getattr(error, "code", None)
-        if method is not None and callable(method):
+        if callable(method):
             code = method()
             return code in TRANSIENT_CODES
 


### PR DESCRIPTION
In `_retry.is_transient_error`, we now check to make sure the exception
is an instance of `grpc.Call` before examining its `code` attribute. We
also make sure `code` is callable before calling it.

Fixes #415