### PR TITLE
perf: suppress debug logging in normal operation

### DIFF
--- a/google/cloud/ndb/_datastore_api.py
+++ b/google/cloud/ndb/_datastore_api.py
@@ -31,6 +31,7 @@ from google.cloud.ndb import _options
 from google.cloud.ndb import _remote
 from google.cloud.ndb import _retry
 from google.cloud.ndb import tasklets
+from google.cloud.ndb import utils
 
 EVENTUAL = datastore_pb2.ReadOptions.EVENTUAL
 EVENTUAL_CONSISTENCY = EVENTUAL  # Legacy NDB
@@ -85,9 +86,9 @@ def make_call(rpc_name, request, retries=None, timeout=None):
         context = context_module.get_toplevel_context()
 
         call = method.future(request, timeout=timeout)
-        rpc = _remote.RemoteCall(call, "{}({})".format(rpc_name, request))
-        log.debug(rpc)
-        log.debug("timeout={}".format(timeout))
+        rpc = _remote.RemoteCall(call, rpc_name)
+        utils.logging_debug(log, rpc)
+        utils.logging_debug(log, "timeout={}", timeout)
 
         try:
             result = yield rpc
@@ -248,7 +249,7 @@ class _LookupBatch(object):
 
         # Process results, which are divided into found, missing, and deferred
         results = rpc.result()
-        log.debug(results)
+        utils.logging_debug(log, results)
 
         # For all deferred keys, batch them up again with their original
         # futures
@@ -805,7 +806,7 @@ def _process_commit(rpc, futures):
     #
     # https://github.com/googleapis/googleapis/blob/master/google/datastore/v1/datastore.proto#L241
     response = rpc.result()
-    log.debug(response)
+    utils.logging_debug(log, response)
 
     results_futures = zip(response.mutation_results, futures)
     for mutation_result, future in results_futures:

--- a/google/cloud/ndb/_datastore_query.py
+++ b/google/cloud/ndb/_datastore_query.py
@@ -30,6 +30,7 @@ from google.cloud.ndb import exceptions
 from google.cloud.ndb import key as key_module
 from google.cloud.ndb import model
 from google.cloud.ndb import tasklets
+from google.cloud.ndb import utils
 
 log = logging.getLogger(__name__)
 
@@ -877,7 +878,7 @@ def _datastore_run_query(query):
     response = yield _datastore_api.make_call(
         "RunQuery", request, timeout=query.timeout
     )
-    log.debug(response)
+    utils.logging_debug(log, response)
     raise tasklets.Return(response)
 
 

--- a/google/cloud/ndb/_eventloop.py
+++ b/google/cloud/ndb/_eventloop.py
@@ -27,6 +27,7 @@ try:
 except ImportError:  # pragma: NO PY3 COVER
     import Queue as queue
 
+from google.cloud.ndb import utils
 
 log = logging.getLogger(__name__)
 
@@ -135,21 +136,21 @@ class EventLoop(object):
             idlers = self.idlers
             queue = self.queue
             rpcs = self.rpcs
-            log.debug("Clearing stale EventLoop instance...")
+            utils.logging_debug(log, "Clearing stale EventLoop instance...")
             if current:
-                log.debug("  current = %s", current)
+                utils.logging_debug(log, "  current = {}", current)
             if idlers:
-                log.debug("  idlers = %s", idlers)
+                utils.logging_debug(log, "  idlers = {}", idlers)
             if queue:
-                log.debug("  queue = %s", queue)
+                utils.logging_debug(log, "  queue = {}", queue)
             if rpcs:
-                log.debug("  rpcs = %s", rpcs)
+                utils.logging_debug(log, "  rpcs = {}", rpcs)
             self.__init__()
             current.clear()
             idlers.clear()
             queue[:] = []
             rpcs.clear()
