### PR TITLE
fix: fix format exceptions in `utils.logging_debug`

### DIFF
--- a/google/cloud/ndb/utils.py
+++ b/google/cloud/ndb/utils.py
@@ -84,7 +84,10 @@ def logging_debug(log, message, *args, **kwargs):
     **kwargs)`, otherwise this is a no-op.
     """
     if DEBUG:
-        log.debug(str(message).format(*args, **kwargs))
+        message = str(message)
+        if args or kwargs:
+            message = message.format(*args, **kwargs)
+        log.debug(message)
 
 
 class keyword_only(object):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ from google.cloud.ndb import context as context_module
 from google.cloud.ndb import _eventloop
 from google.cloud.ndb import global_cache as global_cache_module
 from google.cloud.ndb import model
+from google.cloud.ndb import utils
 
 import pytest
 
@@ -33,6 +34,8 @@ try:
     from unittest import mock
 except ImportError:
     import mock
+
+utils.DEBUG = True
 
 
 class TestingEventLoop(_eventloop.EventLoop):


### PR DESCRIPTION
Changes introduced in #508 caused debug logging to break. The bug is
fixed and debug logging is now turned on during testing, so we can catch
regressions.