### PR TITLE
perf: improve context cache performance

### DIFF
--- a/google/cloud/ndb/_cache.py
+++ b/google/cloud/ndb/_cache.py
@@ -18,19 +18,12 @@ from google.cloud.ndb import _batch
 from google.cloud.ndb import context as context_module
 from google.cloud.ndb import tasklets
 
-# For Python 2.7 Compatibility
-try:
-    from collections import UserDict
-except ImportError:  # pragma: NO PY3 COVER
-    from UserDict import UserDict
-
-
 _LOCKED = b"0"
 _LOCK_TIME = 32
 _PREFIX = b"NDB30"
 
 
-class ContextCache(UserDict):
+class ContextCache(dict):
     """A per-context in-memory entity cache.
 
     This cache verifies the fetched entity has the correct key before
@@ -42,11 +35,11 @@ class ContextCache(UserDict):
         """Verify that the entity's key has not changed since it was added
            to the cache. If it has changed, consider this a cache miss.
            See issue 13.  http://goo.gl/jxjOP"""
-        entity = self.data[key]  # May be None, meaning "doesn't exist".
+        entity = self[key]  # May be None, meaning "doesn't exist".
         if entity is None or entity._key == key:
             return entity
         else:
-            del self.data[key]
+            del self[key]
             raise KeyError(key)
 
     def __repr__(self):

--- a/google/cloud/ndb/key.py
+++ b/google/cloud/ndb/key.py
@@ -281,6 +281,8 @@ class Key(object):
             arguments were given with the path.
     """
 
+    _hash_value = None
+
     def __new__(cls, *path_args, **kwargs):
         # Avoid circular import in Python 2.7
         from google.cloud.ndb import context as context_module
@@ -375,7 +377,10 @@ class Key(object):
             values. The primary concern is that hashes of equal keys are
             equal, not the other way around.
         """
-        return hash(self.pairs())
+        hash_value = self._hash_value
+        if hash_value is None:
+            self._hash_value = hash_value = hash(self.pairs())
+        return hash_value
 
     def _tuple(self):
         """Helper to return an orderable tuple."""

--- a/tests/unit/test__datastore_query.py
+++ b/tests/unit/test__datastore_query.py
@@ -1105,7 +1105,7 @@ class Test_Result:
         entity = mock.Mock(key=key_pb)
         cached_entity = mock.Mock(key=key_pb, _key=key)
         context = context_module.get_context()
-        context.cache.data[key] = cached_entity
+        context.cache[key] = cached_entity
         model._entity_from_protobuf.return_value = entity
         result = _datastore_query._Result(
             _datastore_query.RESULT_TYPE_FULL,


### PR DESCRIPTION
`Key.__hash__` is relatively expensive to compute, so the computed hash
is now stored on the `Key` instance on the first call to `Key.__hash__`.

`context.ContextCache` has been made a subclass of `dict` rather than
`UserDict`, resulting in *much* better performance.