### PR TITLE
perf: improve count query performance for simple queries

### DIFF
--- a/google/cloud/ndb/query.py
+++ b/google/cloud/ndb/query.py
@@ -2172,7 +2172,6 @@ class Query(object):
         """
         return self.count_async(_options=kwargs["_options"]).result()
 
-    @tasklets.tasklet
     @_query_options
     @utils.keyword_only(
         offset=None,
@@ -2201,19 +2200,7 @@ class Query(object):
         # Avoid circular import in Python 2.7
         from google.cloud.ndb import _datastore_query
 
-        _options = kwargs["_options"]
-        options = _options.copy(projection=["__key__"], order_by=None)
-        results = _datastore_query.iterate(options, raw=True)
-        count = 0
-        limit = options.limit
-        while (yield results.has_next_async()):
-            count += 1
-            if limit and count == limit:
-                break
-
-            results.next()
-
-        raise tasklets.Return(count)
+        return _datastore_query.count(kwargs["_options"])
 
     @_query_options
     @utils.keyword_only(


### PR DESCRIPTION
For simple queries (queries that map directly to single Datastore
queries, ie not multiqueries, or queries with post filters),
`Query.count` can be otimized by setting a high offset and counting the
number of entities skipped.

Note that this still requires Datastore to assemble and iterate over a
result set and Datastore will still only "skip" a certain number of
entities at a time. (1000 at the time of this writing.) So this doesn't
dramatically impact the amount of work that has to be done on the
Datastore side, nor does it reduce the number gRPC calls necessary to
count a large result set. It does reduce significantly, however, the amount of
I/O required, which has sped up some large counts in testing by a factor
of around 4x.