### PR TITLE
fix: refactor transactions to use their own event loops

### DIFF
--- a/google/cloud/ndb/_batch.py
+++ b/google/cloud/ndb/_batch.py
@@ -14,8 +14,6 @@
 
 """Support for batching operations."""
 
-from google.cloud.ndb import _eventloop
-
 
 def get_batch(batch_cls, options=None):
     """Gets a data structure for storing batched calls to Datastore Lookup.
@@ -68,5 +66,5 @@ def get_batch(batch_cls, options=None):
         return idle
 
     batches[options_key] = batch = batch_cls(options)
-    _eventloop.add_idle(idler(batch))
+    context.eventloop.add_idle(idler(batch))
     return batch

--- a/google/cloud/ndb/_datastore_api.py
+++ b/google/cloud/ndb/_datastore_api.py
@@ -671,8 +671,8 @@ class _TransactionalCommitBatch(_NonTransactionalCommitBatch):
 
     def idle_callback(self):
         """Call AllocateIds on any incomplete keys in the batch."""
-        # If there are now incomplete mutations, or if we're already preparing
-        # to commit, there's not need to allocate ids.
+        # If there are no incomplete mutations, or if we're already preparing
+        # to commit, there's no need to allocate ids.
         if self.preparing_to_commit or not self.incomplete_mutations:
             return
 

--- a/google/cloud/ndb/_datastore_api.py
+++ b/google/cloud/ndb/_datastore_api.py
@@ -519,6 +519,19 @@ class _NonTransactionalCommitBatch(object):
         rpc.add_done_callback(commit_callback)
 
 
+def prepare_to_commit(transaction):
+    """Signal that we're ready to commit a transaction.
+
+    Currently just used to signal to the commit batch that we're not going to
+    need to call `AllocateIds`, because we're ready to commit now.
+
+    Args:
+        transaction (bytes): The transaction id about to be committed.
+    """
+    batch = _get_commit_batch(transaction, _options.Options())
+    batch.preparing_to_commit = True
+
+
 def commit(transaction, retries=None, timeout=None):
     """Commit a transaction.
 
@@ -605,6 +618,7 @@ class _TransactionalCommitBatch(_NonTransactionalCommitBatch):
         self.allocating_ids = []
         self.incomplete_mutations = []
         self.incomplete_futures = []