-            log.debug("Cleared")
+            utils.logging_debug(log, "Cleared")
 
     def insort_event_right(self, event):
         """Insert event in queue with sorting.
@@ -253,12 +254,12 @@ class EventLoop(object):
             return False
         idler = self.idlers.popleft()
         callback, args, kwargs = idler
-        log.debug("idler: %s", callback.__name__)
+        utils.logging_debug(log, "idler: {}", callback.__name__)
         result = callback(*args, **kwargs)
 
         # See add_idle() for meaning of callback return value.
         if result is None:
-            log.debug("idler %s removed", callback.__name__)
+            utils.logging_debug(log, "idler {} removed", callback.__name__)
         else:
             if result:
                 self.inactive = 0
@@ -297,7 +298,7 @@ class EventLoop(object):
             if delay <= 0:
                 self.inactive = 0
                 _, callback, args, kwargs = self.queue.pop(0)
-                log.debug("event: %s", callback.__name__)
+                utils.logging_debug(log, "event: {}", callback.__name__)
                 callback(*args, **kwargs)
                 return 0
 
@@ -313,7 +314,9 @@ class EventLoop(object):
             start_time = time.time()
             rpc_id, rpc = self.rpc_results.get()
             elapsed = time.time() - start_time
-            log.debug("Blocked for {}s awaiting RPC results.".format(elapsed))
+            utils.logging_debug(
+                log, "Blocked for {}s awaiting RPC results.", elapsed
+            )
             context.wait_time += elapsed
 
             callback = self.rpcs.pop(rpc_id)

--- a/google/cloud/ndb/_transaction.py
+++ b/google/cloud/ndb/_transaction.py
@@ -18,6 +18,7 @@ import logging
 from google.cloud.ndb import exceptions
 from google.cloud.ndb import _retry
 from google.cloud.ndb import tasklets
+from google.cloud.ndb import utils
 
 log = logging.getLogger(__name__)
 
@@ -120,11 +121,11 @@ def _transaction_async(context, callback, read_only=False):
     from google.cloud.ndb import _datastore_api
 
     # Start the transaction
-    log.debug("Start transaction")
+    utils.logging_debug(log, "Start transaction")
     transaction_id = yield _datastore_api.begin_transaction(
         read_only, retries=0
     )
-    log.debug("Transaction Id: {}".format(transaction_id))
+    utils.logging_debug(log, "Transaction Id: {}", transaction_id)
 
     on_commit_callbacks = []
     tx_context = context.new(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -14,22 +14,40 @@
 
 import threading
 
+try:
+    from unittest import mock
+except ImportError:  # pragma: NO PY3 COVER
+    import mock
+
 import pytest
 
 from google.cloud.ndb import utils
 
 
-def test___all__():
-    assert utils.__all__ == []
+class Test_asbool:
+    @staticmethod
+    def test_None():
+        assert utils.asbool(None) is False
+
+    @staticmethod
+    def test_bool():
+        assert utils.asbool(True) is True
+        assert utils.asbool(False) is False
+
+    @staticmethod
+    def test_truthy_int():
+        assert utils.asbool(0) is False
+        assert utils.asbool(1) is True
+
+    @staticmethod
+    def test_truthy_string():
+        assert utils.asbool("Y") is True
+        assert utils.asbool("f") is False
 
 
 def test_code_info():
     with pytest.raises(NotImplementedError):
         utils.code_info()
-
-
-def test_DEBUG():
-    assert utils.DEBUG is True
 
 
 def test_decorator():
@@ -57,9 +75,24 @@ def test_get_stack():
         utils.get_stack()
 
 
-def test_logging_debug():
-    with pytest.raises(NotImplementedError):
-        utils.logging_debug()
+class Test_logging_debug:
+    @staticmethod
+    @mock.patch("google.cloud.ndb.utils.DEBUG", False)
+    def test_noop():
+        log = mock.Mock(spec=("debug",))
+        utils.logging_debug(
+            log, "hello dad! {} {where}", "I'm", where="in jail"
+        )
+        log.debug.assert_not_called()
+
+    @staticmethod
+    @mock.patch("google.cloud.ndb.utils.DEBUG", True)
+    def test_log_it():
+        log = mock.Mock(spec=("debug",))
+        utils.logging_debug(
+            log, "hello dad! {} {where}", "I'm", where="in jail"
+        )
+        log.debug.assert_called_once_with("hello dad! I'm in jail")
 
 
 def test_positional():


### PR DESCRIPTION
In order to enable debug logging, users must now set an environment
variable, `NDB_DEBUG`, to a "truthy" value (True, t, Yes, 1, etc...).
This mostly prevents gRPC protocol buffers from getting rendered as
strings unnecessarily, which has a significant impact on performance.