### PR TITLE
fix: uniform handling of `projection` argument

### DIFF
--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -4714,6 +4714,14 @@ class TestModel:
             XModel.query(distinct=True, group_by=("x",))
 
     @staticmethod
+    def test_query_projection_of_unindexed_attribute():
+        class XModel(model.Model):
+            x = model.IntegerProperty(indexed=False)
+
+        with pytest.raises(model.InvalidPropertyError):
+            XModel.query(projection=["x"])
+
+    @staticmethod
     @pytest.mark.usefixtures("in_context")
     def test_gql():
         class Simple(model.Model):

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -1960,6 +1960,20 @@ class TestQuery:
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
+    @mock.patch("google.cloud.ndb._datastore_query")
+    def test_fetch_projection_of_unindexed_property(_datastore_query):
+        class SomeKind(model.Model):
+            foo = model.IntegerProperty(indexed=False)
+
+        future = tasklets.Future("fetch")
+        future.set_result("foo")
+        _datastore_query.fetch.return_value = future
+        query = query_module.Query(kind="SomeKind")
+        with pytest.raises(model.InvalidPropertyError):
+            query.fetch(projection=["foo"])
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
     def test_run_to_queue():
         query = query_module.Query()
         with pytest.raises(NotImplementedError):


### PR DESCRIPTION
The `projection` argument is now handled the same whether it is passed
in to the constructor for `Query` or to one if it's methods, such as
`Query.fetch`.

Fixes #379