### PR TITLE
fix: all query types should use cache if available

### DIFF
--- a/google/cloud/ndb/context.py
+++ b/google/cloud/ndb/context.py
@@ -279,9 +279,9 @@ class _Context(_ContextTuple):
         if keys:
             yield [_cache.global_delete(key) for key in keys]
 
-    def _use_cache(self, key, options):
+    def _use_cache(self, key, options=None):
         """Return whether to use the context cache for this key."""
-        flag = options.use_cache
+        flag = options.use_cache if options else None
         if flag is None:
             flag = self.cache_policy(key)
         if flag is None:
@@ -300,7 +300,7 @@ class _Context(_ContextTuple):
             flag = True
         return flag
 
-    def _global_cache_timeout(self, key, options):
+    def _global_cache_timeout(self, key, options=None):
         """Return  global cache timeout (expiration) for this key."""
         timeout = None
         if options:

--- a/google/cloud/ndb/context.py
+++ b/google/cloud/ndb/context.py
@@ -300,7 +300,7 @@ class _Context(_ContextTuple):
             flag = True
         return flag
 
-    def _global_cache_timeout(self, key, options=None):
+    def _global_cache_timeout(self, key, options):
         """Return  global cache timeout (expiration) for this key."""
         timeout = None
         if options:

--- a/tests/system/test_crud.py
+++ b/tests/system/test_crud.py
@@ -1429,3 +1429,32 @@ def test_custom_validator(dispose_of, ds_client):
 
     retrieved = key.get()
     assert retrieved.foo == datetime.datetime(2020, 8, 8, 1, 2, 3)
+
+
+@pytest.mark.usefixtures("client_context")
+def test_cache_returns_entity_if_available(dispose_of, client_context):
+    """Regression test for #441
+
+    https://github.com/googleapis/python-ndb/issues/441
+    """
+
+    class SomeKind(ndb.Model):
+        foo = ndb.IntegerProperty()
+        bar = ndb.StringProperty()
+
+    class OtherKind:
+        def __init__(self, somekind):
+            self.somekind = somekind
+
+    client_context.set_cache_policy(None)  # Use default
+
+    somekind = SomeKind(foo=1)
+    key = somekind.put()
+    dispose_of(key._key)
+    otherkind = OtherKind(somekind)
+
+    query = ndb.Query(kind="SomeKind")
+    ourkind = [x for x in query.fetch() if x.key == key][0]
+    ourkind.bar = "confusing"
+
+    assert otherkind.somekind.bar == "confusing"


### PR DESCRIPTION
We were returning cache values in some cases and not others, generating some confusion.

Refs #441