### PR TITLE
feat: record time spent waiting on rpc calls

### DIFF
--- a/google/cloud/ndb/__init__.py
+++ b/google/cloud/ndb/__init__.py
@@ -30,6 +30,7 @@ from google.cloud.ndb.context import AutoBatcher
 from google.cloud.ndb.context import Context
 from google.cloud.ndb.context import ContextOptions
 from google.cloud.ndb.context import get_context
+from google.cloud.ndb.context import get_toplevel_context
 from google.cloud.ndb.context import TransactionOptions
 from google.cloud.ndb._datastore_api import EVENTUAL
 from google.cloud.ndb._datastore_api import EVENTUAL_CONSISTENCY
@@ -218,6 +219,7 @@ __all__ = [
     "add_flow_exception",
     "Future",
     "get_context",
+    "get_toplevel_context",
     "make_context",
     "make_default_context",
     "QueueFuture",

--- a/google/cloud/ndb/_datastore_api.py
+++ b/google/cloud/ndb/_datastore_api.py
@@ -82,6 +82,8 @@ def make_call(rpc_name, request, retries=None, timeout=None):
 
     @tasklets.tasklet
     def rpc_call():
+        context = context_module.get_toplevel_context()
+
         call = method.future(request, timeout=timeout)
         rpc = _remote.RemoteCall(call, "{}({})".format(rpc_name, request))
         log.debug(rpc)
@@ -93,6 +95,8 @@ def make_call(rpc_name, request, retries=None, timeout=None):
             if isinstance(error, grpc.Call):
                 error = core_exceptions.from_grpc_error(error)
             raise error
+        finally:
+            context.rpc_time += rpc.elapsed_time
 
         raise tasklets.Return(result)
 

--- a/google/cloud/ndb/_remote.py
+++ b/google/cloud/ndb/_remote.py
@@ -17,6 +17,7 @@
 # In its own module to avoid circular import between _datastore_api and
 # tasklets modules.
 import grpc
+import time
 
 from google.cloud.ndb import exceptions
 
@@ -39,6 +40,13 @@ class RemoteCall(object):
     def __init__(self, future, info):
         self.future = future
         self.info = info
+        self.start_time = time.time()
+        self.elapsed_time = 0
+
+        def record_time(future):
+            self.elapsed_time = time.time() - self.start_time
+
+        future.add_done_callback(record_time)
 
     def __repr__(self):
         return self.info

--- a/tests/unit/test__eventloop.py
+++ b/tests/unit/test__eventloop.py
@@ -22,14 +22,8 @@ except ImportError:  # pragma: NO PY3 COVER
 import grpc
 import pytest
 
-from . import utils
-
 from google.cloud.ndb import exceptions
 from google.cloud.ndb import _eventloop
-
-
-def test___all__():
-    utils.verify___all__(_eventloop)
 
 
 def _Event(when=0, what="foo", args=(), kw={}):
@@ -258,6 +252,7 @@ class TestEventLoop:
         assert len(loop.queue) == 1
         assert loop.inactive == 0
 
+    @pytest.mark.usefixtures("in_context")
     def test_run0_rpc(self):
         rpc = mock.Mock(spec=grpc.Future)
         callback = mock.Mock(spec=())

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -28,11 +28,36 @@ from google.cloud.ndb import key as key_module
 from google.cloud.ndb import model
 from google.cloud.ndb import _options
 
-from . import utils
+
+class Test_get_context:
+    @staticmethod
+    def test_in_context(in_context):
+        assert context_module.get_context() is in_context
+
+    @staticmethod
+    def test_no_context_raise():
+        with pytest.raises(exceptions.ContextError):
+            context_module.get_context()
+
+    @staticmethod
+    def test_no_context_dont_raise():
+        assert context_module.get_context(False) is None
 
 
-def test___all__():
-    utils.verify___all__(context_module)
+class Test_get_toplevel_context:
+    @staticmethod
+    def test_in_context(in_context):
+        with in_context.new().use():
+            assert context_module.get_toplevel_context() is in_context
+
+    @staticmethod
+    def test_no_context_raise():
+        with pytest.raises(exceptions.ContextError):
+            context_module.get_toplevel_context()
+
+    @staticmethod
+    def test_no_context_dont_raise():
+        assert context_module.get_toplevel_context(False) is None
 
 
 class TestContext:


### PR DESCRIPTION
Two new attributes have been added to the top level context object,
which can be used in looking at performance of underlying Datastore
calls. `rpc_time` records the total amount of time all rpc calls made
in that context have taken. `wait_time` records the total amount of time
spent waiting (blocking) for rpc calls to complete. Because of
parallelism, `wait_time` should be less than `rpc_time`, although in
practice they're almost always quite close.