+        self.preparing_to_commit = False
 
     def put(self, entity_pb):
         """Add an entity to batch to be stored.
@@ -657,8 +671,9 @@ class _TransactionalCommitBatch(_NonTransactionalCommitBatch):
 
     def idle_callback(self):
         """Call AllocateIds on any incomplete keys in the batch."""
-        if not self.incomplete_mutations:
-            # This will happen if `commit` is called first.
+        # If there are now incomplete mutations, or if we're already preparing
+        # to commit, there's not need to allocate ids.
+        if self.preparing_to_commit or not self.incomplete_mutations:
             return
 
         # Signal to a future commit that there is an id allocation in
@@ -727,11 +742,6 @@ class _TransactionalCommitBatch(_NonTransactionalCommitBatch):
         for future in self.allocating_ids:
             if not future.done():
                 yield future
-
-        # Head off making any more AllocateId calls. Any remaining incomplete
-        # keys will get ids as part of the Commit call.
-        self.incomplete_mutations = []
-        self.incomplete_futures = []
 
         future = tasklets.Future("Commit")
         futures = self.futures

--- a/google/cloud/ndb/_eventloop.py
+++ b/google/cloud/ndb/_eventloop.py
@@ -34,7 +34,6 @@ __all__ = [
     "queue_call",
     "queue_rpc",
     "run",
-    "run0",
     "run1",
 ]
 
@@ -396,13 +395,7 @@ def run():
     loop.run()
 
 
-def run0():
-    """Calls :method:`EventLoop.run0` on current event loop."""
-    loop = get_event_loop()
-    loop.run0()
-
-
 def run1():
     """Calls :method:`EventLoop.run1` on current event loop."""
     loop = get_event_loop()
-    loop.run1()
+    return loop.run1()

--- a/google/cloud/ndb/_transaction.py
+++ b/google/cloud/ndb/_transaction.py
@@ -15,6 +15,7 @@
 import functools
 import logging
 
+from google.cloud.ndb import _eventloop
 from google.cloud.ndb import exceptions
 from google.cloud.ndb import _retry
 from google.cloud.ndb import tasklets
@@ -130,14 +131,35 @@ def _transaction_async(context, callback, read_only=False):
     tx_context = context.new(
         transaction=transaction_id,
         on_commit_callbacks=on_commit_callbacks,
-        cache=None,  # Use new, empty cache for transaction
+        batches=None,
+        commit_batches=None,
+        cache=None,
+        # We could just pass `None` here and let the `Context` constructor
+        # instantiate a new event loop, but our unit tests inject a subclass of
+        # `EventLoop` that makes testing a little easier. This makes sure the
+        # new event loop is of the same type as the current one, to propagate
+        # the event loop class used for testing.
+        eventloop=type(context.eventloop)(),
     )
+
+    # The outer loop is dependent on the inner loop
+    def run_inner_loop(inner_context):
+        with inner_context.use():
+            if inner_context.eventloop.run1():
+                return True  # schedule again
+
+    context.eventloop.add_idle(run_inner_loop, tx_context)
+
     with tx_context.use():
         try:
             # Run the callback
             result = callback()
             if isinstance(result, tasklets.Future):
                 result = yield result
+
+            # Make sure we've run everything we can run before calling commit
+            _datastore_api.prepare_to_commit(transaction_id)
+            _eventloop.run()
 
             # Commit the transaction
             yield _datastore_api.commit(transaction_id, retries=0)

--- a/google/cloud/ndb/_transaction.py
+++ b/google/cloud/ndb/_transaction.py
@@ -15,7 +15,6 @@
 import functools
 import logging
 
-from google.cloud.ndb import _eventloop
 from google.cloud.ndb import exceptions
 from google.cloud.ndb import _retry
 from google.cloud.ndb import tasklets
@@ -159,7 +158,7 @@ def _transaction_async(context, callback, read_only=False):
 
             # Make sure we've run everything we can run before calling commit
             _datastore_api.prepare_to_commit(transaction_id)
-            _eventloop.run()
+            tx_context.eventloop.run()
 
             # Commit the transaction
             yield _datastore_api.commit(transaction_id, retries=0)

--- a/tests/system/__init__.py
+++ b/tests/system/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
+import operator
 import time
 
 KIND = "SomeKind"
@@ -61,3 +63,23 @@ def eventually(f, predicate, timeout=120, interval=2):
         time.sleep(interval)
 
     assert predicate(value)
+
+
+def length_equals(n):
+    """Returns predicate that returns True if passed a sequence of length `n`.
+
+    For use with `eventually`.
+    """
+
+    def predicate(sequence):
+        return len(sequence) == n
+
+    return predicate
+
+
+def equals(n):
+    """Returns predicate that returns True if passed `n`.
+
+    For use with `eventually`.
+    """
+    return functools.partial(operator.eq, n)

--- a/tests/unit/test__datastore_api.py
+++ b/tests/unit/test__datastore_api.py
@@ -848,6 +848,14 @@ class Test_NonTransactionalCommitBatch:
 
 
 @mock.patch("google.cloud.ndb._datastore_api._get_commit_batch")
+def test_prepare_to_commit(get_commit_batch):
+    _api.prepare_to_commit(b"123")
+    get_commit_batch.assert_called_once_with(b"123", _options.Options())
+    batch = get_commit_batch.return_value
+    assert batch.preparing_to_commit is True
+
+
+@mock.patch("google.cloud.ndb._datastore_api._get_commit_batch")
 def test_commit(get_commit_batch):
     _api.commit(b"123")
     get_commit_batch.assert_called_once_with(b"123", _options.Options())

--- a/tests/unit/test__eventloop.py
+++ b/tests/unit/test__eventloop.py
@@ -360,13 +360,6 @@ def test_run(context):
         loop.run.assert_called_once_with()
 
 
-def test_run0(context):
-    loop = mock.Mock(spec=("run", "run0"))
-    with context.new(eventloop=loop).use():
-        _eventloop.run0()
-        loop.run0.assert_called_once_with()
-
-
 def test_run1(context):
     loop = mock.Mock(spec=("run", "run1"))
     with context.new(eventloop=loop).use():

--- a/tests/unit/test__transaction.py
+++ b/tests/unit/test__transaction.py
@@ -192,6 +192,56 @@ class Test_transaction_async:
     @staticmethod
     @pytest.mark.usefixtures("in_context")
     @mock.patch("google.cloud.ndb._datastore_api")
+    def test_run_inner_loop(_datastore_api):
+        begin_futures = [
+            tasklets.Future("begin transaction 1"),
+            tasklets.Future("begin transaction 2"),
+        ]
+        _datastore_api.begin_transaction.side_effect = begin_futures
+
+        commit_futures = [
+            tasklets.Future("commit transaction 1"),
+            tasklets.Future("commit transaction 2"),
+        ]
+        _datastore_api.commit.side_effect = commit_futures
+
+        @tasklets.tasklet
+        def callback():
+            # Scheduling the sleep call here causes control to go back up to
+            # the main loop before this tasklet, running in the transaction
+            # loop, has finished, forcing a call to run_inner_loop via the idle
+            # handler.
+            yield tasklets.sleep(0)
+
+        @tasklets.tasklet
+        def some_tasklet():
+            # This tasklet runs in the main loop. In order to get results back
+            # from the transaction_async calls, the run_inner_loop idle handler
+            # will have to be run.
+            yield [
+                _transaction.transaction_async(callback),
+                _transaction.transaction_async(callback),
+            ]
+
+            # Scheduling this sleep call forces the run_inner_loop idle handler
+            # to be run again so we can run it in the case when there is no
+            # more work to be done in the transaction. (Branch coverage.)
+            yield tasklets.sleep(0)
+
+            return "I tried, momma."
+
+        future = some_tasklet()
+
+        begin_futures[0].set_result(b"tx123")
+        begin_futures[1].set_result(b"tx234")
+        commit_futures[0].set_result(None)
+        commit_futures[1].set_result(None)
+
+        assert future.result() == "I tried, momma."
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    @mock.patch("google.cloud.ndb._datastore_api")
     def test_error(_datastore_api):
         error = Exception("Spurious error.")
 

--- a/tests/unit/test__transaction.py
+++ b/tests/unit/test__transaction.py
@@ -228,7 +228,7 @@ class Test_transaction_async:
             # more work to be done in the transaction. (Branch coverage.)
             yield tasklets.sleep(0)
 
-            return "I tried, momma."
+            raise tasklets.Return("I tried, momma.")
 
         future = some_tasklet()
 


### PR DESCRIPTION
Referring to issue #426, the problem ultimately turned out to be that
we could fall out of the transaction scope and trigger a commit while
there is still work left queued on the event loop, including, in this
case, the tasklet that would eventually schedule the call to delete,
causing the delete to never actually happen.

The fix is to go ahead and consume the event loop queues before
scheduling the call to COMMIT. However, if there are other tasks
happening in parallel, this can really mess with the natural sequence of
events in ways that can cause things to blow up. (All of the
`parallel_transaction` tests in `tests/system/test_misc.py` for
instance, will fail.) The fix for that is to give each transaction its
own event loop, so that when it calls `_eventloop.run` prior to commit,
it is only flushing tasks that pertain to it.

Fixes #426