### PR TITLE
fix: respect `_code_name` in `StructuredProperty.__getattr__`

### DIFF
--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -3990,17 +3990,29 @@ class StructuredProperty(Property):
         """Dynamically get a subproperty."""
         # Optimistically try to use the dict key.
         prop = self._model_class._properties.get(attrname)
+
+        # We're done if we have a hit and _code_name matches.
+        if prop is None or prop._code_name != attrname:
+            # Otherwise, use linear search looking for a matching _code_name.
+            for candidate in self._model_class._properties.values():
+                if candidate._code_name == attrname:
+                    prop = candidate
+                    break
+
         if prop is None:
             raise AttributeError(
                 "Model subclass %s has no attribute %s"
                 % (self._model_class.__name__, attrname)
             )
+
         prop_copy = copy.copy(prop)
         prop_copy._name = self._name + "." + prop_copy._name
+
         # Cache the outcome, so subsequent requests for the same attribute
         # name will get the copied property directly rather than going
         # through the above motions all over again.
         setattr(self, attrname, prop_copy)
+
         return prop_copy
 
     def _comparison(self, op, value):

--- a/tests/system/test_query.py
+++ b/tests/system/test_query.py
@@ -970,6 +970,29 @@ def test_query_structured_property_with_projection(dispose_of):
 
 
 @pytest.mark.usefixtures("client_context")
+def test_query_structured_property_rename_subproperty(dispose_of):
+    """Regression test for #449
+
+    https://github.com/googleapis/python-ndb/issues/449
+    """
+    class OtherKind(ndb.Model):
+        one = ndb.StringProperty("a_different_name")
+
+    class SomeKind(ndb.Model):
+        bar = ndb.StructuredProperty(OtherKind)
+
+    key = SomeKind(bar=OtherKind(one="pish")).put()
+    dispose_of(key._key)
+
+    eventually(SomeKind.query().fetch, length_equals(1))
+
+    query = SomeKind.query().filter(SomeKind.bar.one == "pish")
+    results = query.fetch()
+    assert len(results) == 1
+    assert results[0].bar.one == "pish"
+
+
+@pytest.mark.usefixtures("client_context")
 def test_query_repeated_structured_property_with_properties(dispose_of):
     class OtherKind(ndb.Model):
         one = ndb.StringProperty()

--- a/tests/system/test_query.py
+++ b/tests/system/test_query.py
@@ -975,6 +975,7 @@ def test_query_structured_property_rename_subproperty(dispose_of):
 
     https://github.com/googleapis/python-ndb/issues/449
     """
+
     class OtherKind(ndb.Model):
         one = ndb.StringProperty("a_different_name")
 

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -3059,6 +3059,16 @@ class TestStructuredProperty:
         assert prop.foo._name == "bar.foo"
 
     @staticmethod
+    def test___getattr__use_codename():
+        class Mine(model.Model):
+            foo = model.StringProperty("notfoo")
+
+        prop = model.StructuredProperty(Mine)
+        prop._name = "bar"
+        assert isinstance(prop.foo, model.StringProperty)
+        assert prop.foo._name == "bar.notfoo"
+
+    @staticmethod
     def test___getattr___bad_prop():
         class Mine(model.Model):
             foo = model.StringProperty()


### PR DESCRIPTION
Restores a linear search for subproperty by Python name if different
from datastore name, when getting subproperties in
`StructuredProperty.__getattr__`. This bit of code just got overlooked when
porting from legacy.

Fixes #449