### PR TITLE
fix: strip `order_by` option from query when using `count()`

### DIFF
--- a/google/cloud/ndb/query.py
+++ b/google/cloud/ndb/query.py
@@ -2197,7 +2197,7 @@ class Query(object):
         from google.cloud.ndb import _datastore_query
 
         _options = kwargs["_options"]
-        options = _options.copy(projection=["__key__"])
+        options = _options.copy(projection=["__key__"], order_by=None)
         results = _datastore_query.iterate(options, raw=True)
         count = 0
         limit = options.limit

--- a/tests/system/test_query.py
+++ b/tests/system/test_query.py
@@ -600,6 +600,25 @@ def test_count_with_filter(ds_entity):
 
 
 @pytest.mark.usefixtures("client_context")
+def test_count_with_order_by_and_multiquery(ds_entity):
+    """Regression test for #447
+
+    https://github.com/googleapis/python-ndb/issues/447
+    """
+    for i in range(5):
+        entity_id = test_utils.system.unique_resource_id()
+        ds_entity(KIND, entity_id, foo=i)
+
+    class SomeKind(ndb.Model):
+        foo = ndb.IntegerProperty()
+
+    query = SomeKind.query(order_by=[SomeKind.foo]).filter(
+        ndb.OR(SomeKind.foo < 100, SomeKind.foo > -1)
+    )
+    eventually(query.count, equals(5))
+
+
+@pytest.mark.usefixtures("client_context")
 def test_count_with_multi_query(ds_entity):
     for i in range(5):
         entity_id = test_utils.system.unique_resource_id()


### PR DESCRIPTION
A fairly standard use case is to precompose a query and then call
methods like `fetch` or `count` as needed. In this case you might call
`count()` on a query with an `order_by` option. Previously, if the query
was also a multiquery, this could cause an error as we'd be trying to
sort on the client side using data that wasn't there, because we'd
converted the query to `keys_only` for purposes of getting a count.

This fixes that problem by stripping `order_by` from the query options
when `count()` is called.

Fixes #447