### PR TITLE
fix: include ancestors in `Key.to_legacy_urlsafe`

### DIFF
--- a/google/cloud/ndb/key.py
+++ b/google/cloud/ndb/key.py
@@ -759,10 +759,8 @@ class Key(object):
             b'aglzfmV4YW1wbGVyCwsSBEtpbmQYuQoM'
         """
         return google.cloud.datastore.Key(
-            self._key.kind,
-            self._key.id or self._key.name,
-            namespace=self._key.namespace,
-            project=self._key.project,
+            *self.flat(),
+            **{"namespace": self._key.namespace, "project": self._key.project}
         ).to_legacy_urlsafe(location_prefix=location_prefix)
 
     @_options.ReadOptions.options

--- a/tests/unit/test_key.py
+++ b/tests/unit/test_key.py
@@ -588,6 +588,18 @@ class TestKey:
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
+    def test_to_legacy_urlsafe_w_ancestor():
+        """Regression test for #478.
+
+        https://github.com/googleapis/python-ndb/issues/478
+        """
+        key = key_module.Key("d", 123, "e", 234, app="f")
+        urlsafe = key.to_legacy_urlsafe(location_prefix="s~")
+        key2 = key_module.Key(urlsafe=urlsafe)
+        assert key == key2
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
     @mock.patch("google.cloud.ndb._datastore_api")
     @mock.patch("google.cloud.ndb.model._entity_from_protobuf")
     def test_get_with_cache_miss(_entity_from_protobuf, _datastore_api):


### PR DESCRIPTION
Fixes #478.