### PR TITLE
style: upgrade black to latest version, use black default line length

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[flake8]
+ignore = E203, E266, E501, W503

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -158,9 +158,7 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
-latex_documents = [
-    (master_doc, "ndb.tex", "ndb Documentation", "Google LLC", "manual")
-]
+latex_documents = [(master_doc, "ndb.tex", "ndb Documentation", "Google LLC", "manual")]
 
 
 # -- Options for manual page output ------------------------------------------

--- a/google/cloud/ndb/_batch.py
+++ b/google/cloud/ndb/_batch.py
@@ -43,11 +43,7 @@ def get_batch(batch_cls, options=None):
     if options is not None:
         options_key = tuple(
             sorted(
-                (
-                    (key, value)
-                    for key, value in options.items()
-                    if value is not None
-                )
+                ((key, value) for key, value in options.items() if value is not None)
             )
         )
     else:

--- a/google/cloud/ndb/_cache.py
+++ b/google/cloud/ndb/_cache.py
@@ -33,8 +33,8 @@ class ContextCache(dict):
 
     def get_and_validate(self, key):
         """Verify that the entity's key has not changed since it was added
-           to the cache. If it has changed, consider this a cache miss.
-           See issue 13.  http://goo.gl/jxjOP"""
+        to the cache. If it has changed, consider this a cache miss.
+        See issue 13.  http://goo.gl/jxjOP"""
         entity = self[key]  # May be None, meaning "doesn't exist".
         if entity is None or entity._key == key:
             return entity
@@ -58,8 +58,7 @@ def _future_result(result):
 
 
 class _GlobalCacheBatch(object):
-    """Abstract base for classes used to batch operations for the global cache.
-    """
+    """Abstract base for classes used to batch operations for the global cache."""
 
     def full(self):
         """Indicates whether more work can be added to this batch.

--- a/google/cloud/ndb/_datastore_api.py
+++ b/google/cloud/ndb/_datastore_api.py
@@ -132,9 +132,7 @@ def lookup(key, options):
         use_global_cache = context._use_global_cache(key, options)
 
     if not (use_global_cache or use_datastore):
-        raise TypeError(
-            "use_global_cache and use_datastore can't both be False"
-        )
+        raise TypeError("use_global_cache and use_datastore can't both be False")
 
     entity_pb = _NOT_FOUND
     key_locked = False
@@ -160,9 +158,7 @@ def lookup(key, options):
         if use_global_cache and not key_locked and entity_pb is not _NOT_FOUND:
             expires = context._global_cache_timeout(key, options)
             serialized = entity_pb.SerializeToString()
-            yield _cache.global_compare_and_swap(
-                cache_key, serialized, expires=expires
-            )
+            yield _cache.global_compare_and_swap(cache_key, serialized, expires=expires)
 
     raise tasklets.Return(entity_pb)
 
@@ -257,9 +253,7 @@ class _LookupBatch(object):
             next_batch = _batch.get_batch(type(self), self.options)
             for key in results.deferred:
                 todo_key = key.SerializeToString()
-                next_batch.todo.setdefault(todo_key, []).extend(
-                    self.todo[todo_key]
-                )
+                next_batch.todo.setdefault(todo_key, []).extend(self.todo[todo_key])
 
         # For all missing keys, set result to _NOT_FOUND and let callers decide
         # how to handle
@@ -331,9 +325,7 @@ def get_read_options(options, default_read_consistency=None):
             read_consistency = default_read_consistency
 
     elif read_consistency is EVENTUAL:
-        raise ValueError(
-            "read_consistency must not be EVENTUAL when in transaction"
-        )
+        raise ValueError("read_consistency must not be EVENTUAL when in transaction")
 
     return datastore_pb2.ReadOptions(
         read_consistency=read_consistency, transaction=transaction
@@ -380,9 +372,7 @@ def put(entity, options):
     use_global_cache = context._use_global_cache(entity.key, options)
     use_datastore = context._use_datastore(entity.key, options)
     if not (use_global_cache or use_datastore):
-        raise TypeError(
-            "use_global_cache and use_datastore can't both be False"
-        )
+        raise TypeError("use_global_cache and use_datastore can't both be False")
 
     if not use_datastore and entity.key.is_partial:
         raise TypeError("Can't store partial keys when use_datastore is False")
@@ -990,9 +980,7 @@ def _datastore_allocate_ids(keys, retries=None, timeout=None):
             :class:`google.cloud.datastore_v1.datastore_pb2.AllocateIdsResponse`
     """
     client = context_module.get_context().client
-    request = datastore_pb2.AllocateIdsRequest(
-        project_id=client.project, keys=keys
-    )
+    request = datastore_pb2.AllocateIdsRequest(project_id=client.project, keys=keys)
 
     return make_call("AllocateIds", request, retries=retries, timeout=timeout)
 
@@ -1050,9 +1038,7 @@ def _datastore_begin_transaction(read_only, retries=None, timeout=None):
         project_id=client.project, transaction_options=options
     )
 
-    return make_call(
-        "BeginTransaction", request, retries=retries, timeout=timeout
-    )
+    return make_call("BeginTransaction", request, retries=retries, timeout=timeout)
 
 
 @tasklets.tasklet

--- a/google/cloud/ndb/_datastore_query.py
+++ b/google/cloud/ndb/_datastore_query.py
@@ -311,9 +311,7 @@ class _QueryIteratorImpl(QueryIterator):
             batch.more_results == MORE_RESULTS_TYPE_NOT_FINISHED
         )
 
-        self._more_results_after_limit = (
-            batch.more_results == MORE_RESULTS_AFTER_LIMIT
-        )
+        self._more_results_after_limit = batch.more_results == MORE_RESULTS_AFTER_LIMIT
 
         if more_results:
             # Fix up query for next batch
@@ -538,9 +536,7 @@ class _MultiQueryIteratorImpl(QueryIterator):
                 self._extra_projections = extra_projections
 
         queries = [
-            query.copy(
-                filters=node, projection=projection, offset=None, limit=None
-            )
+            query.copy(filters=node, projection=projection, offset=None, limit=None)
             for node in query.filters._nodes
         ]
         self._result_sets = [iterate(_query, raw=True) for _query in queries]
@@ -625,10 +621,7 @@ class _MultiQueryIteratorImpl(QueryIterator):
     def probably_has_next(self):
         """Implements :meth:`QueryIterator.probably_has_next`."""
         return bool(self._next_result) or any(
-            [
-                result_set.probably_has_next()
-                for result_set in self._result_sets
-            ]
+            [result_set.probably_has_next() for result_set in self._result_sets]
         )
 
     def next(self):
@@ -774,9 +767,7 @@ class _Result(object):
             key = key_module.Key._from_ds_key(ds_key)
             return key
 
-        raise NotImplementedError(
-            "Got unexpected entity result type for query."
-        )
+        raise NotImplementedError("Got unexpected entity result type for query.")
 
 
 def _query_to_protobuf(query):
@@ -794,16 +785,13 @@ def _query_to_protobuf(query):
 
     if query.projection:
         query_args["projection"] = [
-            query_pb2.Projection(
-                property=query_pb2.PropertyReference(name=name)
-            )
+            query_pb2.Projection(property=query_pb2.PropertyReference(name=name))
             for name in query.projection
         ]
 
     if query.distinct_on:
         query_args["distinct_on"] = [
-            query_pb2.PropertyReference(name=name)
-            for name in query.distinct_on
+            query_pb2.PropertyReference(name=name) for name in query.distinct_on
         ]
 
     if query.order_by:

--- a/google/cloud/ndb/_datastore_types.py
+++ b/google/cloud/ndb/_datastore_types.py
@@ -55,8 +55,7 @@ class BlobKey(object):
         if isinstance(blob_key, bytes):
             if len(blob_key) > _MAX_STRING_LENGTH:
                 raise exceptions.BadValueError(
-                    "blob key must be under {:d} "
-                    "bytes.".format(_MAX_STRING_LENGTH)
+                    "blob key must be under {:d} " "bytes.".format(_MAX_STRING_LENGTH)
                 )
         elif blob_key is not None:
             raise exceptions.BadValueError(

--- a/google/cloud/ndb/_eventloop.py
+++ b/google/cloud/ndb/_eventloop.py
@@ -31,9 +31,7 @@ from google.cloud.ndb import utils
 
 log = logging.getLogger(__name__)
 
-_Event = collections.namedtuple(
-    "_Event", ("when", "callback", "args", "kwargs")
-)
+_Event = collections.namedtuple("_Event", ("when", "callback", "args", "kwargs"))
 
 
 class EventLoop(object):
@@ -314,9 +312,7 @@ class EventLoop(object):
             start_time = time.time()
             rpc_id, rpc = self.rpc_results.get()
             elapsed = time.time() - start_time
-            utils.logging_debug(
-                log, "Blocked for {}s awaiting RPC results.", elapsed
-            )
+            utils.logging_debug(log, "Blocked for {}s awaiting RPC results.", elapsed)
             context.wait_time += elapsed
 
             callback = self.rpcs.pop(rpc_id)

--- a/google/cloud/ndb/_gql.py
+++ b/google/cloud/ndb/_gql.py
@@ -93,9 +93,7 @@ class GQL(object):
     _limit = -1
     _hint = ""
 
-    def __init__(
-        self, query_string, _app=None, _auth_domain=None, namespace=None
-    ):
+    def __init__(self, query_string, _app=None, _auth_domain=None, namespace=None):
         """Parses the input query into the class as a pre-compiled query.
 
         Args:
@@ -191,9 +189,7 @@ class GQL(object):
     _quoted_identifier_regex = re.compile(r'((?:"[^"\s]+")+)$')
     _conditions_regex = re.compile(r"(<=|>=|!=|=|<|>|is|in)$", re.IGNORECASE)
     _number_regex = re.compile(r"(\d+)$")
-    _cast_regex = re.compile(
-        r"(geopt|user|key|date|time|datetime)$", re.IGNORECASE
-    )
+    _cast_regex = re.compile(r"(geopt|user|key|date|time|datetime)$", re.IGNORECASE)
 
     def _Error(self, error_message):
         """Generic query error.
@@ -216,8 +212,7 @@ class GQL(object):
             )
 
     def _Accept(self, symbol_string):
-        """Advance the symbol and return true if the next symbol matches input.
-        """
+        """Advance the symbol and return true if the next symbol matches input."""
         if self._next_symbol < len(self._symbols):
             if self._symbols[self._next_symbol].upper() == symbol_string:
                 self._next_symbol += 1
@@ -335,9 +330,7 @@ class GQL(object):
 
         if not self._AddSimpleFilter(identifier, condition, self._Reference()):
 
-            if not self._AddSimpleFilter(
-                identifier, condition, self._Literal()
-            ):
+            if not self._AddSimpleFilter(identifier, condition, self._Literal()):
 
                 type_cast = self._TypeCast()
                 if not type_cast or not self._AddProcessedParameterFilter(
@@ -389,13 +382,9 @@ class GQL(object):
             else:
                 self._Error('"IS" expected to follow "ANCESTOR"')
         elif condition.lower() == "is":
-            self._Error(
-                '"IS" can only be used when comparing against "ANCESTOR"'
-            )
+            self._Error('"IS" can only be used when comparing against "ANCESTOR"')
 
-    def _AddProcessedParameterFilter(
-        self, identifier, condition, operator, parameters
-    ):
+    def _AddProcessedParameterFilter(self, identifier, condition, operator, parameters):
         """Add a filter with post-processing required.
 
         Args:
@@ -424,9 +413,7 @@ class GQL(object):
         if operator == "list" and condition.lower() != "in":
             self._Error("Only IN can process a list of values")
 
-        self._filters.setdefault(filter_rule, []).append(
-            (operator, parameters)
-        )
+        self._filters.setdefault(filter_rule, []).append((operator, parameters))
         return True
 
     def _AddSimpleFilter(self, identifier, condition, parameter):
@@ -776,9 +763,7 @@ class Literal(object):
 
 def _raise_not_implemented(func):
     def raise_inner(value):
-        raise NotImplementedError(
-            "GQL function {} is not implemented".format(func)
-        )
+        raise NotImplementedError("GQL function {} is not implemented".format(func))
 
     return raise_inner
 
@@ -795,9 +780,7 @@ def _time_function(values):
                 time_tuple = time.strptime(value, "%H:%M:%S")
             except ValueError as error:
                 _raise_cast_error(
-                    "Error during time conversion, {}, {}".format(
-                        error, values
-                    )
+                    "Error during time conversion, {}, {}".format(error, values)
                 )
             time_tuple = time_tuple[3:]
             time_tuple = time_tuple[0:3]
@@ -812,9 +795,7 @@ def _time_function(values):
     try:
         return datetime.time(*time_tuple)
     except ValueError as error:
-        _raise_cast_error(
-            "Error during time conversion, {}, {}".format(error, values)
-        )
+        _raise_cast_error("Error during time conversion, {}, {}".format(error, values))
 
 
 def _date_function(values):
@@ -825,9 +806,7 @@ def _date_function(values):
                 time_tuple = time.strptime(value, "%Y-%m-%d")[0:6]
             except ValueError as error:
                 _raise_cast_error(
-                    "Error during date conversion, {}, {}".format(
-                        error, values
-                    )
+                    "Error during date conversion, {}, {}".format(error, values)
                 )
         else:
             _raise_cast_error("Invalid argument for date(), {}".format(value))
@@ -838,9 +817,7 @@ def _date_function(values):
     try:
         return datetime.datetime(*time_tuple)
     except ValueError as error:
-        _raise_cast_error(
-            "Error during date conversion, {}, {}".format(error, values)
-        )
+        _raise_cast_error("Error during date conversion, {}, {}".format(error, values))
 
 
 def _datetime_function(values):
@@ -851,14 +828,10 @@ def _datetime_function(values):
                 time_tuple = time.strptime(value, "%Y-%m-%d %H:%M:%S")[0:6]
             except ValueError as error:
                 _raise_cast_error(
-                    "Error during date conversion, {}, {}".format(
-                        error, values
-                    )
+                    "Error during date conversion, {}, {}".format(error, values)
                 )
         else:
-            _raise_cast_error(
-                "Invalid argument for datetime(), {}".format(value)
-            )
+            _raise_cast_error("Invalid argument for datetime(), {}".format(value))
     else:
         time_tuple = values
     try:
@@ -883,9 +856,7 @@ def _key_function(values):
             *values, namespace=context.get_namespace(), project=client.project
         )
     _raise_cast_error(
-        "Key requires even number of operands or single string, {}".format(
-            values
-        )
+        "Key requires even number of operands or single string, {}".format(values)
     )
 
 

--- a/google/cloud/ndb/_legacy_entity_pb.py
+++ b/google/cloud/ndb/_legacy_entity_pb.py
@@ -451,9 +451,7 @@ class Property(ProtocolBuffer.ProtocolMessage):
                 continue
             if tt == 42:
                 length = d.getVarInt32()
-                tmp = ProtocolBuffer.Decoder(
-                    d.buffer(), d.pos(), d.pos() + length
-                )
+                tmp = ProtocolBuffer.Decoder(d.buffer(), d.pos(), d.pos() + length)
                 d.skip(length)
                 self.mutable_value().TryMerge(tmp)
                 continue
@@ -611,9 +609,7 @@ class Reference(ProtocolBuffer.ProtocolMessage):
                 continue
             if tt == 114:
                 length = d.getVarInt32()
-                tmp = ProtocolBuffer.Decoder(
-                    d.buffer(), d.pos(), d.pos() + length
-                )
+                tmp = ProtocolBuffer.Decoder(d.buffer(), d.pos(), d.pos() + length)
                 d.skip(length)
                 self.mutable_path().TryMerge(tmp)
                 continue
@@ -692,25 +688,19 @@ class EntityProto(ProtocolBuffer.ProtocolMessage):
                 continue
             if tt == 106:
                 length = d.getVarInt32()
-                tmp = ProtocolBuffer.Decoder(
-                    d.buffer(), d.pos(), d.pos() + length
-                )
+                tmp = ProtocolBuffer.Decoder(d.buffer(), d.pos(), d.pos() + length)
                 d.skip(length)
                 self.mutable_key().TryMerge(tmp)
                 continue
             if tt == 114:
                 length = d.getVarInt32()
-                tmp = ProtocolBuffer.Decoder(
-                    d.buffer(), d.pos(), d.pos() + length
-                )
+                tmp = ProtocolBuffer.Decoder(d.buffer(), d.pos(), d.pos() + length)
                 d.skip(length)
                 self.add_property().TryMerge(tmp)
                 continue
             if tt == 122:
                 length = d.getVarInt32()
-                tmp = ProtocolBuffer.Decoder(
-                    d.buffer(), d.pos(), d.pos() + length
-                )
+                tmp = ProtocolBuffer.Decoder(d.buffer(), d.pos(), d.pos() + length)
                 d.skip(length)
                 self.add_property().TryMerge(tmp)
                 continue
@@ -739,9 +729,7 @@ class EntityProto(ProtocolBuffer.ProtocolMessage):
         for prop in self.property_list():
             name = prop.name().decode("utf-8")
             entity_props[name] = (
-                prop.has_value()
-                and self._get_property_value(prop.value())
-                or None
+                prop.has_value() and self._get_property_value(prop.value()) or None
             )
         return entity_props
 

--- a/google/cloud/ndb/_options.py
+++ b/google/cloud/ndb/_options.py
@@ -103,9 +103,7 @@ class Options(object):
     def __init__(self, config=None, **kwargs):
         cls = type(self)
         if config is not None and not isinstance(config, cls):
-            raise TypeError(
-                "Config must be a {} instance.".format(cls.__name__)
-            )
+            raise TypeError("Config must be a {} instance.".format(cls.__name__))
 
         deadline = kwargs.pop("deadline", None)
         if deadline is not None:
@@ -207,8 +205,7 @@ class ReadOptions(Options):
             )
             if kwargs.get("read_consistency"):
                 raise TypeError(
-                    "Cannot use both 'read_policy' and 'read_consistency' "
-                    "options."
+                    "Cannot use both 'read_policy' and 'read_consistency' " "options."
                 )
             kwargs["read_consistency"] = read_policy
 

--- a/google/cloud/ndb/_transaction.py
+++ b/google/cloud/ndb/_transaction.py
@@ -122,9 +122,7 @@ def _transaction_async(context, callback, read_only=False):
 
     # Start the transaction
     utils.logging_debug(log, "Start transaction")
-    transaction_id = yield _datastore_api.begin_transaction(
-        read_only, retries=0
-    )
+    transaction_id = yield _datastore_api.begin_transaction(read_only, retries=0)
     utils.logging_debug(log, "Transaction Id: {}", transaction_id)
 
     on_commit_callbacks = []
@@ -330,9 +328,7 @@ def non_transactional(allow_existing=True):
                 return wrapped(*args, **kwargs)
             if not allow_existing:
                 raise exceptions.BadRequestError(
-                    "{} cannot be called within a transaction".format(
-                        wrapped.__name__
-                    )
+                    "{} cannot be called within a transaction".format(wrapped.__name__)
                 )
             new_ctx = ctx.new(transaction=None)
             with new_ctx.use():

--- a/google/cloud/ndb/client.py
+++ b/google/cloud/ndb/client.py
@@ -35,9 +35,7 @@ _CLIENT_INFO = client_info.ClientInfo(
     user_agent="google-cloud-ndb/{}".format(__version__)
 )
 
-DATASTORE_API_HOST = datastore_client.DatastoreClient.SERVICE_ADDRESS.rsplit(
-    ":", 1
-)[0]
+DATASTORE_API_HOST = datastore_client.DatastoreClient.SERVICE_ADDRESS.rsplit(":", 1)[0]
 
 
 def _get_gcd_project():
@@ -48,19 +46,19 @@ def _get_gcd_project():
 def _determine_default_project(project=None):
     """Determine default project explicitly or implicitly as fall-back.
 
-    In implicit case, supports four environments. In order of precedence, the
-    implicit environments are:
+        In implicit case, supports four environments. In order of precedence, the
+        implicit environments are:
 
-    * DATASTORE_DATASET environment variable (for ``gcd`` / emulator testing)
-    * GOOGLE_CLOUD_PROJECT environment variable
-    * Google App Engine application ID
-    * Google Compute Engine project ID (from metadata server)
-_
-    Arguments:
-        project (Optional[str]): The project to use as default.
+        * DATASTORE_DATASET environment variable (for ``gcd`` / emulator testing)
+        * GOOGLE_CLOUD_PROJECT environment variable
+        * Google App Engine application ID
+        * Google Compute Engine project ID (from metadata server)
+    _
+        Arguments:
+            project (Optional[str]): The project to use as default.
 
-    Returns:
-        Union([str, None]): Default project if it can be determined.
+        Returns:
+            Union([str, None]): Default project if it can be determined.
     """
     if project is None:
         project = _get_gcd_project()
@@ -92,9 +90,7 @@ class Client(google_client.ClientWithProject):
 
     def __init__(self, project=None, namespace=None, credentials=None):
         self.namespace = namespace
-        self.host = os.environ.get(
-            environment_vars.GCD_HOST, DATASTORE_API_HOST
-        )
+        self.host = os.environ.get(environment_vars.GCD_HOST, DATASTORE_API_HOST)
         self.client_info = _CLIENT_INFO
 
         # Use insecure connection when using Datastore Emulator, otherwise
@@ -114,9 +110,7 @@ class Client(google_client.ClientWithProject):
                 _http=requests.Session,
             )
         else:
-            super(Client, self).__init__(
-                project=project, credentials=credentials
-            )
+            super(Client, self).__init__(project=project, credentials=credentials)
 
         if emulator:
             channel = grpc.insecure_channel(self.host)

--- a/google/cloud/ndb/context.py
+++ b/google/cloud/ndb/context.py
@@ -180,9 +180,7 @@ Defers to ``_use_global_cache`` on the Model class for the key's kind.
 See: :meth:`~google.cloud.ndb.context.Context.set_global_cache_policy`
 """
 
-_default_global_cache_timeout_policy = _default_policy(
-    "_global_cache_timeout", int
-)
+_default_global_cache_timeout_policy = _default_policy("_global_cache_timeout", int)
 """The default global cache timeout policy.
 
 Defers to ``_global_cache_timeout`` on the Model class for the key's kind.

--- a/google/cloud/ndb/key.py
+++ b/google/cloud/ndb/key.py
@@ -101,8 +101,7 @@ _APP_ID_ENVIRONMENT = "APPLICATION_ID"
 _APP_ID_DEFAULT = "_"
 _WRONG_TYPE = "Cannot construct Key reference on non-Key class; received {!r}"
 _REFERENCE_APP_MISMATCH = (
-    "Key reference constructed uses a different app {!r} than "
-    "the one specified {!r}"
+    "Key reference constructed uses a different app {!r} than " "the one specified {!r}"
 )
 _REFERENCE_NAMESPACE_MISMATCH = (
     "Key reference constructed uses a different namespace {!r} than "
@@ -112,12 +111,8 @@ _INVALID_ID_TYPE = "Key ID must be a string or a number; received {!r}"
 _NO_LEGACY = "The `google.appengine.ext.db` module is not available."
 _MAX_INTEGER_ID = 0x7FFFFFFFFFFFFFFF  # 2 ** 63 - 1
 _MAX_KEYPART_BYTES = 1500
-_BAD_KIND = (
-    "Key kind string must be a non-empty string up to {:d} bytes; received {}"
-)
-_BAD_INTEGER_ID = (
-    "Key ID number is outside of range [1, 2^63 - 1]; received {:d}"
-)
+_BAD_KIND = "Key kind string must be a non-empty string up to {:d} bytes; received {}"
+_BAD_INTEGER_ID = "Key ID number is outside of range [1, 2^63 - 1]; received {:d}"
 _BAD_STRING_ID = (
     "Key name strings must be non-empty strings up to {:d} bytes; received {}"
 )
@@ -295,19 +290,13 @@ class Key(object):
             context = context_module.get_context()
             kwargs["namespace"] = context.get_namespace()
 
-        if (
-            "reference" in kwargs
-            or "serialized" in kwargs
-            or "urlsafe" in kwargs
-        ):
+        if "reference" in kwargs or "serialized" in kwargs or "urlsafe" in kwargs:
             ds_key, reference = _parse_from_ref(cls, **kwargs)
         elif "pairs" in kwargs or "flat" in kwargs:
             ds_key = _parse_from_args(**kwargs)
             reference = None
         else:
-            raise TypeError(
-                "Key() cannot create a Key instance without arguments."
-            )
+            raise TypeError("Key() cannot create a Key instance without arguments.")
 
         instance._key = ds_key
         instance._reference = reference
@@ -453,9 +442,7 @@ class Key(object):
             TypeError: If the single element in ``state`` is not a dictionary.
         """
         if len(state) != 1:
-            msg = "Invalid state length, expected 1; received {:d}".format(
-                len(state)
-            )
+            msg = "Invalid state length, expected 1; received {:d}".format(len(state))
             raise TypeError(msg)
 
         kwargs = state[0]
@@ -925,9 +912,7 @@ class Key(object):
 
         future = get()
         if cls:
-            future.add_done_callback(
-                functools.partial(cls._post_get_hook, self)
-            )
+            future.add_done_callback(functools.partial(cls._post_get_hook, self))
         return future
 
     @_options.Options.options
@@ -1048,9 +1033,7 @@ class Key(object):
         future = delete()
 
         if cls:
-            future.add_done_callback(
-                functools.partial(cls._post_delete_hook, self)
-            )
+            future.add_done_callback(functools.partial(cls._post_delete_hook, self))
 
         return future
 
@@ -1141,17 +1124,13 @@ def _from_reference(reference, app, namespace):
     project = _project_from_app(reference.app)
     if app is not None:
         if _project_from_app(app) != project:
-            raise RuntimeError(
-                _REFERENCE_APP_MISMATCH.format(reference.app, app)
-            )
+            raise RuntimeError(_REFERENCE_APP_MISMATCH.format(reference.app, app))
 
     parsed_namespace = _key_module._get_empty(reference.name_space, "")
     if namespace is not None:
         if namespace != parsed_namespace:
             raise RuntimeError(
-                _REFERENCE_NAMESPACE_MISMATCH.format(
-                    reference.name_space, namespace
-                )
+                _REFERENCE_NAMESPACE_MISMATCH.format(reference.name_space, namespace)
             )
 
     _key_module._check_database_id(reference.database_id)
@@ -1324,8 +1303,7 @@ def _parse_from_ref(
 
     if kwargs or not _exactly_one_specified(reference, serialized, urlsafe):
         raise TypeError(
-            "Cannot construct Key reference from incompatible "
-            "keyword arguments."
+            "Cannot construct Key reference from incompatible " "keyword arguments."
         )
 
     if reference:
@@ -1370,9 +1348,7 @@ def _parse_from_args(
     _clean_flat_path(flat)
 
     if project and app:
-        raise TypeError(
-            "Can't specify both 'project' and 'app'. They are synonyms."
-        )
+        raise TypeError("Can't specify both 'project' and 'app'. They are synonyms.")
     elif not app:
         app = project
 
@@ -1417,13 +1393,9 @@ def _get_path(flat, pairs):
     """
     if flat:
         if pairs is not None:
-            raise TypeError(
-                "Key() cannot accept both flat and pairs arguments."
-            )
+            raise TypeError("Key() cannot accept both flat and pairs arguments.")
         if len(flat) % 2:
-            raise ValueError(
-                "Key() must have an even number of positional arguments."
-            )
+            raise ValueError("Key() must have an even number of positional arguments.")
         flat = list(flat)
     else:
         flat = []
@@ -1470,9 +1442,7 @@ def _clean_flat_path(flat):
         id_ = flat[i + 1]
         if id_ is None:
             if i + 2 < len(flat):
-                raise exceptions.BadArgumentError(
-                    "Incomplete Key entry must be last"
-                )
+                raise exceptions.BadArgumentError("Incomplete Key entry must be last")
         elif not isinstance(id_, six.string_types + six.integer_types):
             raise TypeError(_INVALID_ID_TYPE.format(id_))
 
@@ -1539,9 +1509,7 @@ def _to_legacy_path(dict_path):
     """
     elements = []
     for part in dict_path:
-        element_kwargs = {
-            "type": _verify_path_value(part["kind"], True, is_kind=True)
-        }
+        element_kwargs = {"type": _verify_path_value(part["kind"], True, is_kind=True)}
         if "id" in part:
             element_kwargs["id"] = _verify_path_value(part["id"], False)
         elif "name" in part:

--- a/google/cloud/ndb/metadata.py
+++ b/google/cloud/ndb/metadata.py
@@ -242,8 +242,7 @@ class Property(_BaseMetadata):
 
 
 class EntityGroup(object):
-    """Model for __entity_group__ metadata. No longer supported by datastore.
-    """
+    """Model for __entity_group__ metadata. No longer supported by datastore."""
 
     def __new__(self, *args, **kwargs):
         raise exceptions.NoLongerImplementedError()
@@ -299,9 +298,7 @@ def get_namespaces(start=None, end=None):
 
     query = query_module.Query(kind=Namespace._get_kind())
     if start is not None:
-        query = query.filter(
-            Namespace.key >= Namespace.key_for_namespace(start)
-        )
+        query = query.filter(Namespace.key >= Namespace.key_for_namespace(start))
     if end is not None:
         query = query.filter(Namespace.key < Namespace.key_for_namespace(end))
 
@@ -330,15 +327,11 @@ def get_properties_of_kind(kind, start=None, end=None):
         kind=Property._get_kind(), ancestor=Property.key_for_kind(kind)
     )
     if start is not None and start != "":
-        query = query.filter(
-            Property.key >= Property.key_for_property(kind, start)
-        )
+        query = query.filter(Property.key >= Property.key_for_property(kind, start))
     if end is not None:
         if end == "":
             return []
-        query = query.filter(
-            Property.key < Property.key_for_property(kind, end)
-        )
+        query = query.filter(Property.key < Property.key_for_property(kind, end))
 
     results = query.fetch()
     return [prop.property_name for prop in results]
@@ -364,21 +357,15 @@ def get_representations_of_kind(kind, start=None, end=None):
         kind=Property._get_kind(), ancestor=Property.key_for_kind(kind)
     )
     if start is not None and start != "":
-        query = query.filter(
-            Property.key >= Property.key_for_property(kind, start)
-        )
+        query = query.filter(Property.key >= Property.key_for_property(kind, start))
     if end is not None:
         if end == "":
             return {}
-        query = query.filter(
-            Property.key < Property.key_for_property(kind, end)
-        )
+        query = query.filter(Property.key < Property.key_for_property(kind, end))
 
     representations = {}
     results = query.fetch()
     for property in results:
-        representations[
-            property.property_name
-        ] = property.property_representation
+        representations[property.property_name] = property.property_representation
 
     return representations

--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -652,13 +652,9 @@ def _entity_from_ds_entity(ds_entity, model_class=None):
             return None if value is None else _BaseValue(value)
 
         if not (prop is not None and isinstance(prop, Property)):
-            if value is not None and isinstance(  # pragma: NO BRANCH
-                entity, Expando
-            ):
+            if value is not None and isinstance(entity, Expando):  # pragma: NO BRANCH
                 if isinstance(value, list):
-                    value = [
-                        base_value_or_none(sub_value) for sub_value in value
-                    ]
+                    value = [base_value_or_none(sub_value) for sub_value in value]
                 else:
                     value = _BaseValue(value)
                 setattr(entity, name, value)
@@ -670,9 +666,7 @@ def _entity_from_ds_entity(ds_entity, model_class=None):
                 # projection query.
                 if isinstance(value, list):
                     # Not a projection
-                    value = [
-                        base_value_or_none(sub_value) for sub_value in value
-                    ]
+                    value = [base_value_or_none(sub_value) for sub_value in value]
                 else:
                     # Projection
                     value = [_BaseValue(value)]
@@ -769,9 +763,7 @@ def _entity_to_ds_entity(entity, set_key=True):
             key._key, exclude_from_indexes=exclude_from_indexes
         )
     else:
-        ds_entity = ds_entity_module.Entity(
-            exclude_from_indexes=exclude_from_indexes
-        )
+        ds_entity = ds_entity_module.Entity(exclude_from_indexes=exclude_from_indexes)
 
     # Some properties may need to set meanings for backwards compatibility,
     # so we look for them. They are set using the _to_datastore calls above.
@@ -1070,9 +1062,7 @@ class Property(ModelAttribute):
             raise TypeError("Name {!r} is not a string".format(name))
 
         if "." in name:
-            raise ValueError(
-                "Name {!r} cannot contain period characters".format(name)
-            )
+            raise ValueError("Name {!r} cannot contain period characters".format(name))
 
         return name
 
@@ -1084,9 +1074,7 @@ class Property(ModelAttribute):
                 ``required`` or ``default`` is set.
         """
         if self._repeated and (self._required or self._default is not None):
-            raise ValueError(
-                "repeated is incompatible with required or default"
-            )
+            raise ValueError("repeated is incompatible with required or default")
 
     @staticmethod
     def _verify_choices(choices):
@@ -1105,9 +1093,7 @@ class Property(ModelAttribute):
         """
         if not isinstance(choices, (list, tuple, set, frozenset)):
             raise TypeError(
-                "choices must be a list, tuple or set; received {!r}".format(
-                    choices
-                )
+                "choices must be a list, tuple or set; received {!r}".format(choices)
             )
         return frozenset(choices)
 
@@ -1141,9 +1127,7 @@ class Property(ModelAttribute):
         #       implementation. It's not clear why ``callable()`` was not used.
         if getattr(validator, "__call__", None) is None:
             raise TypeError(
-                "validator must be callable or None; received {!r}".format(
-                    validator
-                )
+                "validator must be callable or None; received {!r}".format(validator)
             )
 
         return validator
@@ -1157,9 +1141,7 @@ class Property(ModelAttribute):
         """
         # inspect.signature not available in Python 2.7, so we use positional
         # decorator combined with argspec instead.
-        argspec = getattr(
-            self.__init__, "_argspec", _getfullargspec(self.__init__)
-        )
+        argspec = getattr(self.__init__, "_argspec", _getfullargspec(self.__init__))
         positional = getattr(self.__init__, "_positional_args", 1)
         for index, name in enumerate(argspec.args):
             if name == "self":
@@ -1966,9 +1948,7 @@ class Property(ModelAttribute):
         """
         self._delete_value(entity)
 
-    def _serialize(
-        self, entity, pb, prefix="", parent_repeated=False, projection=None
-    ):
+    def _serialize(self, entity, pb, prefix="", parent_repeated=False, projection=None):
         """Serialize this property to a protocol buffer.
 
         Some subclasses may override this method.
@@ -2044,9 +2024,7 @@ class Property(ModelAttribute):
                 subproperties).
         """
         if require_indexed and not self._indexed:
-            raise InvalidPropertyError(
-                "Property is unindexed: {}".format(self._name)
-            )
+            raise InvalidPropertyError("Property is unindexed: {}".format(self._name))
 
         if rest:
             raise InvalidPropertyError(
@@ -2202,9 +2180,7 @@ class ModelKey(Property):
         if value is not None:
             return super(ModelKey, self)._comparison(op, value)
 
-        raise exceptions.BadValueError(
-            "__key__ filter query can't be compared to None"
-        )
+        raise exceptions.BadValueError("__key__ filter query can't be compared to None")
 
     def _validate(self, value):
         """Validate a ``value`` before setting it.
@@ -2272,9 +2248,7 @@ class BooleanProperty(Property):
             .BadValueError: If ``value`` is not a :class:`bool`.
         """
         if not isinstance(value, bool):
-            raise exceptions.BadValueError(
-                "Expected bool, got {!r}".format(value)
-            )
+            raise exceptions.BadValueError("Expected bool, got {!r}".format(value))
         return value
 
 
@@ -2303,9 +2277,7 @@ class IntegerProperty(Property):
                 to one.
         """
         if not isinstance(value, six.integer_types):
-            raise exceptions.BadValueError(
-                "Expected integer, got {!r}".format(value)
-            )
+            raise exceptions.BadValueError("Expected integer, got {!r}".format(value))
         return int(value)
 
 
@@ -2335,9 +2307,7 @@ class FloatProperty(Property):
                 to one.
         """
         if not isinstance(value, six.integer_types + (float,)):
-            raise exceptions.BadValueError(
-                "Expected float, got {!r}".format(value)
-            )
+            raise exceptions.BadValueError("Expected float, got {!r}".format(value))
         return float(value)
 
 
@@ -2468,9 +2438,7 @@ class BlobProperty(Property):
                 exceeds the maximum length (1500 bytes).
         """
         if not isinstance(value, bytes):
-            raise exceptions.BadValueError(
-                "Expected bytes, got {!r}".format(value)
-            )
+            raise exceptions.BadValueError("Expected bytes, got {!r}".format(value))
 
         if self._indexed and len(value) > _MAX_STRING_LENGTH:
             raise exceptions.BadValueError(
@@ -2615,9 +2583,7 @@ class CompressedTextProperty(BlobProperty):
         parent_init = super(CompressedTextProperty, self).__init__
         # inspect.signature not available in Python 2.7, so we use positional
         # decorator combined with argspec instead.
-        argspec = getattr(
-            parent_init, "_argspec", _getfullargspec(parent_init)
-        )
+        argspec = getattr(parent_init, "_argspec", _getfullargspec(parent_init))
         positional = getattr(parent_init, "_positional_args", 1)
         for index, name in enumerate(argspec.args):
             if name in ("self", "indexed", "compressed"):
@@ -2777,9 +2743,7 @@ class TextProperty(Property):
         parent_init = super(TextProperty, self).__init__
         # inspect.signature not available in Python 2.7, so we use positional
         # decorator combined with argspec instead.
-        argspec = getattr(
-            parent_init, "_argspec", _getfullargspec(parent_init)
-        )
+        argspec = getattr(parent_init, "_argspec", _getfullargspec(parent_init))
         positional = getattr(parent_init, "_positional_args", 1)
         for index, name in enumerate(argspec.args):
             if name == "self" or name == "indexed":
@@ -2816,9 +2780,7 @@ class TextProperty(Property):
         elif isinstance(value, six.string_types):
             encoded_length = len(value.encode("utf-8"))
         else:
-            raise exceptions.BadValueError(
-                "Expected string, got {!r}".format(value)
-            )
+            raise exceptions.BadValueError("Expected string, got {!r}".format(value))
 
         if self._indexed and encoded_length > _MAX_STRING_LENGTH:
             raise exceptions.BadValueError(
@@ -2919,9 +2881,7 @@ class GeoPtProperty(Property):
             .BadValueError: If ``value`` is not a :attr:`.GeoPt`.
         """
         if not isinstance(value, GeoPt):
-            raise exceptions.BadValueError(
-                "Expected GeoPt, got {!r}".format(value)
-            )
+            raise exceptions.BadValueError("Expected GeoPt, got {!r}".format(value))
 
 
 class PickleProperty(BlobProperty):
@@ -3041,9 +3001,7 @@ class JsonProperty(BlobProperty):
         if self._json_type is None:
             return
         if not isinstance(value, self._json_type):
-            raise TypeError(
-                "JSON property must be a {}".format(self._json_type)
-            )
+            raise TypeError("JSON property must be a {}".format(self._json_type))
 
     def _to_base_type(self, value):
         """Convert a value to the "base" value type for this property.
@@ -3206,10 +3164,7 @@ class User(object):
         if not isinstance(other, User):
             return NotImplemented
 
-        return (
-            self._email == other._email
-            and self._auth_domain == other._auth_domain
-        )
+        return self._email == other._email and self._auth_domain == other._auth_domain
 
     def __lt__(self, other):
         if not isinstance(other, User):  # pragma: NO PY2 COVER
@@ -3345,9 +3300,7 @@ class UserProperty(Property):
         """
         # Might be GAE User or our own version
         if type(value).__name__ != "User":
-            raise exceptions.BadValueError(
-                "Expected User, got {!r}".format(value)
-            )
+            raise exceptions.BadValueError("Expected User, got {!r}".format(value))
 
     def _prepare_for_put(self, entity):
         """Pre-put hook
@@ -3487,9 +3440,7 @@ class KeyProperty(Property):
                     kwargs["kind"] = arg
 
                 elif arg is not None:
-                    raise TypeError(
-                        "Unexpected positional argument: {!r}".format(arg)
-                    )
+                    raise TypeError("Unexpected positional argument: {!r}".format(arg))
 
             return wrapped(self, **kwargs)
 
@@ -3561,9 +3512,7 @@ class KeyProperty(Property):
                 and ``value`` does not match that kind.
         """
         if not isinstance(value, Key):
-            raise exceptions.BadValueError(
-                "Expected Key, got {!r}".format(value)
-            )
+            raise exceptions.BadValueError("Expected Key, got {!r}".format(value))
 
         # Reject incomplete keys.
         if not value.id():
@@ -3575,8 +3524,7 @@ class KeyProperty(Property):
         if self._kind is not None:
             if value.kind() != self._kind:
                 raise exceptions.BadValueError(
-                    "Expected Key with kind={!r}, got "
-                    "{!r}".format(self._kind, value)
+                    "Expected Key with kind={!r}, got " "{!r}".format(self._kind, value)
                 )
 
     def _to_base_type(self, value):
@@ -3627,9 +3575,7 @@ class BlobKeyProperty(Property):
                 :class:`~google.cloud.ndb.model.BlobKey`.
         """
         if not isinstance(value, BlobKey):
-            raise exceptions.BadValueError(
-                "Expected BlobKey, got {!r}".format(value)
-            )
+            raise exceptions.BadValueError("Expected BlobKey, got {!r}".format(value))
 
 
 class DateTimeProperty(Property):
@@ -3745,9 +3691,7 @@ class DateTimeProperty(Property):
             .BadValueError: If ``value`` is not a :class:`~datetime.datetime`.
         """
         if not isinstance(value, datetime.datetime):
-            raise exceptions.BadValueError(
-                "Expected datetime, got {!r}".format(value)
-            )
+            raise exceptions.BadValueError("Expected datetime, got {!r}".format(value))
 
         if self._tzinfo is None and value.tzinfo is not None:
             raise exceptions.BadValueError(
@@ -3778,9 +3722,7 @@ class DateTimeProperty(Property):
         Args:
             entity (Model): An entity with values.
         """
-        if self._auto_now or (
-            self._auto_now_add and not self._has_value(entity)
-        ):
+        if self._auto_now or (self._auto_now_add and not self._has_value(entity)):
             value = self._now()
             self._store_value(entity, value)
 
@@ -3844,9 +3786,7 @@ class DateProperty(DateTimeProperty):
             .BadValueError: If ``value`` is not a :class:`~datetime.date`.
         """
         if not isinstance(value, datetime.date):
-            raise exceptions.BadValueError(
-                "Expected date, got {!r}".format(value)
-            )
+            raise exceptions.BadValueError("Expected date, got {!r}".format(value))
 
     def _to_base_type(self, value):
         """Convert a value to the "base" value type for this property.
@@ -3904,9 +3844,7 @@ class TimeProperty(DateTimeProperty):
             .BadValueError: If ``value`` is not a :class:`~datetime.time`.
         """
         if not isinstance(value, datetime.time):
-            raise exceptions.BadValueError(
-                "Expected time, got {!r}".format(value)
-            )
+            raise exceptions.BadValueError("Expected time, got {!r}".format(value))
 
     def _to_base_type(self, value):
         """Convert a value to the "base" value type for this property.
@@ -3970,8 +3908,7 @@ class StructuredProperty(Property):
                 raise TypeError(
                     "This StructuredProperty cannot use repeated=True "
                     "because its model class (%s) contains repeated "
-                    "properties (directly or indirectly)."
-                    % model_class.__name__
+                    "properties (directly or indirectly)." % model_class.__name__
                 )
         self._model_class = model_class
 
@@ -4029,9 +3966,7 @@ class StructuredProperty(Property):
 
     def _comparison(self, op, value):
         if op != query_module._EQ_OP:
-            raise exceptions.BadFilterError(
-                "StructuredProperty filter can only use =="
-            )
+            raise exceptions.BadFilterError("StructuredProperty filter can only use ==")
         if not self._indexed:
             raise exceptions.BadFilterError(
                 "Cannot query for unindexed StructuredProperty %s" % self._name
@@ -4055,8 +3990,7 @@ class StructuredProperty(Property):
             if prop._repeated:
                 if subvalue:  # pragma: no branch
                     raise exceptions.BadFilterError(
-                        "Cannot query for non-empty repeated property %s"
-                        % prop._name
+                        "Cannot query for non-empty repeated property %s" % prop._name
                     )
                 continue  # pragma: NO COVER
 
@@ -4162,9 +4096,7 @@ class StructuredProperty(Property):
             raise InvalidPropertyError(
                 "Structured property %s requires a subproperty" % self._name
             )
-        self._model_class._check_properties(
-            [rest], require_indexed=require_indexed
-        )
+        self._model_class._check_properties([rest], require_indexed=require_indexed)
 
     def _to_base_type(self, value):
         """Convert a value to the "base" value type for this property.
@@ -4194,9 +4126,7 @@ class StructuredProperty(Property):
             The converted value with given class.
         """
         if isinstance(value, ds_entity_module.Entity):
-            value = _entity_from_ds_entity(
-                value, model_class=self._model_class
-            )
+            value = _entity_from_ds_entity(value, model_class=self._model_class)
         return value
 
     def _get_value_size(self, entity):
@@ -4317,9 +4247,7 @@ class LocalStructuredProperty(BlobProperty):
 
         if not isinstance(value, self._model_class):
             raise exceptions.BadValueError(
-                "Expected {}, got {!r}".format(
-                    self._model_class.__name__, value
-                )
+                "Expected {}, got {!r}".format(self._model_class.__name__, value)
             )
 
     def _get_for_dict(self, entity):
@@ -4413,9 +4341,7 @@ class LocalStructuredProperty(BlobProperty):
             for value in values:
                 ds_entity = None
                 if value is not None:
-                    ds_entity = _entity_to_ds_entity(
-                        value, set_key=self._keep_keys
-                    )
+                    ds_entity = _entity_to_ds_entity(value, set_key=self._keep_keys)
                 legacy_values.append(ds_entity)
             if not self._repeated:
                 legacy_values = legacy_values[0]
@@ -4497,9 +4423,7 @@ class ComputedProperty(GenericProperty):
     _kwargs = None
     _func = None
 
-    def __init__(
-        self, func, name=None, indexed=None, repeated=None, verbose_name=None
-    ):
+    def __init__(self, func, name=None, indexed=None, repeated=None, verbose_name=None):
         """Constructor.
 
         Args:
@@ -4879,9 +4803,7 @@ class Model(_NotEqualMixin):
             if value is None:
                 arg_repr = "None"
             elif prop._repeated:
-                arg_reprs = [
-                    prop._value_to_repr(sub_value) for sub_value in value
-                ]
+                arg_reprs = [prop._value_to_repr(sub_value) for sub_value in value]
                 arg_repr = "[{}]".format(", ".join(arg_reprs))
             else:
                 arg_repr = prop._value_to_repr(value)
@@ -5104,9 +5026,7 @@ class Model(_NotEqualMixin):
 
         for name in dir(cls):
             attr = getattr(cls, name, None)
-            if isinstance(attr, ModelAttribute) and not isinstance(
-                attr, ModelKey
-            ):
+            if isinstance(attr, ModelAttribute) and not isinstance(attr, ModelKey):
                 if name.startswith("_"):
                     raise TypeError(
                         "ModelAttribute {} cannot begin with an underscore "
@@ -5335,14 +5255,10 @@ class Model(_NotEqualMixin):
         # Validating distinct
         if kwargs["distinct"]:
             if kwargs["distinct_on"]:
-                raise TypeError(
-                    "Cannot use `distinct` and `distinct_on` together."
-                )
+                raise TypeError("Cannot use `distinct` and `distinct_on` together.")
 
             if kwargs["group_by"]:
-                raise TypeError(
-                    "Cannot use `distinct` and `group_by` together."
-                )
+                raise TypeError("Cannot use `distinct` and `group_by` together.")
 
             if not kwargs["projection"]:
                 raise TypeError("Cannot use `distinct` without `projection`.")
@@ -5498,16 +5414,11 @@ class Model(_NotEqualMixin):
         def allocate_ids():
             cls._pre_allocate_ids_hook(size, max, parent)
             kind = cls._get_kind()
-            keys = [
-                key_module.Key(kind, None, parent=parent)._key
-                for _ in range(size)
-            ]
+            keys = [key_module.Key(kind, None, parent=parent)._key for _ in range(size)]
             key_pbs = yield _datastore_api.allocate(keys, _options)
             keys = tuple(
                 (
-                    key_module.Key._from_ds_key(
-                        helpers.key_from_protobuf(key_pb)
-                    )
+                    key_module.Key._from_ds_key(helpers.key_from_protobuf(key_pb))
                     for key_pb in key_pbs
                 )
             )
@@ -5679,9 +5590,7 @@ class Model(_NotEqualMixin):
         """
         if app:
             if project:
-                raise TypeError(
-                    "Can't pass 'app' and 'project' arguments together."
-                )
+                raise TypeError("Can't pass 'app' and 'project' arguments together.")
 
             project = app
 
@@ -5876,18 +5785,14 @@ class Model(_NotEqualMixin):
                 or created.
         """
         if not isinstance(name, six.string_types):
-            raise TypeError(
-                "'name' must be a string; received {!r}".format(name)
-            )
+            raise TypeError("'name' must be a string; received {!r}".format(name))
 
         elif not name:
             raise TypeError("'name' must not be an empty string.")
 
         if app:
             if project:
-                raise TypeError(
-                    "Can't pass 'app' and 'project' arguments together."
-                )
+                raise TypeError("Can't pass 'app' and 'project' arguments together.")
 
             project = app
 
@@ -6459,12 +6364,10 @@ def delete_multi(
 
 
 def get_indexes_async(**options):
-    """Get a data structure representing the configured indexes.
-    """
+    """Get a data structure representing the configured indexes."""
     raise NotImplementedError
 
 
 def get_indexes(**options):
-    """Get a data structure representing the configured indexes.
-    """
+    """Get a data structure representing the configured indexes."""
     raise NotImplementedError

--- a/google/cloud/ndb/polymodel.py
+++ b/google/cloud/ndb/polymodel.py
@@ -98,8 +98,7 @@ class _ClassKeyProperty(model.StringProperty):
         return value
 
     def _prepare_for_put(self, entity):
-        """Ensure the class_ property is initialized before it is serialized.
-        """
+        """Ensure the class_ property is initialized before it is serialized."""
         self._get_value(entity)  # For its side effects.
 
 

--- a/google/cloud/ndb/query.py
+++ b/google/cloud/ndb/query.py
@@ -179,12 +179,12 @@ _log = logging.getLogger(__name__)
 
 class PropertyOrder(object):
     """The sort order for a property name, to be used when ordering the
-       results of a query.
+    results of a query.
 
-       Args:
-           name (str): The name of the model property to use for ordering.
-           reverse (bool): Whether to reverse the sort order (descending)
-               or not (ascending). Default is False.
+    Args:
+        name (str): The name of the model property to use for ordering.
+        reverse (bool): Whether to reverse the sort order (descending)
+            or not (ascending). Default is False.
     """
 
     def __init__(self, name, reverse=False):
@@ -192,9 +192,7 @@ class PropertyOrder(object):
         self.reverse = reverse
 
     def __repr__(self):
-        return "PropertyOrder(name='{}', reverse={})".format(
-            self.name, self.reverse
-        )
+        return "PropertyOrder(name='{}', reverse={})".format(self.name, self.reverse)
 
     def __neg__(self):
         reverse = not self.reverse
@@ -257,8 +255,7 @@ class RepeatedStructuredPropertyPredicate(object):
                 subprop_name = prop_name.split(".", 1)[1]
                 if not subentities:
                     subentities = [
-                        {subprop_name: value}
-                        for value in prop_pb.array_value.values
+                        {subprop_name: value} for value in prop_pb.array_value.values
                     ]
                 else:
                     for subentity, value in zip(
@@ -308,9 +305,7 @@ class Parameter(ParameterizedThing):
     def __init__(self, key):
         if not isinstance(key, six.integer_types + six.string_types):
             raise TypeError(
-                "Parameter key must be an integer or string, not {}".format(
-                    key
-                )
+                "Parameter key must be an integer or string, not {}".format(key)
             )
         self._key = key
 
@@ -345,9 +340,7 @@ class Parameter(ParameterizedThing):
         """
         key = self._key
         if key not in bindings:
-            raise exceptions.BadArgumentError(
-                "Parameter :{} is not bound.".format(key)
-            )
+            raise exceptions.BadArgumentError("Parameter :{} is not bound.".format(key))
         value = bindings[key]
         used[key] = True
         return value
@@ -527,9 +520,7 @@ class ParameterNode(Node):
         if op not in _OPS:
             raise TypeError("Expected a valid operator, got {!r}".format(op))
         if not isinstance(param, ParameterizedThing):
-            raise TypeError(
-                "Expected a ParameterizedThing, got {!r}".format(param)
-            )
+            raise TypeError("Expected a ParameterizedThing, got {!r}".format(param))
         obj = super(ParameterNode, cls).__new__(cls)
         obj._prop = prop
         obj._op = op
@@ -657,9 +648,7 @@ class FilterNode(Node):
                     "in expected a list, tuple or set of values; "
                     "received {!r}".format(value)
                 )
-            nodes = [
-                FilterNode(name, _EQ_OP, sub_value) for sub_value in value
-            ]
+            nodes = [FilterNode(name, _EQ_OP, sub_value) for sub_value in value]
             if not nodes:
                 return FalseNode()
             if len(nodes) == 1:
@@ -730,9 +719,7 @@ class FilterNode(Node):
                 "to a single filter ({!r})".format(self._opsymbol)
             )
 
-        return _datastore_query.make_filter(
-            self._name, self._opsymbol, self._value
-        )
+        return _datastore_query.make_filter(self._name, self._opsymbol, self._value)
 
 
 class PostFilterNode(Node):
@@ -1191,9 +1178,7 @@ def _query_options(wrapped):
 
         if kwargs.get("keys_only"):
             if kwargs.get("projection"):
-                raise TypeError(
-                    "Cannot specify 'projection' with 'keys_only=True'"
-                )
+                raise TypeError("Cannot specify 'projection' with 'keys_only=True'")
             kwargs["projection"] = ["__key__"]
             del kwargs["keys_only"]
 
@@ -1392,14 +1377,12 @@ class Query(object):
                 if isinstance(ancestor, ParameterizedFunction):
                     if ancestor.func != "key":
                         raise TypeError(
-                            "ancestor cannot be a GQL function"
-                            "other than Key"
+                            "ancestor cannot be a GQL function" "other than Key"
                         )
             else:
                 if not isinstance(ancestor, model.Key):
                     raise TypeError(
-                        "ancestor must be a Key; "
-                        "received {}".format(ancestor)
+                        "ancestor must be a Key; " "received {}".format(ancestor)
                     )
                 if not ancestor.id():
                     raise ValueError("ancestor cannot be an incomplete key")
@@ -1499,13 +1482,9 @@ class Query(object):
         if self.keys_only is not None:
             args.append("keys_only=%r" % self.keys_only)
         if self.projection:
-            args.append(
-                "projection=%r" % (_to_property_names(self.projection))
-            )
+            args.append("projection=%r" % (_to_property_names(self.projection)))
         if self.distinct_on:
-            args.append(
-                "distinct_on=%r" % (_to_property_names(self.distinct_on))
-            )
+            args.append("distinct_on=%r" % (_to_property_names(self.distinct_on)))
         if self.default_options is not None:
             args.append("default_options=%r" % self.default_options)
         return "%s(%s)" % (self.__class__.__name__, ", ".join(args))
@@ -2303,9 +2282,7 @@ class Query(object):
                 result returned, and `more` indicates whether there are
                 (likely) more results after that.
         """
-        return self.fetch_page_async(
-            None, _options=kwargs["_options"]
-        ).result()
+        return self.fetch_page_async(None, _options=kwargs["_options"]).result()
 
     @tasklets.tasklet
     @_query_options
@@ -2395,8 +2372,7 @@ def _to_property_names(properties):
             fixed.append(prop._name)
         else:
             raise TypeError(
-                "Unexpected property {}; "
-                "should be string or Property".format(prop)
+                "Unexpected property {}; " "should be string or Property".format(prop)
             )
     return fixed
 

--- a/google/cloud/ndb/stats.py
+++ b/google/cloud/ndb/stats.py
@@ -403,9 +403,7 @@ class NamespaceKindPropertyNameStat(KindPropertyNameStat):
     STORED_KIND_NAME = "__Stat_Ns_PropertyName_Kind__"
 
 
-class NamespaceKindPropertyNamePropertyTypeStat(
-    KindPropertyNamePropertyTypeStat
-):
+class NamespaceKindPropertyNamePropertyTypeStat(KindPropertyNamePropertyTypeStat):
     """KindPropertyNamePropertyTypeStat equivalent for a specific namespace.
 
     These may be found in each specific namespace and represent stats for that

--- a/google/cloud/ndb/tasklets.py
+++ b/google/cloud/ndb/tasklets.py
@@ -124,9 +124,7 @@ class Future(object):
         """
         while not self._done:
             if not _eventloop.run1():
-                raise RuntimeError(
-                    "Eventloop is exhausted with unfinished futures."
-                )
+                raise RuntimeError("Eventloop is exhausted with unfinished futures.")
 
     def check_success(self):
         """Check whether a future has completed without raising an exception.
@@ -310,9 +308,7 @@ class _TaskletFuture(Future):
                     except AttributeError:  # pragma: NO PY3 COVER  # pragma: NO BRANCH  # noqa: E501
                         traceback = None
 
-                    yielded = self.generator.throw(
-                        type(error), error, traceback
-                    )
+                    yielded = self.generator.throw(type(error), error, traceback)
 
                 else:
                     # send_value will be None if this is the first time
@@ -355,9 +351,7 @@ class _TaskletFuture(Future):
 
             error = yielded.exception()
             if error:
-                self.context.eventloop.call_soon(
-                    self._advance_tasklet, error=error
-                )
+                self.context.eventloop.call_soon(self._advance_tasklet, error=error)
             else:
                 self.context.eventloop.call_soon(
                     self._advance_tasklet, yielded.result()
@@ -527,9 +521,7 @@ def wait_any(futures):
                 return future
 
         if not _eventloop.run1():
-            raise RuntimeError(
-                "Eventloop is exhausted with unfinished futures."
-            )
+            raise RuntimeError("Eventloop is exhausted with unfinished futures.")
 
 
 def wait_all(futures):

--- a/noxfile.py
+++ b/noxfile.py
@@ -28,7 +28,8 @@ DEFAULT_INTERPRETER = "3.7"
 ALL_INTERPRETERS = ("2.7", "3.6", "3.7")
 PY3_INTERPRETERS = ("3.6", "3.7")
 MAJOR_INTERPRETERS = ("2.7", "3.7")
-BLACK_VERSION = "black==19.10b0"
+
+BLACK_VERSION = "black==20.8b1"
 
 
 def get_path(*names):
@@ -84,7 +85,6 @@ def run_black(session, use_check=False):
 
     args.extend(
         [
-            "--line-length=79",
             get_path("docs"),
             get_path("noxfile.py"),
             get_path("google"),
@@ -119,9 +119,7 @@ def docs(session):
     """Build the docs for this library."""
 
     session.install("-e", ".")
-    session.install(
-        "sphinx", "alabaster", "recommonmark", "sphinxcontrib.spelling"
-    )
+    session.install("sphinx", "alabaster", "recommonmark", "sphinxcontrib.spelling")
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(
@@ -190,6 +188,4 @@ def system(session):
     if system_test_exists:
         session.run("py.test", "--quiet", system_test_path, *session.posargs)
     if system_test_folder_exists:
-        session.run(
-            "py.test", "--quiet", system_test_folder_path, *session.posargs
-        )
+        session.run("py.test", "--quiet", system_test_folder_path, *session.posargs)

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -78,9 +78,7 @@ def with_ds_client(ds_client, to_delete, deleted_keys, other_namespace):
         if entity.key not in deleted_keys
     ]
     if not_deleted:
-        log.warning(
-            "CLEAN UP: Entities not deleted from test: {}".format(not_deleted)
-        )
+        log.warning("CLEAN UP: Entities not deleted from test: {}".format(not_deleted))
 
 
 @pytest.fixture
@@ -137,7 +135,9 @@ def other_namespace():
 def client_context(namespace):
     client = ndb.Client()
     context_manager = client.context(
-        cache_policy=False, legacy_data=False, namespace=namespace,
+        cache_policy=False,
+        legacy_data=False,
+        namespace=namespace,
     )
     with context_manager as context:
         yield context

--- a/tests/system/test_crud.py
+++ b/tests/system/test_crud.py
@@ -449,10 +449,7 @@ def test_retrieve_entity_with_legacy_compressed_property(
     compressed_value = zlib.compress(value)
     entity_id = test_utils.system.unique_resource_id()
     ds_entity_with_meanings(
-        {"blob": (22, compressed_value)},
-        KIND,
-        entity_id,
-        **{"blob": compressed_value}
+        {"blob": (22, compressed_value)}, KIND, entity_id, **{"blob": compressed_value}
     )
 
     key = ndb.Key(KIND, entity_id)
@@ -766,9 +763,7 @@ def test_delete_entity_in_transaction(ds_entity):
     assert key.get() is None
 
 
-def test_delete_entity_in_transaction_with_global_cache(
-    client_context, ds_entity
-):
+def test_delete_entity_in_transaction_with_global_cache(client_context, ds_entity):
     """Regression test for #426
 
     https://github.com/googleapis/python-ndb/issues/426
@@ -952,9 +947,7 @@ def test_retrieve_entity_with_legacy_structured_property(ds_entity):
         bar = ndb.StructuredProperty(OtherKind)
 
     entity_id = test_utils.system.unique_resource_id()
-    ds_entity(
-        KIND, entity_id, **{"foo": 42, "bar.one": "hi", "bar.two": "mom"}
-    )
+    ds_entity(KIND, entity_id, **{"foo": 42, "bar.one": "hi", "bar.two": "mom"})
 
     key = ndb.Key(KIND, entity_id)
     retrieved = key.get()
@@ -1398,9 +1391,7 @@ def test_serialization(dispose_of):
         def _get_kind(cls):
             return "SomeKind"
 
-    entity = SomeKind(
-        other=OtherKind(foo=1, namespace="Test"), namespace="Test"
-    )
+    entity = SomeKind(other=OtherKind(foo=1, namespace="Test"), namespace="Test")
     key = entity.put()
     dispose_of(key._key)
 

--- a/tests/system/test_metadata.py
+++ b/tests/system/test_metadata.py
@@ -88,10 +88,7 @@ def test_get_kinds(dispose_of):
 
     kinds = eventually(get_kinds, _length_at_least(4))
     assert (
-        all(
-            kind in kinds
-            for kind in ["AnyKind", "MyKind", "OtherKind", "SomeKind"]
-        )
+        all(kind in kinds for kind in ["AnyKind", "MyKind", "OtherKind", "SomeKind"])
         != []
     )
 
@@ -131,11 +128,7 @@ def test_namespace_metadata(dispose_of):
 
     names = [result.namespace_name for result in results]
     assert (
-        all(
-            name in names
-            for name in ["_test_namespace_", "_test_namespace_2_"]
-        )
-        != []
+        all(name in names for name in ["_test_namespace_", "_test_namespace_2_"]) != []
     )
 
 
@@ -161,21 +154,16 @@ def test_get_namespaces(dispose_of):
     names = eventually(get_namespaces, _length_at_least(3))
     assert (
         all(
-            name in names
-            for name in ["CoolNamespace", "MyNamespace", "OtherNamespace"]
+            name in names for name in ["CoolNamespace", "MyNamespace", "OtherNamespace"]
         )
         != []
     )
 
     names = get_namespaces(start="L")
-    assert (
-        all(name in names for name in ["MyNamespace", "OtherNamspace"]) != []
-    )
+    assert all(name in names for name in ["MyNamespace", "OtherNamspace"]) != []
 
     names = get_namespaces(end="N")
-    assert (
-        all(name in names for name in ["CoolNamespace", "MyNamespace"]) != []
-    )
+    assert all(name in names for name in ["CoolNamespace", "MyNamespace"]) != []
 
     names = get_namespaces(start="D", end="N")
     assert all(name in names for name in ["MyNamespace"]) != []
@@ -200,9 +188,7 @@ def test_property_metadata(dispose_of):
     results = eventually(query.fetch, _length_at_least(2))
 
     properties = [
-        result.property_name
-        for result in results
-        if result.kind_name == "AnyKind"
+        result.property_name for result in results if result.kind_name == "AnyKind"
     ]
     assert properties == ["bar", "foo"]
 
@@ -248,9 +234,7 @@ def test_get_properties_of_kind_different_namespace(dispose_of, namespace):
         baz = ndb.IntegerProperty()
         qux = ndb.StringProperty()
 
-    entity1 = AnyKind(
-        foo=1, bar="x", baz=3, qux="y", namespace="DiffNamespace"
-    )
+    entity1 = AnyKind(foo=1, bar="x", baz=3, qux="y", namespace="DiffNamespace")
     entity1.put()
     dispose_of(entity1.key._key)
 
@@ -301,7 +285,5 @@ def test_get_representations_of_kind(dispose_of):
     representations = get_representations_of_kind("AnyKind", end="e")
     assert representations == {"bar": ["STRING"], "baz": ["INT64"]}
 
-    representations = get_representations_of_kind(
-        "AnyKind", start="c", end="p"
-    )
+    representations = get_representations_of_kind("AnyKind", start="c", end="p")
     assert representations == {"foo": ["INT64"]}

--- a/tests/system/test_misc.py
+++ b/tests/system/test_misc.py
@@ -334,9 +334,7 @@ def test_do_not_disclose_cache_contents(begin_transaction, client_context):
 
     https://github.com/googleapis/python-ndb/issues/482
     """
-    begin_transaction.side_effect = core_exceptions.ServiceUnavailable(
-        "Spurious Error"
-    )
+    begin_transaction.side_effect = core_exceptions.ServiceUnavailable("Spurious Error")
 
     client_context.cache["hello dad"] = "i'm in jail"
 

--- a/tests/system/test_query.py
+++ b/tests/system/test_query.py
@@ -336,9 +336,7 @@ def test_query_default_namespace_when_context_namespace_is_other(
     entity2.put()
     dispose_of(entity2.key._key)
 
-    eventually(
-        SomeKind.query(namespace=other_namespace).fetch, length_equals(1)
-    )
+    eventually(SomeKind.query(namespace=other_namespace).fetch, length_equals(1))
 
     with client_context.new(namespace=other_namespace).use():
         query = SomeKind.query(namespace="")
@@ -743,9 +741,7 @@ def test_fetch_page(dispose_of):
 
     safe_cursor = cursor.urlsafe()
     next_cursor = ndb.Cursor(urlsafe=safe_cursor)
-    results, cursor, more = query.fetch_page(
-        page_size, start_cursor=next_cursor
-    )
+    results, cursor, more = query.fetch_page(page_size, start_cursor=next_cursor)
     assert [entity.foo for entity in results] == [5, 6, 7, 8, 9]
 
     results, cursor, more = query.fetch_page(page_size, start_cursor=cursor)
@@ -860,12 +856,8 @@ def test_query_structured_property(dispose_of):
 
     @ndb.synctasklet
     def make_entities():
-        entity1 = SomeKind(
-            foo=1, bar=OtherKind(one="pish", two="posh", three="pash")
-        )
-        entity2 = SomeKind(
-            foo=2, bar=OtherKind(one="pish", two="posh", three="push")
-        )
+        entity1 = SomeKind(foo=1, bar=OtherKind(one="pish", two="posh", three="pash"))
+        entity2 = SomeKind(foo=2, bar=OtherKind(one="pish", two="posh", three="push"))
         entity3 = SomeKind(
             foo=3,
             bar=OtherKind(one="pish", two="moppish", three="pass the peas"),
@@ -908,12 +900,8 @@ def test_query_structured_property_legacy_data(client_context, dispose_of):
 
     @ndb.synctasklet
     def make_entities():
-        entity1 = SomeKind(
-            foo=1, bar=OtherKind(one="pish", two="posh", three="pash")
-        )
-        entity2 = SomeKind(
-            foo=2, bar=OtherKind(one="pish", two="posh", three="push")
-        )
+        entity1 = SomeKind(foo=1, bar=OtherKind(one="pish", two="posh", three="pash"))
+        entity2 = SomeKind(foo=2, bar=OtherKind(one="pish", two="posh", three="push"))
         entity3 = SomeKind(
             foo=3,
             bar=OtherKind(one="pish", two="moppish", three="pass the peas"),
@@ -1008,12 +996,8 @@ def test_query_structured_property_with_projection(dispose_of):
 
     @ndb.synctasklet
     def make_entities():
-        entity1 = SomeKind(
-            foo=1, bar=OtherKind(one="pish", two="posh", three="pash")
-        )
-        entity2 = SomeKind(
-            foo=2, bar=OtherKind(one="bish", two="bosh", three="bush")
-        )
+        entity1 = SomeKind(foo=1, bar=OtherKind(one="pish", two="posh", three="pash"))
+        entity2 = SomeKind(foo=2, bar=OtherKind(one="bish", two="bosh", three="bush"))
         entity3 = SomeKind(
             foo=3,
             bar=OtherKind(one="pish", two="moppish", three="pass the peas"),
@@ -1368,9 +1352,7 @@ def test_query_repeated_structured_property_with_projection(dispose_of):
         dispose_of(key._key)
 
     eventually(SomeKind.query().fetch, length_equals(3))
-    query = SomeKind.query(projection=("bar.one", "bar.two")).filter(
-        SomeKind.foo < 2
-    )
+    query = SomeKind.query(projection=("bar.one", "bar.two")).filter(SomeKind.foo < 2)
 
     # This counter-intuitive result is consistent with Legacy NDB behavior and
     # is a result of the odd way Datastore handles projection queries with
@@ -1757,9 +1739,7 @@ def test_projection_with_json_property(dispose_of):
 def test_DateTime(ds_entity):
     for i in range(5):
         entity_id = test_utils.system.unique_resource_id()
-        ds_entity(
-            KIND, entity_id, foo=datetime.datetime(2020, i + 1, 1, 12, 0, 0)
-        )
+        ds_entity(KIND, entity_id, foo=datetime.datetime(2020, i + 1, 1, 12, 0, 0))
 
     class SomeKind(ndb.Model):
         foo = ndb.DateTimeProperty()
@@ -1797,9 +1777,7 @@ def test_Date(ds_entity):
 def test_Time(ds_entity):
     for i in range(5):
         entity_id = test_utils.system.unique_resource_id()
-        ds_entity(
-            KIND, entity_id, foo=datetime.datetime(1970, 1, 1, i + 1, 0, 0)
-        )
+        ds_entity(KIND, entity_id, foo=datetime.datetime(1970, 1, 1, i + 1, 0, 0))
 
     class SomeKind(ndb.Model):
         foo = ndb.TimeProperty()

--- a/tests/unit/test__cache.py
+++ b/tests/unit/test__cache.py
@@ -161,9 +161,7 @@ class Test_global_set:
     def test_without_expires(_batch):
         batch = _batch.get_batch.return_value
         assert _cache.global_set(b"key", b"value") is batch.add.return_value
-        _batch.get_batch.assert_called_once_with(
-            _cache._GlobalCacheSetBatch, {}
-        )
+        _batch.get_batch.assert_called_once_with(_cache._GlobalCacheSetBatch, {})
         batch.add.assert_called_once_with(b"key", b"value")
 
     @staticmethod
@@ -211,9 +209,7 @@ class Test_GlobalCacheSetBatch:
         with in_context.new(global_cache=cache).use():
             batch.idle_callback()
 
-        cache.set.assert_called_once_with(
-            {b"foo": b"one", b"bar": b"two"}, expires=5
-        )
+        cache.set.assert_called_once_with({b"foo": b"one", b"bar": b"two"}, expires=5)
         assert future1.result() is None
         assert future2.result() is None
 
@@ -294,8 +290,7 @@ class Test_global_compare_and_swap:
     def test_without_expires(_batch):
         batch = _batch.get_batch.return_value
         assert (
-            _cache.global_compare_and_swap(b"key", b"value")
-            is batch.add.return_value
+            _cache.global_compare_and_swap(b"key", b"value") is batch.add.return_value
         )
         _batch.get_batch.assert_called_once_with(
             _cache._GlobalCacheCompareAndSwapBatch, {}

--- a/tests/unit/test__datastore_api.py
+++ b/tests/unit/test__datastore_api.py
@@ -181,9 +181,7 @@ class Test_make_call:
 
 def _mock_key(key_str):
     key = mock.Mock(kind="SomeKind", spec=("to_protobuf", "kind"))
-    key.to_protobuf.return_value = protobuf = mock.Mock(
-        spec=("SerializeToString",)
-    )
+    key.to_protobuf.return_value = protobuf = mock.Mock(spec=("SerializeToString",))
     protobuf.SerializeToString.return_value = key_str
     return key
 
@@ -237,9 +235,7 @@ class Test_lookup:
             _api.lookup(_mock_key("foo"), _options.ReadOptions())
             _api.lookup(_mock_key("bar"), _options.ReadOptions())
 
-            batch = new_context.batches[_api._LookupBatch][
-                (("transaction", b"tx123"),)
-            ]
+            batch = new_context.batches[_api._LookupBatch][(("transaction", b"tx123"),)]
             assert len(batch.todo["foo"]) == 2
             assert len(batch.todo["bar"]) == 1
             assert new_context.eventloop.add_idle.call_count == 1
@@ -286,9 +282,7 @@ class Test_lookup_WithGlobalCache:
         batch = _LookupBatch.return_value
         batch.add.side_effect = Exception("Shouldn't use Datastore")
 
-        future = _api.lookup(
-            key._key, _options.ReadOptions(use_datastore=False)
-        )
+        future = _api.lookup(key._key, _options.ReadOptions(use_datastore=False))
         assert future.result() is _api._NOT_FOUND
 
         assert global_cache.get([cache_key]) == [None]
@@ -378,9 +372,7 @@ class Test_LookupBatch:
             batch.idle_callback()
 
             called_with = _datastore_lookup.call_args[0]
-            called_with_keys = set(
-                (mock_key.key for mock_key in called_with[0])
-            )
+            called_with_keys = set((mock_key.key for mock_key in called_with[0]))
             assert called_with_keys == set(["foo", "bar"])
             called_with_options = called_with[1]
             assert called_with_options == datastore_pb2.ReadOptions()
@@ -507,9 +499,7 @@ class Test_LookupBatch:
         with context.new(eventloop=eventloop).use() as context:
             future1, future2, future3 = (tasklets.Future() for _ in range(3))
             batch = _api._LookupBatch(_options.ReadOptions())
-            batch.todo.update(
-                {"foo": [future1], "bar": [future2], "baz": [future3]}
-            )
+            batch.todo.update({"foo": [future1], "bar": [future2], "baz": [future3]})
 
             entity1 = mock.Mock(key=key_pb("foo"), spec=("key",))
             entity2 = mock.Mock(key=key_pb("bar"), spec=("key",))
@@ -545,9 +535,7 @@ def test__datastore_lookup(datastore_pb2, context):
         future = tasklets.Future()
         future.set_result("response")
         Lookup.future.return_value = future
-        assert (
-            _api._datastore_lookup(["foo", "bar"], None).result() == "response"
-        )
+        assert _api._datastore_lookup(["foo", "bar"], None).result() == "response"
 
         datastore_pb2.LookupRequest.assert_called_once_with(
             project_id="theproject", keys=["foo", "bar"], read_options=None
@@ -563,8 +551,7 @@ class Test_get_read_options:
     @pytest.mark.usefixtures("in_context")
     def test_no_args_no_transaction():
         assert (
-            _api.get_read_options(_options.ReadOptions())
-            == datastore_pb2.ReadOptions()
+            _api.get_read_options(_options.ReadOptions()) == datastore_pb2.ReadOptions()
         )
 
     @staticmethod
@@ -576,9 +563,7 @@ class Test_get_read_options:
     @staticmethod
     def test_args_override_transaction(context):
         with context.new(transaction=b"txfoo").use():
-            options = _api.get_read_options(
-                _options.ReadOptions(transaction=b"txbar")
-            )
+            options = _api.get_read_options(_options.ReadOptions(transaction=b"txbar"))
             assert options == datastore_pb2.ReadOptions(transaction=b"txbar")
 
     @staticmethod
@@ -682,9 +667,7 @@ class Test_put:
 
         mock_entity = MockEntity("what", "ever")
         with pytest.raises(TypeError):
-            _api.put(
-                mock_entity, _options.Options(use_datastore=False)
-            ).result()
+            _api.put(mock_entity, _options.Options(use_datastore=False)).result()
 
 
 class Test_put_WithGlobalCache:
@@ -701,9 +684,7 @@ class Test_put_WithGlobalCache:
         batch = Batch.return_value
         batch.put.return_value = future_result(None)
 
-        future = _api.put(
-            model._entity_to_ds_entity(entity), _options.Options()
-        )
+        future = _api.put(model._entity_to_ds_entity(entity), _options.Options())
         assert future.result() is None
 
         assert global_cache.get([cache_key]) == [None]
@@ -722,9 +703,7 @@ class Test_put_WithGlobalCache:
         batch = Batch.return_value
         batch.put.return_value = future_result(key_pb)
 
-        future = _api.put(
-            model._entity_to_ds_entity(entity), _options.Options()
-        )
+        future = _api.put(model._entity_to_ds_entity(entity), _options.Options())
         assert future.result() == key._key
 
         assert global_cache.get([cache_key]) == [None]
@@ -862,9 +841,7 @@ class Test_delete_WithGlobalCache:
         batch = Batch.return_value
         batch.delete.return_value = future_result(None)
 
-        future = _api.delete(
-            key._key, _options.Options(use_global_cache=False)
-        )
+        future = _api.delete(key._key, _options.Options(use_global_cache=False))
         assert future.result() is None
 
         assert global_cache.get([cache_key]) == [None]
@@ -960,18 +937,10 @@ class Test__TransactionalCommitBatch:
                 mock.Mock(
                     keys=[
                         entity_pb2.Key(
-                            path=[
-                                entity_pb2.Key.PathElement(
-                                    kind="SomeKind", id=1
-                                )
-                            ]
+                            path=[entity_pb2.Key.PathElement(kind="SomeKind", id=1)]
                         ),
                         entity_pb2.Key(
-                            path=[
-                                entity_pb2.Key.PathElement(
-                                    kind="SomeKind", id=2
-                                )
-                            ]
+                            path=[entity_pb2.Key.PathElement(kind="SomeKind", id=2)]
                         ),
                     ]
                 )
@@ -1070,9 +1039,7 @@ class Test__TransactionalCommitBatch:
     @staticmethod
     @mock.patch("google.cloud.ndb._datastore_api._process_commit")
     @mock.patch("google.cloud.ndb._datastore_api._datastore_commit")
-    def test_commit_allocating_ids(
-        datastore_commit, process_commit, in_context
-    ):
+    def test_commit_allocating_ids(datastore_commit, process_commit, in_context):
         batch = _api._TransactionalCommitBatch(b"123", _options.Options())
         batch.futures = object()
         batch.mutations = object()
@@ -1202,9 +1169,7 @@ class Test_datastore_commit:
         future = tasklets.Future()
         future.set_result("response")
         api.Commit.future.return_value = future
-        assert (
-            _api._datastore_commit(mutations, b"tx123").result() == "response"
-        )
+        assert _api._datastore_commit(mutations, b"tx123").result() == "response"
 
         datastore_pb2.CommitRequest.assert_called_once_with(
             project_id="testing",
@@ -1261,9 +1226,7 @@ class Test_AllocateIdsBatch:
             key_pbs, retries=None, timeout=None
         )
         rpc = _datastore_allocate_ids.return_value
-        rpc.add_done_callback.assert_called_once_with(
-            batch.allocate_ids_callback
-        )
+        rpc.add_done_callback.assert_called_once_with(batch.allocate_ids_callback)
 
     @staticmethod
     @mock.patch("google.cloud.ndb._datastore_api._datastore_allocate_ids")
@@ -1271,9 +1234,7 @@ class Test_AllocateIdsBatch:
         options = _options.Options()
         batch = _api._AllocateIdsBatch(options)
         batch.futures = futures = [tasklets.Future(), tasklets.Future()]
-        rpc = utils.future_result(
-            mock.Mock(keys=["key1", "key2"], spec=("key",))
-        )
+        rpc = utils.future_result(mock.Mock(keys=["key1", "key2"], spec=("key",)))
         batch.allocate_ids_callback(rpc)
         results = [future.result() for future in futures]
         assert results == ["key1", "key2"]
@@ -1380,9 +1341,7 @@ def test_rollback(_datastore_rollback):
     _datastore_rollback.return_value = rpc
     future = _api.rollback(b"tx123")
 
-    _datastore_rollback.assert_called_once_with(
-        b"tx123", retries=None, timeout=None
-    )
+    _datastore_rollback.assert_called_once_with(b"tx123", retries=None, timeout=None)
     rpc.set_result(None)
 
     assert future.result() is None

--- a/tests/unit/test__datastore_query.py
+++ b/tests/unit/test__datastore_query.py
@@ -61,8 +61,7 @@ def test_make_composite_and_filter():
     expected = query_pb2.CompositeFilter(
         op=query_pb2.CompositeFilter.AND,
         filters=[
-            query_pb2.Filter(property_filter=sub_filter)
-            for sub_filter in filters
+            query_pb2.Filter(property_filter=sub_filter) for sub_filter in filters
         ],
     )
     assert _datastore_query.make_composite_and_filter(filters) == expected
@@ -107,14 +106,10 @@ class Test_iterate:
         QueryIterator.assert_called_once_with(query, raw=False)
 
     @staticmethod
-    @mock.patch(
-        "google.cloud.ndb._datastore_query._PostFilterQueryIteratorImpl"
-    )
+    @mock.patch("google.cloud.ndb._datastore_query._PostFilterQueryIteratorImpl")
     def test_iterate_single_with_post_filter(QueryIterator):
         query = mock.Mock(
-            filters=mock.Mock(
-                _multiquery=False, spec=("_multiquery", "_post_filters")
-            ),
+            filters=mock.Mock(_multiquery=False, spec=("_multiquery", "_post_filters")),
             spec=("filters", "_post_filters"),
         )
         iterator = QueryIterator.return_value
@@ -204,9 +199,7 @@ class Test_QueryIteratorImpl:
     @staticmethod
     def test_has_next():
         iterator = _datastore_query._QueryIteratorImpl("foo")
-        iterator.has_next_async = mock.Mock(
-            return_value=utils.future_result("bar")
-        )
+        iterator.has_next_async = mock.Mock(return_value=utils.future_result("bar"))
         assert iterator.has_next() == "bar"
 
     @staticmethod
@@ -498,13 +491,9 @@ class Test_PostFilterQueryIteratorImpl:
     @staticmethod
     def test_constructor():
         foo = model.StringProperty("foo")
-        query = query_module.QueryOptions(
-            offset=20, limit=10, filters=foo == u"this"
-        )
+        query = query_module.QueryOptions(offset=20, limit=10, filters=foo == u"this")
         predicate = object()
-        iterator = _datastore_query._PostFilterQueryIteratorImpl(
-            query, predicate
-        )
+        iterator = _datastore_query._PostFilterQueryIteratorImpl(query, predicate)
         assert iterator._result_set._query == query_module.QueryOptions(
             filters=foo == u"this"
         )
@@ -515,21 +504,15 @@ class Test_PostFilterQueryIteratorImpl:
     @staticmethod
     def test_has_next():
         query = query_module.QueryOptions()
-        iterator = _datastore_query._PostFilterQueryIteratorImpl(
-            query, "predicate"
-        )
-        iterator.has_next_async = mock.Mock(
-            return_value=utils.future_result("bar")
-        )
+        iterator = _datastore_query._PostFilterQueryIteratorImpl(query, "predicate")
+        iterator.has_next_async = mock.Mock(return_value=utils.future_result("bar"))
         assert iterator.has_next() == "bar"
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
     def test_has_next_async_next_loaded():
         query = query_module.QueryOptions()
-        iterator = _datastore_query._PostFilterQueryIteratorImpl(
-            query, "predicate"
-        )
+        iterator = _datastore_query._PostFilterQueryIteratorImpl(query, "predicate")
         iterator._next_result = "foo"
         assert iterator.has_next_async().result()
 
@@ -540,9 +523,7 @@ class Test_PostFilterQueryIteratorImpl:
             return result.result % 2 == 0
 
         query = query_module.QueryOptions()
-        iterator = _datastore_query._PostFilterQueryIteratorImpl(
-            query, predicate
-        )
+        iterator = _datastore_query._PostFilterQueryIteratorImpl(query, predicate)
         iterator._result_set = MockResultSet([1, 2, 3, 4, 5, 6, 7])
 
         @tasklets.tasklet
@@ -592,9 +573,7 @@ class Test_PostFilterQueryIteratorImpl:
             return result.result % 2 == 0
 
         query = query_module.QueryOptions(offset=1, limit=2)
-        iterator = _datastore_query._PostFilterQueryIteratorImpl(
-            query, predicate
-        )
+        iterator = _datastore_query._PostFilterQueryIteratorImpl(query, predicate)
         iterator._result_set = MockResultSet([1, 2, 3, 4, 5, 6, 7, 8])
 
         @tasklets.tasklet
@@ -613,9 +592,7 @@ class Test_PostFilterQueryIteratorImpl:
     @pytest.mark.usefixtures("in_context")
     def test_probably_has_next_next_loaded():
         query = query_module.QueryOptions()
-        iterator = _datastore_query._PostFilterQueryIteratorImpl(
-            query, "predicate"
-        )
+        iterator = _datastore_query._PostFilterQueryIteratorImpl(query, "predicate")
         iterator._next_result = "foo"
         assert iterator.probably_has_next() is True
 
@@ -623,9 +600,7 @@ class Test_PostFilterQueryIteratorImpl:
     @pytest.mark.usefixtures("in_context")
     def test_probably_has_next_delegate():
         query = query_module.QueryOptions()
-        iterator = _datastore_query._PostFilterQueryIteratorImpl(
-            query, "predicate"
-        )
+        iterator = _datastore_query._PostFilterQueryIteratorImpl(query, "predicate")
         iterator._result_set._next_result = "foo"
         assert iterator.probably_has_next() is True
 
@@ -633,9 +608,7 @@ class Test_PostFilterQueryIteratorImpl:
     @pytest.mark.usefixtures("in_context")
     def test_probably_has_next_doesnt():
         query = query_module.QueryOptions()
-        iterator = _datastore_query._PostFilterQueryIteratorImpl(
-            query, "predicate"
-        )
+        iterator = _datastore_query._PostFilterQueryIteratorImpl(query, "predicate")
         iterator._result_set._batch = []
         iterator._result_set._index = 0
         assert iterator.probably_has_next() is False
@@ -644,9 +617,7 @@ class Test_PostFilterQueryIteratorImpl:
     @pytest.mark.usefixtures("in_context")
     def test_cursor_before():
         query = query_module.QueryOptions()
-        iterator = _datastore_query._PostFilterQueryIteratorImpl(
-            query, "predicate"
-        )
+        iterator = _datastore_query._PostFilterQueryIteratorImpl(query, "predicate")
         iterator._cursor_before = "himom"
         assert iterator.cursor_before() == "himom"
 
@@ -654,9 +625,7 @@ class Test_PostFilterQueryIteratorImpl:
     @pytest.mark.usefixtures("in_context")
     def test_cursor_before_no_cursor():
         query = query_module.QueryOptions()
-        iterator = _datastore_query._PostFilterQueryIteratorImpl(
-            query, "predicate"
-        )
+        iterator = _datastore_query._PostFilterQueryIteratorImpl(query, "predicate")
         with pytest.raises(exceptions.BadArgumentError):
             iterator.cursor_before()
 
@@ -664,9 +633,7 @@ class Test_PostFilterQueryIteratorImpl:
     @pytest.mark.usefixtures("in_context")
     def test_cursor_after():
         query = query_module.QueryOptions()
-        iterator = _datastore_query._PostFilterQueryIteratorImpl(
-            query, "predicate"
-        )
+        iterator = _datastore_query._PostFilterQueryIteratorImpl(query, "predicate")
         iterator._cursor_after = "himom"
         assert iterator.cursor_after() == "himom"
 
@@ -674,22 +641,16 @@ class Test_PostFilterQueryIteratorImpl:
     @pytest.mark.usefixtures("in_context")
     def test_cursor_after_no_cursor():
         query = query_module.QueryOptions()
-        iterator = _datastore_query._PostFilterQueryIteratorImpl(
-            query, "predicate"
-        )
+        iterator = _datastore_query._PostFilterQueryIteratorImpl(query, "predicate")
         with pytest.raises(exceptions.BadArgumentError):
             iterator.cursor_after()
 
     @staticmethod
     def test__more_results_after_limit():
         foo = model.StringProperty("foo")
-        query = query_module.QueryOptions(
-            offset=20, limit=10, filters=foo == u"this"
-        )
+        query = query_module.QueryOptions(offset=20, limit=10, filters=foo == u"this")
         predicate = object()
-        iterator = _datastore_query._PostFilterQueryIteratorImpl(
-            query, predicate
-        )
+        iterator = _datastore_query._PostFilterQueryIteratorImpl(query, predicate)
         assert iterator._result_set._query == query_module.QueryOptions(
             filters=foo == u"this"
         )
@@ -751,10 +712,14 @@ class Test_MultiQueryIteratorImpl:
         )
         iterator = _datastore_query._MultiQueryIteratorImpl(query)
         assert iterator._result_sets[0]._query == query_module.QueryOptions(
-            filters=foo == "this", order_by=order_by, projection=["foo"],
+            filters=foo == "this",
+            order_by=order_by,
+            projection=["foo"],
         )
         assert iterator._result_sets[1]._query == query_module.QueryOptions(
-            filters=foo == "that", order_by=order_by, projection=["foo"],
+            filters=foo == "that",
+            order_by=order_by,
+            projection=["foo"],
         )
         assert iterator._sortable
 
@@ -796,9 +761,7 @@ class Test_MultiQueryIteratorImpl:
             filters=query_module.OR(foo == "this", foo == "that")
         )
         iterator = _datastore_query._MultiQueryIteratorImpl(query)
-        iterator.has_next_async = mock.Mock(
-            return_value=utils.future_result("bar")
-        )
+        iterator.has_next_async = mock.Mock(return_value=utils.future_result("bar"))
         assert iterator.has_next() == "bar"
 
     @staticmethod
@@ -840,7 +803,8 @@ class Test_MultiQueryIteratorImpl:
         iterator._next_result = next_result = mock.Mock(
             result_pb=mock.Mock(
                 entity=mock.Mock(
-                    properties={"foo": 1, "bar": "two"}, spec=("properties",),
+                    properties={"foo": 1, "bar": "two"},
+                    spec=("properties",),
                 ),
                 spec=("entity",),
             ),
@@ -1197,9 +1161,7 @@ class Test_Result:
             model._entity_from_protobuf.return_value = entity
             result = _datastore_query._Result(
                 _datastore_query.RESULT_TYPE_FULL,
-                mock.Mock(
-                    entity=entity, cursor=b"123", spec=("entity", "cursor")
-                ),
+                mock.Mock(entity=entity, cursor=b"123", spec=("entity", "cursor")),
             )
             assert result.entity() is entity
 
@@ -1224,15 +1186,11 @@ class Test_Result:
     @mock.patch("google.cloud.ndb._datastore_query.model")
     def test_entity_projection(model):
         entity = mock.Mock(spec=("_set_projection",))
-        entity_pb = mock.Mock(
-            properties={"a": 0, "b": 1}, spec=("properties",)
-        )
+        entity_pb = mock.Mock(properties={"a": 0, "b": 1}, spec=("properties",))
         model._entity_from_protobuf.return_value = entity
         result = _datastore_query._Result(
             _datastore_query.RESULT_TYPE_PROJECTION,
-            mock.Mock(
-                entity=entity_pb, cursor=b"123", spec=("entity", "cursor")
-            ),
+            mock.Mock(entity=entity_pb, cursor=b"123", spec=("entity", "cursor")),
         )
 
         assert result.entity() is entity
@@ -1348,12 +1306,8 @@ class Test__query_to_protobuf:
         query = query_module.QueryOptions(projection=("a", "b"))
         expected_pb = query_pb2.Query(
             projection=[
-                query_pb2.Projection(
-                    property=query_pb2.PropertyReference(name="a")
-                ),
-                query_pb2.Projection(
-                    property=query_pb2.PropertyReference(name="b")
-                ),
+                query_pb2.Projection(property=query_pb2.PropertyReference(name="a")),
+                query_pb2.Projection(property=query_pb2.PropertyReference(name="b")),
             ]
         )
         assert _datastore_query._query_to_protobuf(query) == expected_pb
@@ -1411,9 +1365,7 @@ class Test__query_to_protobuf:
     @staticmethod
     def test_offset():
         query = query_module.QueryOptions(offset=20)
-        assert _datastore_query._query_to_protobuf(query) == query_pb2.Query(
-            offset=20
-        )
+        assert _datastore_query._query_to_protobuf(query) == query_pb2.Query(offset=20)
 
     @staticmethod
     def test_limit():
@@ -1424,18 +1376,14 @@ class Test__query_to_protobuf:
 
     @staticmethod
     def test_start_cursor():
-        query = query_module.QueryOptions(
-            start_cursor=_datastore_query.Cursor(b"abc")
-        )
+        query = query_module.QueryOptions(start_cursor=_datastore_query.Cursor(b"abc"))
         assert _datastore_query._query_to_protobuf(query) == query_pb2.Query(
             start_cursor=b"abc"
         )
 
     @staticmethod
     def test_end_cursor():
-        query = query_module.QueryOptions(
-            end_cursor=_datastore_query.Cursor(b"abc")
-        )
+        query = query_module.QueryOptions(end_cursor=_datastore_query.Cursor(b"abc"))
         assert _datastore_query._query_to_protobuf(query) == query_pb2.Query(
             end_cursor=b"abc"
         )
@@ -1452,9 +1400,7 @@ class Test__datastore_run_query:
         read_options = datastore_pb2.ReadOptions()
         request = datastore_pb2.RunQueryRequest(
             project_id="testing",
-            partition_id=entity_pb2.PartitionId(
-                project_id="testing", namespace_id=""
-            ),
+            partition_id=entity_pb2.PartitionId(project_id="testing", namespace_id=""),
             query=query_pb,
             read_options=read_options,
         )

--- a/tests/unit/test__gql.py
+++ b/tests/unit/test__gql.py
@@ -184,9 +184,7 @@ class TestGQL:
     @staticmethod
     def test_cast():
         gql = gql_module.GQL("SELECT * FROM SomeKind WHERE prop1=user('js')")
-        assert gql.filters() == {
-            ("prop1", "="): [("user", [gql_module.Literal("js")])]
-        }
+        assert gql.filters() == {("prop1", "="): [("user", [gql_module.Literal("js")])]}
 
     @staticmethod
     def test_in_list():
@@ -208,12 +206,8 @@ class TestGQL:
 
     @staticmethod
     def test_ancestor_is():
-        gql = gql_module.GQL(
-            "SELECT * FROM SomeKind WHERE ANCESTOR IS 'AnyKind'"
-        )
-        assert gql.filters() == {
-            (-1, "is"): [("nop", [gql_module.Literal("AnyKind")])]
-        }
+        gql = gql_module.GQL("SELECT * FROM SomeKind WHERE ANCESTOR IS 'AnyKind'")
+        assert gql.filters() == {(-1, "is"): [("nop", [gql_module.Literal("AnyKind")])]}
 
     @staticmethod
     def test_ancestor_multiple_ancestors():
@@ -243,37 +237,27 @@ class TestGQL:
     @staticmethod
     def test_null():
         gql = gql_module.GQL("SELECT * FROM SomeKind WHERE prop1=NULL")
-        assert gql.filters() == {
-            ("prop1", "="): [("nop", [gql_module.Literal(None)])]
-        }
+        assert gql.filters() == {("prop1", "="): [("nop", [gql_module.Literal(None)])]}
 
     @staticmethod
     def test_true():
         gql = gql_module.GQL("SELECT * FROM SomeKind WHERE prop1=TRUE")
-        assert gql.filters() == {
-            ("prop1", "="): [("nop", [gql_module.Literal(True)])]
-        }
+        assert gql.filters() == {("prop1", "="): [("nop", [gql_module.Literal(True)])]}
 
     @staticmethod
     def test_false():
         gql = gql_module.GQL("SELECT * FROM SomeKind WHERE prop1=FALSE")
-        assert gql.filters() == {
-            ("prop1", "="): [("nop", [gql_module.Literal(False)])]
-        }
+        assert gql.filters() == {("prop1", "="): [("nop", [gql_module.Literal(False)])]}
 
     @staticmethod
     def test_float():
         gql = gql_module.GQL("SELECT * FROM SomeKind WHERE prop1=3.14")
-        assert gql.filters() == {
-            ("prop1", "="): [("nop", [gql_module.Literal(3.14)])]
-        }
+        assert gql.filters() == {("prop1", "="): [("nop", [gql_module.Literal(3.14)])]}
 
     @staticmethod
     def test_quoted_identifier():
         gql = gql_module.GQL('SELECT * FROM SomeKind WHERE "prop1"=3.14')
-        assert gql.filters() == {
-            ("prop1", "="): [("nop", [gql_module.Literal(3.14)])]
-        }
+        assert gql.filters() == {("prop1", "="): [("nop", [gql_module.Literal(3.14)])]}
 
     @staticmethod
     def test_order_by_ascending():
@@ -334,9 +318,7 @@ class TestGQL:
         class SomeKind(model.Model):
             prop1 = model.IntegerProperty()
 
-        gql = gql_module.GQL(
-            "SELECT prop1 FROM SomeKind WHERE prop1 IN (1, 2, 3)"
-        )
+        gql = gql_module.GQL("SELECT prop1 FROM SomeKind WHERE prop1 IN (1, 2, 3)")
         query = gql.get_query()
         assert query.filters == query_module.OR(
             query_module.FilterNode("prop1", "=", 1),
@@ -350,9 +332,7 @@ class TestGQL:
         class SomeKind(model.Model):
             prop1 = model.StringProperty()
 
-        gql = gql_module.GQL(
-            "SELECT prop1 FROM SomeKind WHERE prop1 IN (:1, :2, :3)"
-        )
+        gql = gql_module.GQL("SELECT prop1 FROM SomeKind WHERE prop1 IN (:1, :2, :3)")
         query = gql.get_query()
         assert "'in'," in str(query.filters)
 
@@ -401,9 +381,7 @@ class TestGQL:
         class SomeKind(model.Model):
             prop1 = model.DateProperty()
 
-        gql = gql_module.GQL(
-            "SELECT prop1 FROM SomeKind WHERE prop1 = Date(:1)"
-        )
+        gql = gql_module.GQL("SELECT prop1 FROM SomeKind WHERE prop1 = Date(:1)")
         query = gql.get_query()
         assert "'date'" in str(query.filters)
 
@@ -425,9 +403,7 @@ class TestGQL:
         class SomeKind(model.Model):
             prop1 = model.DateProperty()
 
-        gql = gql_module.GQL(
-            "SELECT prop1 FROM SomeKind WHERE prop1 = Date(42)"
-        )
+        gql = gql_module.GQL("SELECT prop1 FROM SomeKind WHERE prop1 = Date(42)")
         with pytest.raises(exceptions.BadQueryError):
             gql.get_query()
 
@@ -491,9 +467,7 @@ class TestGQL:
         class SomeKind(model.Model):
             prop1 = model.DateTimeProperty()
 
-        gql = gql_module.GQL(
-            "SELECT prop1 FROM SomeKind WHERE prop1 = DateTime(:1)"
-        )
+        gql = gql_module.GQL("SELECT prop1 FROM SomeKind WHERE prop1 = DateTime(:1)")
         query = gql.get_query()
         assert "'datetime'" in str(query.filters)
 
@@ -515,9 +489,7 @@ class TestGQL:
         class SomeKind(model.Model):
             prop1 = model.DateTimeProperty()
 
-        gql = gql_module.GQL(
-            "SELECT prop1 FROM SomeKind WHERE prop1 = DateTime(42)"
-        )
+        gql = gql_module.GQL("SELECT prop1 FROM SomeKind WHERE prop1 = DateTime(42)")
         with pytest.raises(exceptions.BadQueryError):
             gql.get_query()
 
@@ -539,9 +511,7 @@ class TestGQL:
         class SomeKind(model.Model):
             prop1 = model.TimeProperty()
 
-        gql = gql_module.GQL(
-            "SELECT prop1 FROM SomeKind WHERE prop1 = Time(12, 45, 5)"
-        )
+        gql = gql_module.GQL("SELECT prop1 FROM SomeKind WHERE prop1 = Time(12, 45, 5)")
         query = gql.get_query()
         assert query.filters == query_module.FilterNode(
             "prop1", "=", datetime.datetime(1970, 1, 1, 12, 45, 5)
@@ -567,9 +537,7 @@ class TestGQL:
         class SomeKind(model.Model):
             prop1 = model.TimeProperty()
 
-        gql = gql_module.GQL(
-            "SELECT prop1 FROM SomeKind WHERE prop1 = Time(12)"
-        )
+        gql = gql_module.GQL("SELECT prop1 FROM SomeKind WHERE prop1 = Time(12)")
         query = gql.get_query()
         assert query.filters == query_module.FilterNode(
             "prop1", "=", datetime.datetime(1970, 1, 1, 12)
@@ -581,9 +549,7 @@ class TestGQL:
         class SomeKind(model.Model):
             prop1 = model.TimeProperty()
 
-        gql = gql_module.GQL(
-            "SELECT prop1 FROM SomeKind WHERE prop1 = Time(:1)"
-        )
+        gql = gql_module.GQL("SELECT prop1 FROM SomeKind WHERE prop1 = Time(:1)")
         query = gql.get_query()
         assert "'time'" in str(query.filters)
 
@@ -605,9 +571,7 @@ class TestGQL:
         class SomeKind(model.Model):
             prop1 = model.TimeProperty()
 
-        gql = gql_module.GQL(
-            "SELECT prop1 FROM SomeKind WHERE prop1 = Time(3.141592)"
-        )
+        gql = gql_module.GQL("SELECT prop1 FROM SomeKind WHERE prop1 = Time(3.141592)")
         with pytest.raises(exceptions.BadQueryError):
             gql.get_query()
 
@@ -655,9 +619,7 @@ class TestGQL:
         class SomeKind(model.Model):
             prop1 = model.GeoPtProperty()
 
-        gql = gql_module.GQL(
-            "SELECT prop1 FROM SomeKind WHERE prop1 = GeoPt(:1)"
-        )
+        gql = gql_module.GQL("SELECT prop1 FROM SomeKind WHERE prop1 = GeoPt(:1)")
         query = gql.get_query()
         assert "'geopt'" in str(query.filters)
 
@@ -668,8 +630,7 @@ class TestGQL:
             prop1 = model.GeoPtProperty()
 
         gql = gql_module.GQL(
-            "SELECT prop1 FROM SomeKind WHERE prop1 = "
-            "GeoPt(20.67,-100.32, 1.5)"
+            "SELECT prop1 FROM SomeKind WHERE prop1 = " "GeoPt(20.67,-100.32, 1.5)"
         )
         with pytest.raises(exceptions.BadQueryError):
             gql.get_query()
@@ -695,9 +656,7 @@ class TestGQL:
         class SomeKind(model.Model):
             prop1 = model.KeyProperty()
 
-        gql = gql_module.GQL(
-            "SELECT prop1 FROM SomeKind WHERE prop1 = Key(:1)"
-        )
+        gql = gql_module.GQL("SELECT prop1 FROM SomeKind WHERE prop1 = Key(:1)")
         query = gql.get_query()
         assert "'key'" in str(query.filters)
 

--- a/tests/unit/test__legacy_entity_pb.py
+++ b/tests/unit/test__legacy_entity_pb.py
@@ -78,9 +78,7 @@ class TestEntityProto:
     @staticmethod
     def test_TryMerge_mutable_key_path():
         entity = entity_module.EntityProto()
-        d = _get_decoder(
-            b"\x6a\x0c\x72\x0a\x0b\x12\x01\x44\x18\x01\x22\x01\x45\x0c"
-        )
+        d = _get_decoder(b"\x6a\x0c\x72\x0a\x0b\x12\x01\x44\x18\x01\x22\x01\x45\x0c")
         entity.TryMerge(d)
         assert entity.has_key()  # noqa: W601
         assert entity.key().has_path()
@@ -96,8 +94,7 @@ class TestEntityProto:
     def test_TryMerge_mutable_key_path_with_skip_data():
         entity = entity_module.EntityProto()
         d = _get_decoder(
-            b"\x6a\x0f\x72\x0d\x02\x01\x01\x0b\x12\x01\x44\x18\x01\x22\x01"
-            b"\x45\x0c"
+            b"\x6a\x0f\x72\x0d\x02\x01\x01\x0b\x12\x01\x44\x18\x01\x22\x01" b"\x45\x0c"
         )
         entity.TryMerge(d)
         assert entity.key().has_path()
@@ -113,8 +110,7 @@ class TestEntityProto:
     def test_TryMerge_mutable_key_path_element_with_skip_data():
         entity = entity_module.EntityProto()
         d = _get_decoder(
-            b"\x6a\x0f\x72\x0d\x0b\x02\x01\x01\x12\x01\x44\x18\x01\x22\x01"
-            b"\x45\x0c"
+            b"\x6a\x0f\x72\x0d\x0b\x02\x01\x01\x12\x01\x44\x18\x01\x22\x01" b"\x45\x0c"
         )
         entity.TryMerge(d)
         assert entity.key().has_path()
@@ -222,9 +218,7 @@ class TestEntityProto:
     @staticmethod
     def test_TryMerge_property_double():
         entity = entity_module.EntityProto()
-        d = _get_decoder(
-            b"\x72\x0e\x1a\x01\x46\x2a\x09\x21\x00\x00\x00\x00\x00\x00E@"
-        )
+        d = _get_decoder(b"\x72\x0e\x1a\x01\x46\x2a\x09\x21\x00\x00\x00\x00\x00\x00E@")
         entity.TryMerge(d)
         assert entity.entity_props()["F"] == 42.0
 
@@ -323,9 +317,7 @@ class TestEntityProto:
     @staticmethod
     def test_TryMerge_property_reference_name_space():
         entity = entity_module.EntityProto()
-        d = _get_decoder(
-            b"\x72\x0b\x1a\x01\x46\x2a\x06\x63\xa2\x01\x01\x41" b"\x64"
-        )
+        d = _get_decoder(b"\x72\x0b\x1a\x01\x46\x2a\x06\x63\xa2\x01\x01\x41" b"\x64")
         entity.TryMerge(d)
         assert entity.entity_props()["F"].has_name_space()
         assert entity.entity_props()["F"].name_space().decode() == "A"
@@ -333,9 +325,7 @@ class TestEntityProto:
     @staticmethod
     def test_TryMerge_property_reference_database_id():
         entity = entity_module.EntityProto()
-        d = _get_decoder(
-            b"\x72\x0b\x1a\x01\x46\x2a\x06\x63\xba\x01\x01\x41" b"\x64"
-        )
+        d = _get_decoder(b"\x72\x0b\x1a\x01\x46\x2a\x06\x63\xba\x01\x01\x41" b"\x64")
         entity.TryMerge(d)
         assert entity.entity_props()["F"].has_database_id()
         assert entity.entity_props()["F"].database_id().decode() == "A"
@@ -381,9 +371,7 @@ class TestEntityProto:
     @staticmethod
     def test_TryMerge_with_skip_data():
         entity = entity_module.EntityProto()
-        d = _get_decoder(
-            b"\x02\x01\x01\x7a\x08\x1a\x01\x46\x2a\x03\x1a\x01" b"\x47"
-        )
+        d = _get_decoder(b"\x02\x01\x01\x7a\x08\x1a\x01\x46\x2a\x03\x1a\x01" b"\x47")
         entity.TryMerge(d)
         assert entity.entity_props()["F"].decode() == "G"
 

--- a/tests/unit/test__options.py
+++ b/tests/unit/test__options.py
@@ -139,9 +139,7 @@ class TestOptions:
     @staticmethod
     def test_items():
         options = MyOptions(retries=8, bar="app")
-        items = [
-            (key, value) for key, value in options.items() if value is not None
-        ]
+        items = [(key, value) for key, value in options.items() if value is not None]
         assert items == [("bar", "app"), ("retries", 8)]
 
     @staticmethod
@@ -184,12 +182,8 @@ class TestOptions:
 class TestReadOptions:
     @staticmethod
     def test_constructor_w_read_policy():
-        options = _options.ReadOptions(
-            read_policy=_datastore_api.EVENTUAL_CONSISTENCY
-        )
-        assert options == _options.ReadOptions(
-            read_consistency=_datastore_api.EVENTUAL
-        )
+        options = _options.ReadOptions(read_policy=_datastore_api.EVENTUAL_CONSISTENCY)
+        assert options == _options.ReadOptions(read_consistency=_datastore_api.EVENTUAL)
 
     @staticmethod
     def test_constructor_w_read_policy_and_read_consistency():

--- a/tests/unit/test__transaction.py
+++ b/tests/unit/test__transaction.py
@@ -101,9 +101,7 @@ class Test_transaction_async:
 
         future = _transaction.transaction_async(callback)
 
-        _datastore_api.begin_transaction.assert_called_once_with(
-            False, retries=0
-        )
+        _datastore_api.begin_transaction.assert_called_once_with(False, retries=0)
         begin_future.set_result(b"tx123")
 
         _datastore_api.commit.assert_called_once_with(b"tx123", retries=0)
@@ -150,9 +148,7 @@ class Test_transaction_async:
 
         future = _transaction.transaction_async(callback, retries=0)
 
-        _datastore_api.begin_transaction.assert_called_once_with(
-            False, retries=0
-        )
+        _datastore_api.begin_transaction.assert_called_once_with(False, retries=0)
         begin_future.set_result(b"tx123")
 
         _datastore_api.commit.assert_called_once_with(b"tx123", retries=0)
@@ -177,9 +173,7 @@ class Test_transaction_async:
 
         future = _transaction.transaction_async(callback)
 
-        _datastore_api.begin_transaction.assert_called_once_with(
-            False, retries=0
-        )
+        _datastore_api.begin_transaction.assert_called_once_with(False, retries=0)
         begin_future.set_result(b"tx123")
 
         tasklet.set_result("I tried, momma.")
@@ -256,9 +250,7 @@ class Test_transaction_async:
 
         future = _transaction.transaction_async(callback)
 
-        _datastore_api.begin_transaction.assert_called_once_with(
-            False, retries=0
-        )
+        _datastore_api.begin_transaction.assert_called_once_with(False, retries=0)
         begin_future.set_result(b"tx123")
 
         _datastore_api.rollback.assert_called_once_with(b"tx123")
@@ -430,7 +422,7 @@ def test_non_transactional_in_transaction(in_context):
         assert res == 142
 
         with pytest.raises(exceptions.BadRequestError):
-            wrapped_function = _transaction.non_transactional(
-                allow_existing=False
-            )(simple_function)
+            wrapped_function = _transaction.non_transactional(allow_existing=False)(
+                simple_function
+            )
             wrapped_function(100, 42)

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -129,9 +129,7 @@ class TestContext:
         assert not context.cache
 
     def test__clear_global_cache(self):
-        context = self._make_one(
-            global_cache=global_cache._InProcessGlobalCache()
-        )
+        context = self._make_one(global_cache=global_cache._InProcessGlobalCache())
         with context.use():
             key = key_module.Key("SomeKind", 1)
             cache_key = _cache.global_cache_key(key._key)
@@ -143,9 +141,7 @@ class TestContext:
         assert context.global_cache.cache == {"anotherkey": "otherdata"}
 
     def test__clear_global_cache_nothing_to_do(self):
-        context = self._make_one(
-            global_cache=global_cache._InProcessGlobalCache()
-        )
+        context = self._make_one(global_cache=global_cache._InProcessGlobalCache())
         with context.use():
             context.global_cache.cache["anotherkey"] = "otherdata"
             context._clear_global_cache().result()
@@ -160,9 +156,7 @@ class TestContext:
 
     def test_get_cache_policy(self):
         context = self._make_one()
-        assert (
-            context.get_cache_policy() is context_module._default_cache_policy
-        )
+        assert context.get_cache_policy() is context_module._default_cache_policy
 
     def test_get_datastore_policy(self):
         context = self._make_one()
@@ -193,16 +187,14 @@ class TestContext:
         context = self._make_one()
         context.get_memcache_policy()
         assert (
-            context.get_memcache_policy()
-            is context_module._default_global_cache_policy
+            context.get_memcache_policy() is context_module._default_global_cache_policy
         )
 
     def test_get_global_cache_policy(self):
         context = self._make_one()
         context.get_global_cache_policy()
         assert (
-            context.get_memcache_policy()
-            is context_module._default_global_cache_policy
+            context.get_memcache_policy() is context_module._default_global_cache_policy
         )
 
     def test_get_memcache_timeout_policy(self):
@@ -228,9 +220,7 @@ class TestContext:
     def test_set_cache_policy_to_None(self):
         context = self._make_one()
         context.set_cache_policy(None)
-        assert (
-            context.get_cache_policy() is context_module._default_cache_policy
-        )
+        assert context.get_cache_policy() is context_module._default_cache_policy
 
     def test_set_cache_policy_with_bool(self):
         context = self._make_one()
@@ -260,10 +250,7 @@ class TestContext:
     def test_set_datastore_policy(self):
         context = self._make_one()
         context.set_datastore_policy(None)
-        assert (
-            context.datastore_policy
-            is context_module._default_datastore_policy
-        )
+        assert context.datastore_policy is context_module._default_datastore_policy
 
     def test_set_datastore_policy_as_bool(self):
         context = self._make_one()
@@ -274,16 +261,14 @@ class TestContext:
         context = self._make_one()
         context.set_memcache_policy(None)
         assert (
-            context.global_cache_policy
-            is context_module._default_global_cache_policy
+            context.global_cache_policy is context_module._default_global_cache_policy
         )
 
     def test_set_global_cache_policy(self):
         context = self._make_one()
         context.set_global_cache_policy(None)
         assert (
-            context.global_cache_policy
-            is context_module._default_global_cache_policy
+            context.global_cache_policy is context_module._default_global_cache_policy
         )
 
     def test_set_global_cache_policy_as_bool(self):
@@ -364,9 +349,7 @@ class TestContext:
     def test_call_on_commit_with_transaction(self):
         callbacks = []
         callback = "himom!"
-        context = self._make_one(
-            transaction=b"tx123", on_commit_callbacks=callbacks
-        )
+        context = self._make_one(transaction=b"tx123", on_commit_callbacks=callbacks)
         context.call_on_commit(callback)
         assert context.on_commit_callbacks == ["himom!"]
 
@@ -543,9 +526,7 @@ class Test_default_global_cache_policy:
 class Test_default_global_cache_timeout_policy:
     @staticmethod
     def test_key_is_None():
-        assert (
-            context_module._default_global_cache_timeout_policy(None) is None
-        )
+        assert context_module._default_global_cache_timeout_policy(None) is None
 
     @staticmethod
     def test_no_model_class():
@@ -559,10 +540,7 @@ class Test_default_global_cache_timeout_policy:
             pass
 
         key = key_module.Key("ThisKind", 0)
-        assert (
-            context_module._default_global_cache_timeout_policy(key._key)
-            is None
-        )
+        assert context_module._default_global_cache_timeout_policy(key._key) is None
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
@@ -573,9 +551,7 @@ class Test_default_global_cache_timeout_policy:
                 return 13
 
         key = key_module.Key("ThisKind", 0)
-        assert (
-            context_module._default_global_cache_timeout_policy(key._key) == 13
-        )
+        assert context_module._default_global_cache_timeout_policy(key._key) == 13
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
@@ -584,6 +560,4 @@ class Test_default_global_cache_timeout_policy:
             _global_cache_timeout = 12
 
         key = key_module.Key("ThisKind", 0)
-        assert (
-            context_module._default_global_cache_timeout_policy(key._key) == 12
-        )
+        assert context_module._default_global_cache_timeout_policy(key._key) == 12

--- a/tests/unit/test_global_cache.py
+++ b/tests/unit/test_global_cache.py
@@ -39,9 +39,7 @@ class TestGlobalCache:
                 return super(MockImpl, self).watch(keys)
 
             def compare_and_swap(self, items, expires=None):
-                return super(MockImpl, self).compare_and_swap(
-                    items, expires=expires
-                )
+                return super(MockImpl, self).compare_and_swap(items, expires=expires)
 
         return MockImpl()
 
@@ -215,9 +213,7 @@ class TestRedisCache:
     @mock.patch("google.cloud.ndb.global_cache.uuid")
     def test_watch(uuid):
         uuid.uuid4.return_value = "abc123"
-        redis = mock.Mock(
-            pipeline=mock.Mock(spec=("watch",)), spec=("pipeline",)
-        )
+        redis = mock.Mock(pipeline=mock.Mock(spec=("watch",)), spec=("pipeline",))
         pipe = redis.pipeline.return_value
         keys = ["foo", "bar"]
         cache = global_cache.RedisCache(redis)
@@ -256,9 +252,7 @@ class TestRedisCache:
         pipe1.reset.assert_called_once_with()
         pipe2.reset.assert_called_once_with()
 
-        assert cache.pipes == {
-            "whatevs": global_cache._Pipeline(None, "himom!")
-        }
+        assert cache.pipes == {"whatevs": global_cache._Pipeline(None, "himom!")}
 
     @staticmethod
     def test_compare_and_swap_w_expires():
@@ -298,7 +292,5 @@ class TestRedisCache:
         pipe1.reset.assert_called_once_with()
         pipe2.reset.assert_called_once_with()
 
-        assert cache.pipes == {
-            "whatevs": global_cache._Pipeline(None, "himom!")
-        }
+        assert cache.pipes == {"whatevs": global_cache._Pipeline(None, "himom!")}
         assert expired == {"ay": 32, "be": 32, "see": 32}

--- a/tests/unit/test_key.py
+++ b/tests/unit/test_key.py
@@ -45,9 +45,7 @@ class TestKey:
     def test_constructor_default():
         key = key_module.Key("Kind", 42)
 
-        assert key._key == google.cloud.datastore.Key(
-            "Kind", 42, project="testing"
-        )
+        assert key._key == google.cloud.datastore.Key("Kind", 42, project="testing")
         assert key._reference is None
 
     @staticmethod
@@ -59,9 +57,7 @@ class TestKey:
         """
         key = key_module.Key(u"Kind", 42)
 
-        assert key._key == google.cloud.datastore.Key(
-            u"Kind", 42, project="testing"
-        )
+        assert key._key == google.cloud.datastore.Key(u"Kind", 42, project="testing")
         assert key._reference is None
 
     @staticmethod
@@ -117,9 +113,7 @@ class TestKey:
             pass
 
         key = key_module.Key(Simple, 47)
-        assert key._key == google.cloud.datastore.Key(
-            "Simple", 47, project="testing"
-        )
+        assert key._key == google.cloud.datastore.Key("Simple", 47, project="testing")
         assert key._reference is None
 
     @staticmethod
@@ -141,9 +135,7 @@ class TestKey:
     @staticmethod
     @pytest.mark.usefixtures("in_context")
     def test_constructor_with_serialized():
-        serialized = (
-            b"j\x18s~sample-app-no-locationr\n\x0b\x12\x04Zorp\x18X\x0c"
-        )
+        serialized = b"j\x18s~sample-app-no-locationr\n\x0b\x12\x04Zorp\x18X\x0c"
         key = key_module.Key(serialized=serialized)
 
         assert key._key == google.cloud.datastore.Key(
@@ -159,9 +151,7 @@ class TestKey:
     def test_constructor_with_urlsafe(self):
         key = key_module.Key(urlsafe=self.URLSAFE)
 
-        assert key._key == google.cloud.datastore.Key(
-            "Kind", "Thing", project="fire"
-        )
+        assert key._key == google.cloud.datastore.Key("Kind", "Thing", project="fire")
         assert key._reference == make_reference(
             path=({"type": "Kind", "name": "Thing"},),
             app="s~fire",
@@ -173,9 +163,7 @@ class TestKey:
     def test_constructor_with_pairs():
         key = key_module.Key(pairs=[("Kind", 1)])
 
-        assert key._key == google.cloud.datastore.Key(
-            "Kind", 1, project="testing"
-        )
+        assert key._key == google.cloud.datastore.Key("Kind", 1, project="testing")
         assert key._reference is None
 
     @staticmethod
@@ -183,9 +171,7 @@ class TestKey:
     def test_constructor_with_flat():
         key = key_module.Key(flat=["Kind", 1])
 
-        assert key._key == google.cloud.datastore.Key(
-            "Kind", 1, project="testing"
-        )
+        assert key._key == google.cloud.datastore.Key("Kind", 1, project="testing")
         assert key._reference is None
 
     @staticmethod
@@ -199,9 +185,7 @@ class TestKey:
     def test_constructor_with_app():
         key = key_module.Key("Kind", 10, app="s~foo")
 
-        assert key._key == google.cloud.datastore.Key(
-            "Kind", 10, project="foo"
-        )
+        assert key._key == google.cloud.datastore.Key("Kind", 10, project="foo")
         assert key._reference is None
 
     @staticmethod
@@ -209,9 +193,7 @@ class TestKey:
     def test_constructor_with_project():
         key = key_module.Key("Kind", 10, project="foo")
 
-        assert key._key == google.cloud.datastore.Key(
-            "Kind", 10, project="foo"
-        )
+        assert key._key == google.cloud.datastore.Key("Kind", 10, project="foo")
         assert key._reference is None
 
     @staticmethod
@@ -572,19 +554,13 @@ class TestKey:
     @pytest.mark.usefixtures("in_context")
     def test_to_legacy_urlsafe():
         key = key_module.Key("d", 123, app="f")
-        assert (
-            key.to_legacy_urlsafe(location_prefix="s~")
-            == b"agNzfmZyBwsSAWQYeww"
-        )
+        assert key.to_legacy_urlsafe(location_prefix="s~") == b"agNzfmZyBwsSAWQYeww"
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
     def test_to_legacy_urlsafe_name():
         key = key_module.Key("d", "x", app="f")
-        assert (
-            key.to_legacy_urlsafe(location_prefix="s~")
-            == b"agNzfmZyCAsSAWQiAXgM"
-        )
+        assert key.to_legacy_urlsafe(location_prefix="s~") == b"agNzfmZyCAsSAWQiAXgM"
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
@@ -622,9 +598,7 @@ class TestKey:
     @staticmethod
     @mock.patch("google.cloud.ndb._datastore_api")
     @mock.patch("google.cloud.ndb.model._entity_from_protobuf")
-    def test_get_with_cache_hit(
-        _entity_from_protobuf, _datastore_api, in_context
-    ):
+    def test_get_with_cache_hit(_entity_from_protobuf, _datastore_api, in_context):
         class Simple(model.Model):
             pass
 
@@ -689,9 +663,7 @@ class TestKey:
         key = key_module.Key("Simple", 42)
         assert key.get() == "the entity"
 
-        _datastore_api.lookup.assert_called_once_with(
-            key._key, _options.ReadOptions()
-        )
+        _datastore_api.lookup.assert_called_once_with(key._key, _options.ReadOptions())
         _entity_from_protobuf.assert_called_once_with("ds_entity")
 
         assert Simple.pre_get_calls == [((key,), {})]
@@ -711,9 +683,7 @@ class TestKey:
         ds_future.set_result("ds_entity")
         assert future.result() == "the entity"
 
-        _datastore_api.lookup.assert_called_once_with(
-            key._key, _options.ReadOptions()
-        )
+        _datastore_api.lookup.assert_called_once_with(key._key, _options.ReadOptions())
         _entity_from_protobuf.assert_called_once_with("ds_entity")
 
     @staticmethod
@@ -741,9 +711,7 @@ class TestKey:
 
         key = key_module.Key("Simple", "b", app="c")
         assert key.delete() == "result"
-        _datastore_api.delete.assert_called_once_with(
-            key._key, _options.Options()
-        )
+        _datastore_api.delete.assert_called_once_with(key._key, _options.Options())
 
     @staticmethod
     @mock.patch("google.cloud.ndb._datastore_api")
@@ -808,9 +776,7 @@ class TestKey:
 
         key = key_module.Key("Simple", 42)
         assert key.delete() == "result"
-        _datastore_api.delete.assert_called_once_with(
-            key._key, _options.Options()
-        )
+        _datastore_api.delete.assert_called_once_with(key._key, _options.Options())
 
         assert Simple.pre_delete_calls == [((key,), {})]
         assert Simple.post_delete_calls == [((key,), {})]
@@ -824,9 +790,7 @@ class TestKey:
         with in_context.new(transaction=b"tx123").use():
             key = key_module.Key("a", "b", app="c")
             assert key.delete() is None
-            _datastore_api.delete.assert_called_once_with(
-                key._key, _options.Options()
-            )
+            _datastore_api.delete.assert_called_once_with(key._key, _options.Options())
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
@@ -840,9 +804,7 @@ class TestKey:
 
         result = key.delete_async().get_result()
 
-        _datastore_api.delete.assert_called_once_with(
-            key._key, _options.Options()
-        )
+        _datastore_api.delete.assert_called_once_with(key._key, _options.Options())
         assert result == "result"
 
     @staticmethod
@@ -946,9 +908,7 @@ class Test__from_serialized:
 
     @staticmethod
     def test_no_app_prefix():
-        serialized = (
-            b"j\x18s~sample-app-no-locationr\n\x0b\x12\x04Zorp\x18X\x0c"
-        )
+        serialized = b"j\x18s~sample-app-no-locationr\n\x0b\x12\x04Zorp\x18X\x0c"
         ds_key, reference = key_module._from_serialized(serialized, None, None)
         assert ds_key == google.cloud.datastore.Key(
             "Zorp", 88, project="sample-app-no-location"
@@ -985,9 +945,7 @@ class Test__from_urlsafe:
         urlsafe = b"agZzfmZpcmVyDwsSBEtpbmQiBVRoaW5nDA"
 
         ds_key, reference = key_module._from_urlsafe(urlsafe, None, None)
-        assert ds_key == google.cloud.datastore.Key(
-            "Kind", "Thing", project="fire"
-        )
+        assert ds_key == google.cloud.datastore.Key("Kind", "Thing", project="fire")
         assert reference == make_reference(
             path=({"type": "Kind", "name": "Thing"},),
             app="s~fire",
@@ -1030,9 +988,7 @@ def make_reference(
     app="s~sample-app",
     namespace="space",
 ):
-    elements = [
-        _app_engine_key_pb2.Path.Element(**element) for element in path
-    ]
+    elements = [_app_engine_key_pb2.Path.Element(**element) for element in path]
     return _app_engine_key_pb2.Reference(
         app=app,
         path=_app_engine_key_pb2.Path(element=elements),

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -130,9 +130,7 @@ class TestIndex:
     @staticmethod
     def test_constructor():
         index_prop = model.IndexProperty(name="a", direction="asc")
-        index = model.Index(
-            kind="IndK", properties=(index_prop,), ancestor=False
-        )
+        index = model.Index(kind="IndK", properties=(index_prop,), ancestor=False)
         assert index._kind == "IndK"
         assert index._properties == (index_prop,)
         assert not index._ancestor
@@ -159,9 +157,7 @@ class TestIndex:
     @staticmethod
     def test___repr__():
         index_prop = model.IndexProperty(name="a", direction="asc")
-        index = model.Index(
-            kind="IndK", properties=[index_prop], ancestor=False
-        )
+        index = model.Index(kind="IndK", properties=[index_prop], ancestor=False)
         expected = "Index(kind='IndK', properties=[{!r}], ancestor=False)"
         expected = expected.format(index_prop)
         assert repr(index) == expected
@@ -211,17 +207,13 @@ class TestIndexState:
     INDEX = mock.sentinel.index
 
     def test_constructor(self):
-        index_state = model.IndexState(
-            definition=self.INDEX, state="error", id=42
-        )
+        index_state = model.IndexState(definition=self.INDEX, state="error", id=42)
         assert index_state._definition is self.INDEX
         assert index_state._state == "error"
         assert index_state._id == 42
 
     def test_definition(self):
-        index_state = model.IndexState(
-            definition=self.INDEX, state="serving", id=1
-        )
+        index_state = model.IndexState(definition=self.INDEX, state="serving", id=1)
         assert index_state.definition is self.INDEX
 
     @staticmethod
@@ -237,12 +229,8 @@ class TestIndexState:
     @staticmethod
     def test___repr__():
         index_prop = model.IndexProperty(name="a", direction="asc")
-        index = model.Index(
-            kind="IndK", properties=[index_prop], ancestor=False
-        )
-        index_state = model.IndexState(
-            definition=index, state="building", id=1337
-        )
+        index = model.Index(kind="IndK", properties=[index_prop], ancestor=False)
+        index_state = model.IndexState(definition=index, state="building", id=1337)
         expected = (
             "IndexState(definition=Index(kind='IndK', properties=["
             "IndexProperty(name='a', direction='asc')], ancestor=False), "
@@ -251,18 +239,12 @@ class TestIndexState:
         assert repr(index_state) == expected
 
     def test___eq__(self):
-        index_state1 = model.IndexState(
-            definition=self.INDEX, state="error", id=20
-        )
+        index_state1 = model.IndexState(definition=self.INDEX, state="error", id=20)
         index_state2 = model.IndexState(
             definition=mock.sentinel.not_index, state="error", id=20
         )
-        index_state3 = model.IndexState(
-            definition=self.INDEX, state="serving", id=20
-        )
-        index_state4 = model.IndexState(
-            definition=self.INDEX, state="error", id=80
-        )
+        index_state3 = model.IndexState(definition=self.INDEX, state="serving", id=20)
+        index_state4 = model.IndexState(definition=self.INDEX, state="error", id=80)
         index_state5 = mock.sentinel.index_state
         assert index_state1 == index_state1
         assert not index_state1 == index_state2
@@ -271,22 +253,14 @@ class TestIndexState:
         assert not index_state1 == index_state5
 
     def test___ne__(self):
-        index_state1 = model.IndexState(
-            definition=self.INDEX, state="error", id=20
-        )
+        index_state1 = model.IndexState(definition=self.INDEX, state="error", id=20)
         index_state2 = model.IndexState(
             definition=mock.sentinel.not_index, state="error", id=20
         )
-        index_state3 = model.IndexState(
-            definition=self.INDEX, state="serving", id=20
-        )
-        index_state4 = model.IndexState(
-            definition=self.INDEX, state="error", id=80
-        )
+        index_state3 = model.IndexState(definition=self.INDEX, state="serving", id=20)
+        index_state4 = model.IndexState(definition=self.INDEX, state="error", id=80)
         index_state5 = mock.sentinel.index_state
-        index_state6 = model.IndexState(
-            definition=self.INDEX, state="error", id=20
-        )
+        index_state6 = model.IndexState(definition=self.INDEX, state="error", id=20)
         assert not index_state1 != index_state1
         assert index_state1 != index_state2
         assert index_state1 != index_state3
@@ -295,12 +269,8 @@ class TestIndexState:
         assert not index_state1 != index_state6
 
     def test___hash__(self):
-        index_state1 = model.IndexState(
-            definition=self.INDEX, state="error", id=88
-        )
-        index_state2 = model.IndexState(
-            definition=self.INDEX, state="error", id=88
-        )
+        index_state1 = model.IndexState(definition=self.INDEX, state="error", id=88)
+        index_state2 = model.IndexState(definition=self.INDEX, state="error", id=88)
         assert index_state1 is not index_state2
         assert hash(index_state1) == hash(index_state2)
         assert hash(index_state1) == hash((self.INDEX, "error", 88))
@@ -453,9 +423,7 @@ class TestProperty:
         expected = (
             "Property('val', indexed=False, required=True, "
             "default='zorp', choices={}, validator={}, "
-            "verbose_name='VALUE FOR READING')".format(
-                prop._choices, prop._validator
-            )
+            "verbose_name='VALUE FOR READING')".format(prop._choices, prop._validator)
         )
         assert repr(prop) == expected
 
@@ -1014,9 +982,7 @@ class TestProperty:
         assert methods == expected
         # Check cache
         key = "{}.{}".format(SomeProperty.__module__, SomeProperty.__name__)
-        assert model.Property._FIND_METHODS_CACHE == {
-            key: {("IN", "find_me"): methods}
-        }
+        assert model.Property._FIND_METHODS_CACHE == {key: {("IN", "find_me"): methods}}
 
     def test__find_methods_reverse(self):
         SomeProperty = self._property_subtype()
@@ -1043,9 +1009,7 @@ class TestProperty:
         # Set cache
         methods = mock.sentinel.methods
         key = "{}.{}".format(SomeProperty.__module__, SomeProperty.__name__)
-        model.Property._FIND_METHODS_CACHE = {
-            key: {("IN", "find_me"): methods}
-        }
+        model.Property._FIND_METHODS_CACHE = {key: {("IN", "find_me"): methods}}
         assert SomeProperty._find_methods("IN", "find_me") is methods
 
     def test__find_methods_cached_reverse(self):
@@ -1053,9 +1017,7 @@ class TestProperty:
         # Set cache
         methods = ["a", "b"]
         key = "{}.{}".format(SomeProperty.__module__, SomeProperty.__name__)
-        model.Property._FIND_METHODS_CACHE = {
-            key: {("IN", "find_me"): methods}
-        }
+        model.Property._FIND_METHODS_CACHE = {key: {("IN", "find_me"): methods}}
         assert SomeProperty._find_methods("IN", "find_me", reverse=True) == [
             "b",
             "a",
@@ -1347,9 +1309,7 @@ class TestProperty:
 
         entity = SomeKind(prop="foo")
         data = {}
-        assert SomeKind.prop._to_datastore(entity, data, prefix="pre.") == (
-            "pre.prop",
-        )
+        assert SomeKind.prop._to_datastore(entity, data, prefix="pre.") == ("pre.prop",)
         assert data == {"pre.prop": "foo"}
 
     @staticmethod
@@ -1892,9 +1852,7 @@ class TestBlobProperty:
         compressed_value_one = zlib.compress(uncompressed_value_one)
         uncompressed_value_two = b"xyz" * 1000
         compressed_value_two = zlib.compress(uncompressed_value_two)
-        datastore_entity.update(
-            {"foo": [compressed_value_one, compressed_value_two]}
-        )
+        datastore_entity.update({"foo": [compressed_value_one, compressed_value_two]})
         meanings = {
             "foo": (
                 model._MEANING_COMPRESSED,
@@ -2289,9 +2247,7 @@ class TestUser:
 
     @staticmethod
     def test_nickname_mismatch_domain():
-        user_value = model.User(
-            email="foo@example.org", _auth_domain="example.com"
-        )
+        user_value = model.User(email="foo@example.org", _auth_domain="example.com")
         assert user_value.nickname() == "foo@example.org"
 
     def test_email(self):
@@ -2332,12 +2288,8 @@ class TestUser:
 
     def test___eq__(self):
         user_value1 = self._make_default()
-        user_value2 = model.User(
-            email="foo@example.org", _auth_domain="example.com"
-        )
-        user_value3 = model.User(
-            email="foo@example.com", _auth_domain="example.org"
-        )
+        user_value2 = model.User(email="foo@example.org", _auth_domain="example.com")
+        user_value3 = model.User(email="foo@example.com", _auth_domain="example.org")
         user_value4 = mock.sentinel.blob_key
         assert user_value1 == user_value1
         assert not user_value1 == user_value2
@@ -2346,12 +2298,8 @@ class TestUser:
 
     def test___lt__(self):
         user_value1 = self._make_default()
-        user_value2 = model.User(
-            email="foo@example.org", _auth_domain="example.com"
-        )
-        user_value3 = model.User(
-            email="foo@example.com", _auth_domain="example.org"
-        )
+        user_value2 = model.User(email="foo@example.org", _auth_domain="example.com")
+        user_value3 = model.User(email="foo@example.com", _auth_domain="example.org")
         user_value4 = mock.sentinel.blob_key
         assert not user_value1 < user_value1
         assert user_value1 < user_value2
@@ -2368,13 +2316,16 @@ class TestUser:
 
     @staticmethod
     def test__from_ds_entity_with_user_id():
-        assert model.User._from_ds_entity(
-            {
-                "email": "foo@example.com",
-                "auth_domain": "gmail.com",
-                "user_id": "12345",
-            }
-        ) == model.User("foo@example.com", "gmail.com", "12345")
+        assert (
+            model.User._from_ds_entity(
+                {
+                    "email": "foo@example.com",
+                    "auth_domain": "gmail.com",
+                    "user_id": "12345",
+                }
+            )
+            == model.User("foo@example.com", "gmail.com", "12345")
+        )
 
 
 class TestUserProperty:
@@ -2397,9 +2348,7 @@ class TestUserProperty:
     @staticmethod
     def test__validate():
         prop = model.UserProperty(name="u")
-        user_value = model.User(
-            email="foo@example.com", _auth_domain="example.com"
-        )
+        user_value = model.User(email="foo@example.com", _auth_domain="example.com")
         assert prop._validate(user_value) is None
 
     @staticmethod
@@ -2428,7 +2377,12 @@ class TestUserProperty:
     @staticmethod
     def test__to_base_type():
         prop = model.UserProperty(name="u")
-        entity = prop._to_base_type(model.User("email", "auth_domain",))
+        entity = prop._to_base_type(
+            model.User(
+                "email",
+                "auth_domain",
+            )
+        )
         assert entity["email"] == "email"
         assert "email" in entity.exclude_from_indexes
         assert entity["auth_domain"] == "auth_domain"
@@ -2438,9 +2392,7 @@ class TestUserProperty:
     @staticmethod
     def test__to_base_type_w_user_id():
         prop = model.UserProperty(name="u")
-        entity = prop._to_base_type(
-            model.User("email", "auth_domain", "user_id")
-        )
+        entity = prop._to_base_type(model.User("email", "auth_domain", "user_id"))
         assert entity["email"] == "email"
         assert "email" in entity.exclude_from_indexes
         assert entity["auth_domain"] == "auth_domain"
@@ -2721,9 +2673,7 @@ class TestDateTimeProperty:
         with pytest.raises(ValueError):
             model.DateTimeProperty(name="dt_val", auto_now=True, repeated=True)
         with pytest.raises(ValueError):
-            model.DateTimeProperty(
-                name="dt_val", auto_now_add=True, repeated=True
-            )
+            model.DateTimeProperty(name="dt_val", auto_now_add=True, repeated=True)
 
         prop = model.DateTimeProperty(name="dt_val", repeated=True)
         assert prop._repeated
@@ -2741,9 +2691,7 @@ class TestDateTimeProperty:
         )
         value = "2020-08-08 12:53:54"
         # validator must be called first to convert to datetime
-        assert prop._do_validate(value) == datetime.datetime(
-            2020, 8, 8, 12, 53, 54
-        )
+        assert prop._do_validate(value) == datetime.datetime(2020, 8, 8, 12, 53, 54)
 
     @staticmethod
     def test__validate_invalid():
@@ -2840,9 +2788,7 @@ class TestDateTimeProperty:
     def test__from_base_type_int():
         prop = model.DateTimeProperty(name="dt_val")
         value = 1273632120000000
-        assert prop._from_base_type(value) == datetime.datetime(
-            2010, 5, 12, 2, 42
-        )
+        assert prop._from_base_type(value) == datetime.datetime(2010, 5, 12, 2, 42)
 
     @staticmethod
     def test__to_base_type_noop():
@@ -3116,9 +3062,7 @@ class TestStructuredProperty:
 
         prop = model.StructuredProperty(Mine)
         prop._name = "bar"
-        assert prop._comparison("=", None) == query_module.FilterNode(
-            "bar", "=", None
-        )
+        assert prop._comparison("=", None) == query_module.FilterNode("bar", "=", None)
 
     @staticmethod
     def test__comparison_repeated():
@@ -3208,12 +3152,8 @@ class TestStructuredProperty:
         conjunction_nodes = sorted(
             conjunction._nodes, key=lambda a: getattr(a, "_name", "z")
         )
-        assert conjunction_nodes[0] == query_module.FilterNode(
-            "bar.bar", "=", u"y"
-        )
-        assert conjunction_nodes[1] == query_module.FilterNode(
-            "bar.foo", "=", u"x"
-        )
+        assert conjunction_nodes[0] == query_module.FilterNode("bar.bar", "=", u"y")
+        assert conjunction_nodes[1] == query_module.FilterNode("bar.foo", "=", u"x")
         assert conjunction_nodes[2].predicate.name == "bar"
         assert sorted(conjunction_nodes[2].predicate.match_keys) == [
             "bar",
@@ -3717,17 +3657,13 @@ class TestLocalStructuredProperty:
             bar = model.Property()
 
         class SomeKind(model.Model):
-            foo = model.LocalStructuredProperty(
-                SubKind, repeated=True, indexed=False
-            )
+            foo = model.LocalStructuredProperty(SubKind, repeated=True, indexed=False)
 
         entity = SomeKind(foo=[SubKind(bar="baz")])
         data = {"_exclude_from_indexes": []}
         protobuf = model._entity_to_protobuf(entity.foo[0], set_key=False)
         protobuf = protobuf.SerializePartialToString()
-        assert SomeKind.foo._to_datastore(entity, data, repeated=True) == (
-            "foo",
-        )
+        assert SomeKind.foo._to_datastore(entity, data, repeated=True) == ("foo",)
         assert data.pop("_exclude_from_indexes") == ["foo"]
         assert data == {"foo": [[protobuf]]}
 
@@ -3737,19 +3673,13 @@ class TestLocalStructuredProperty:
             bar = model.Property()
 
         class SomeKind(model.Model):
-            foo = model.LocalStructuredProperty(
-                SubKind, repeated=True, indexed=False
-            )
+            foo = model.LocalStructuredProperty(SubKind, repeated=True, indexed=False)
 
         with in_context.new(legacy_data=True).use():
             entity = SomeKind(foo=[SubKind(bar="baz")])
             data = {"_exclude_from_indexes": []}
-            ds_entity = model._entity_to_ds_entity(
-                entity.foo[0], set_key=False
-            )
-            assert SomeKind.foo._to_datastore(entity, data, repeated=True) == (
-                "foo",
-            )
+            ds_entity = model._entity_to_ds_entity(entity.foo[0], set_key=False)
+            assert SomeKind.foo._to_datastore(entity, data, repeated=True) == ("foo",)
             assert data.pop("_exclude_from_indexes") == ["foo"]
             assert data == {"foo": [ds_entity]}
 
@@ -3774,9 +3704,7 @@ class TestLocalStructuredProperty:
         class SubKind(model.Model):
             bar = model.TextProperty()
 
-        prop = model.LocalStructuredProperty(
-            SubKind, repeated=True, compressed=True
-        )
+        prop = model.LocalStructuredProperty(SubKind, repeated=True, compressed=True)
         entity = SubKind(bar="baz")
         ds_entity = model._entity_to_ds_entity(entity, set_key=False)
         assert prop._call_from_base_type(ds_entity) == entity
@@ -3788,9 +3716,7 @@ class TestLocalStructuredProperty:
             bar = model.StringProperty()
             baz = model.StringProperty()
 
-        prop = model.LocalStructuredProperty(
-            SubKind, repeated=True, compressed=True
-        )
+        prop = model.LocalStructuredProperty(SubKind, repeated=True, compressed=True)
         entity = SubKind(foo="so", bar="much", baz="code")
         compressed = b"".join(
             [
@@ -3857,9 +3783,7 @@ class TestLocalStructuredProperty:
         with in_context.new(legacy_data=True).use():
             entity = ContainerA(child_a=ContainerB())
             data = {"_exclude_from_indexes": []}
-            assert ContainerA.child_a._to_datastore(entity, data) == (
-                "child_a",
-            )
+            assert ContainerA.child_a._to_datastore(entity, data) == ("child_a",)
             assert data.pop("_exclude_from_indexes") == ["child_a"]
             assert data["child_a"]["child_b"] is None
 
@@ -3906,9 +3830,7 @@ class TestGenericProperty:
     @staticmethod
     def test_constructor_compressed_and_indexed():
         with pytest.raises(NotImplementedError):
-            model.GenericProperty(
-                name="generic", compressed=True, indexed=True
-            )
+            model.GenericProperty(name="generic", compressed=True, indexed=True)
 
     @staticmethod
     def test__db_get_value():
@@ -4056,8 +3978,7 @@ class TestMetaModel:
             second = model.StringProperty()
 
         expected = (
-            "Mine<first=IntegerProperty('first'), "
-            "second=StringProperty('second')>"
+            "Mine<first=IntegerProperty('first'), " "second=StringProperty('second')>"
         )
         assert repr(Mine) == expected
 
@@ -4173,9 +4094,7 @@ class TestModel:
             author = model.StringProperty()
             publisher = model.StringProperty()
 
-        entity = Book(
-            pages=287, author="Tim Robert", projection=("pages", "author")
-        )
+        entity = Book(pages=287, author="Tim Robert", projection=("pages", "author"))
         assert entity.__dict__ == {
             "_values": {"pages": 287, "author": "Tim Robert"},
             "_projection": ("pages", "author"),
@@ -4265,9 +4184,7 @@ class TestModel:
     @pytest.mark.usefixtures("in_context")
     def test_repr_with_property_named_key():
         ManyFields = ManyFieldsFactory()
-        entity = ManyFields(
-            self=909, id="hi", key=[88.5, 0.0], value=None, _id=78
-        )
+        entity = ManyFields(self=909, id="hi", key=[88.5, 0.0], value=None, _id=78)
         expected = (
             "ManyFields(_key=Key('ManyFields', 78), id='hi', key=[88.5, 0.0], "
             "self=909, value=None)"
@@ -4280,8 +4197,7 @@ class TestModel:
         ManyFields = ManyFieldsFactory()
         entity = ManyFields(self=909, id="hi", value=None, _id=78)
         expected = (
-            "ManyFields(_key=Key('ManyFields', 78), id='hi', "
-            "self=909, value=None)"
+            "ManyFields(_key=Key('ManyFields', 78), id='hi', " "self=909, value=None)"
         )
         assert repr(entity) == expected
 
@@ -4353,9 +4269,7 @@ class TestModel:
     def test___eq__wrong_projection():
         ManyFields = ManyFieldsFactory()
         entity1 = ManyFields(self=90, projection=("self",))
-        entity2 = ManyFields(
-            value="a", unused=0.0, projection=("value", "unused")
-        )
+        entity2 = ManyFields(value="a", unused=0.0, projection=("value", "unused"))
         assert not entity1 == entity2
 
     @staticmethod
@@ -4457,9 +4371,7 @@ class TestModel:
             hi = model.StringProperty()
 
         entity1 = SomeKind(hi="mom", foo=[OtherKind(bar=42)])
-        entity2 = SomeKind(
-            hi="mom", foo=[OtherKind(bar=42), OtherKind(bar=43)]
-        )
+        entity2 = SomeKind(hi="mom", foo=[OtherKind(bar=42), OtherKind(bar=43)])
 
         assert not entity1 == entity2
 
@@ -4869,9 +4781,7 @@ class TestModel:
                 cls, size, max, parent, future, *args, **kwargs
             ):
                 assert isinstance(future, tasklets.Future)
-                cls.post_allocate_id_calls.append(
-                    ((size, max, parent) + args, kwargs)
-                )
+                cls.post_allocate_id_calls.append(((size, max, parent) + args, kwargs))
 
         keys = Simple.allocate_ids(2)
         assert keys == (
@@ -4969,8 +4879,7 @@ class TestModel:
             pass
 
         assert (
-            Simple.get_by_id(1, parent="foo", project="baz", namespace="bar")
-            is entity
+            Simple.get_by_id(1, parent="foo", project="baz", namespace="bar") is entity
         )
 
         key_module.Key.assert_called_once_with(
@@ -4992,9 +4901,7 @@ class TestModel:
 
         assert Simple.get_by_id(1, app="baz") is entity
 
-        key_module.Key.assert_called_once_with(
-            "Simple", 1, parent=None, app="baz"
-        )
+        key_module.Key.assert_called_once_with("Simple", 1, parent=None, app="baz")
 
         key.get_async.assert_called_once_with(_options=_options.ReadOptions())
 
@@ -5111,9 +5018,7 @@ class TestModel:
     @pytest.mark.usefixtures("in_context")
     @mock.patch("google.cloud.ndb.model._transaction")
     @mock.patch("google.cloud.ndb.model.key_module")
-    def test_get_or_insert_insert_in_transaction(
-        patched_key_module, _transaction
-    ):
+    def test_get_or_insert_insert_in_transaction(patched_key_module, _transaction):
         class MockKey(key_module.Key):
             get_async = mock.Mock(return_value=utils.future_result(None))
 
@@ -5129,21 +5034,15 @@ class TestModel:
         entity = Simple.get_or_insert("one", foo=42)
         assert entity.foo == 42
         assert entity._key == MockKey("Simple", "one")
-        assert entity.put_async.called_once_with(
-            _options=_options.ReadOptions()
-        )
+        assert entity.put_async.called_once_with(_options=_options.ReadOptions())
 
-        entity._key.get_async.assert_called_once_with(
-            _options=_options.ReadOptions()
-        )
+        entity._key.get_async.assert_called_once_with(_options=_options.ReadOptions())
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
     @mock.patch("google.cloud.ndb.model._transaction")
     @mock.patch("google.cloud.ndb.model.key_module")
-    def test_get_or_insert_insert_not_in_transaction(
-        patched_key_module, _transaction
-    ):
+    def test_get_or_insert_insert_not_in_transaction(patched_key_module, _transaction):
         class MockKey(key_module.Key):
             get_async = mock.Mock(return_value=utils.future_result(None))
 
@@ -5160,13 +5059,9 @@ class TestModel:
         entity = Simple.get_or_insert("one", foo=42)
         assert entity.foo == 42
         assert entity._key == MockKey("Simple", "one")
-        assert entity.put_async.called_once_with(
-            _options=_options.ReadOptions()
-        )
+        assert entity.put_async.called_once_with(_options=_options.ReadOptions())
 
-        entity._key.get_async.assert_called_once_with(
-            _options=_options.ReadOptions()
-        )
+        entity._key.get_async.assert_called_once_with(_options=_options.ReadOptions())
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
@@ -5446,9 +5341,7 @@ class Test_entity_from_protobuf:
 
         key = datastore.Key("ThisKind", 123, project="testing")
         datastore_entity = datastore.Entity(key=key)
-        datastore_entity.update(
-            {"baz.foo": 42, "baz.bar": "himom", "copacetic": True}
-        )
+        datastore_entity.update({"baz.foo": 42, "baz.bar": "himom", "copacetic": True})
         protobuf = helpers.entity_to_protobuf(datastore_entity)
         entity = model._entity_from_protobuf(protobuf)
         assert isinstance(entity, ThisKind)
@@ -5870,9 +5763,7 @@ def test_serialization():
         def _get_kind(cls):
             return "SomeKind"
 
-    entity = SomeKind(
-        other=OtherKind(foo=1, namespace="Test"), namespace="Test"
-    )
+    entity = SomeKind(other=OtherKind(foo=1, namespace="Test"), namespace="Test")
     assert entity.other.key is None or entity.other.key.id() is None
     entity = pickle.loads(pickle.dumps(entity))
     assert entity.other.foo == 1

--- a/tests/unit/test_polymodel.py
+++ b/tests/unit/test_polymodel.py
@@ -100,9 +100,7 @@ class TestPolyModel:
             pass
 
         assert Animal._default_filters() == ()
-        assert Cat._default_filters() == (
-            query.FilterNode("class", "=", "Cat"),
-        )
+        assert Cat._default_filters() == (query.FilterNode("class", "=", "Cat"),)
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -49,12 +49,8 @@ class TestQueryOptions:
 
     @staticmethod
     def test_constructor_with_config():
-        config = query_module.QueryOptions(
-            kind="other", namespace="config_test"
-        )
-        options = query_module.QueryOptions(
-            config=config, kind="test", project="app"
-        )
+        config = query_module.QueryOptions(kind="other", namespace="config_test")
+        options = query_module.QueryOptions(config=config, kind="test", project="app")
         assert options.kind == "test"
         assert options.project == "app"
         assert options.namespace == "config_test"
@@ -304,9 +300,7 @@ class TestParameter:
 class TestParameterizedFunction:
     @staticmethod
     def test_constructor():
-        query = query_module.ParameterizedFunction(
-            "user", [query_module.Parameter(1)]
-        )
+        query = query_module.ParameterizedFunction("user", [query_module.Parameter(1)])
         assert query.func == "user"
         assert query.values == [query_module.Parameter(1)]
 
@@ -317,39 +311,27 @@ class TestParameterizedFunction:
 
     @staticmethod
     def test___repr__():
-        query = query_module.ParameterizedFunction(
-            "user", [query_module.Parameter(1)]
-        )
-        assert (
-            query.__repr__() == "ParameterizedFunction('user', [Parameter(1)])"
-        )
+        query = query_module.ParameterizedFunction("user", [query_module.Parameter(1)])
+        assert query.__repr__() == "ParameterizedFunction('user', [Parameter(1)])"
 
     @staticmethod
     def test___eq__parameter():
-        query = query_module.ParameterizedFunction(
-            "user", [query_module.Parameter(1)]
-        )
+        query = query_module.ParameterizedFunction("user", [query_module.Parameter(1)])
         assert (
             query.__eq__(
-                query_module.ParameterizedFunction(
-                    "user", [query_module.Parameter(1)]
-                )
+                query_module.ParameterizedFunction("user", [query_module.Parameter(1)])
             )
             is True
         )
 
     @staticmethod
     def test___eq__no_parameter():
-        query = query_module.ParameterizedFunction(
-            "user", [query_module.Parameter(1)]
-        )
+        query = query_module.ParameterizedFunction("user", [query_module.Parameter(1)])
         assert query.__eq__(42) is NotImplemented
 
     @staticmethod
     def test_is_parameterized_True():
-        query = query_module.ParameterizedFunction(
-            "user", [query_module.Parameter(1)]
-        )
+        query = query_module.ParameterizedFunction("user", [query_module.Parameter(1)])
         assert query.is_parameterized()
 
     @staticmethod
@@ -661,9 +643,7 @@ class TestFilterNode:
 
         filter_node1 = query_module.FilterNode("a", "<", 2.5)
         filter_node2 = query_module.FilterNode("a", ">", 2.5)
-        assert or_node == query_module.DisjunctionNode(
-            filter_node1, filter_node2
-        )
+        assert or_node == query_module.DisjunctionNode(filter_node1, filter_node2)
 
     @staticmethod
     def test_pickling():
@@ -907,9 +887,7 @@ class TestConjunctionNode:
         with pytest.raises(RuntimeError):
             query_module.ConjunctionNode(node1, node2)
 
-        boolean_clauses.assert_called_once_with(
-            "ConjunctionNode", combine_or=False
-        )
+        boolean_clauses.assert_called_once_with("ConjunctionNode", combine_or=False)
         assert clauses.add_node.call_count == 2
         clauses.add_node.assert_has_calls([mock.call(node1), mock.call(node2)])
 
@@ -1320,9 +1298,7 @@ class TestQuery:
     @pytest.mark.usefixtures("in_context")
     @mock.patch("google.cloud.ndb.model.Model._check_properties")
     def test_constructor_with_projection_as_property(_check_props):
-        query = query_module.Query(
-            kind="Foo", projection=[model.Property(name="X")]
-        )
+        query = query_module.Query(kind="Foo", projection=[model.Property(name="X")])
         assert query.projection == ("X",)
         _check_props.assert_not_called()
 
@@ -1333,9 +1309,7 @@ class TestQuery:
         class Foo(model.Model):
             x = model.IntegerProperty()
 
-        query = query_module.Query(
-            kind="Foo", projection=[model.Property(name="x")]
-        )
+        query = query_module.Query(kind="Foo", projection=[model.Property(name="x")])
         assert query.projection == ("x",)
         _check_props.assert_called_once_with(["x"])
 
@@ -1360,9 +1334,7 @@ class TestQuery:
     @staticmethod
     @pytest.mark.usefixtures("in_context")
     def test_constructor_with_filters():
-        query = query_module.Query(
-            filters=query_module.FilterNode("f", None, None)
-        )
+        query = query_module.Query(filters=query_module.FilterNode("f", None, None))
         assert isinstance(query.filters, query_module.Node)
 
     @staticmethod
@@ -1706,9 +1678,7 @@ class TestQuery:
         response = _datastore_query.fetch.return_value
         assert query.fetch_async(keys_only=True) is response
         _datastore_query.fetch.assert_called_once_with(
-            query_module.QueryOptions(
-                project="testing", projection=["__key__"]
-            )
+            query_module.QueryOptions(project="testing", projection=["__key__"])
         )
 
     @staticmethod
@@ -1738,9 +1708,7 @@ class TestQuery:
         response = _datastore_query.fetch.return_value
         assert query.fetch_async(projection=("foo", "bar")) is response
         _datastore_query.fetch.assert_called_once_with(
-            query_module.QueryOptions(
-                project="testing", projection=["foo", "bar"]
-            )
+            query_module.QueryOptions(project="testing", projection=["foo", "bar"])
         )
 
     @staticmethod
@@ -1755,9 +1723,7 @@ class TestQuery:
         bar._name = "bar"
         assert query.fetch_async(projection=(foo, bar)) is response
         _datastore_query.fetch.assert_called_once_with(
-            query_module.QueryOptions(
-                project="testing", projection=["foo", "bar"]
-            )
+            query_module.QueryOptions(project="testing", projection=["foo", "bar"])
         )
 
     @staticmethod
@@ -1769,9 +1735,7 @@ class TestQuery:
         response = _datastore_query.fetch.return_value
         assert query.fetch_async(options=options) is response
         _datastore_query.fetch.assert_called_once_with(
-            query_module.QueryOptions(
-                project="testing", projection=("foo", "bar")
-            )
+            query_module.QueryOptions(project="testing", projection=("foo", "bar"))
         )
 
     @staticmethod
@@ -1898,9 +1862,7 @@ class TestQuery:
         response = _datastore_query.fetch.return_value
         assert query.fetch_async(read_policy="foo") is response
         _datastore_query.fetch.assert_called_once_with(
-            query_module.QueryOptions(
-                project="testing", read_consistency="foo"
-            )
+            query_module.QueryOptions(project="testing", read_consistency="foo")
         )
 
     @staticmethod
@@ -1930,9 +1892,7 @@ class TestQuery:
     def test_fetch_async_with_tx_and_read_policy(_datastore_query):
         query = query_module.Query()
         with pytest.raises(TypeError):
-            query.fetch_async(
-                transaction="foo", read_policy=_datastore_api.EVENTUAL
-            )
+            query.fetch_async(transaction="foo", read_policy=_datastore_api.EVENTUAL)
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
@@ -2096,9 +2056,7 @@ class TestQuery:
     @mock.patch("google.cloud.ndb._datastore_query")
     def test_get(_datastore_query):
         query = query_module.Query()
-        _datastore_query.fetch.return_value = utils.future_result(
-            ["foo", "bar"]
-        )
+        _datastore_query.fetch.return_value = utils.future_result(["foo", "bar"])
         assert query.get() == "foo"
         _datastore_query.fetch.assert_called_once_with(
             query_module.QueryOptions(project="testing", limit=1)
@@ -2117,9 +2075,7 @@ class TestQuery:
     @mock.patch("google.cloud.ndb._datastore_query")
     def test_get_async(_datastore_query):
         query = query_module.Query()
-        _datastore_query.fetch.return_value = utils.future_result(
-            ["foo", "bar"]
-        )
+        _datastore_query.fetch.return_value = utils.future_result(["foo", "bar"])
         future = query.get_async()
         assert future.result() == "foo"
 
@@ -2141,9 +2097,7 @@ class TestQuery:
         query = query_module.Query()
         assert query.count() == 5
         _datastore_query.iterate.assert_called_once_with(
-            query_module.QueryOptions(
-                project="testing", projection=["__key__"]
-            ),
+            query_module.QueryOptions(project="testing", projection=["__key__"]),
             raw=True,
         )
 
@@ -2190,9 +2144,7 @@ class TestQuery:
         future = query.count_async()
         assert future.result() == 5
         _datastore_query.iterate.assert_called_once_with(
-            query_module.QueryOptions(
-                project="testing", projection=["__key__"]
-            ),
+            query_module.QueryOptions(project="testing", projection=["__key__"]),
             raw=True,
         )
 
@@ -2227,7 +2179,8 @@ class TestQuery:
         _datastore_query.iterate.return_value = DummyQueryIterator()
         query = query_module.Query()
         query.filters = mock.Mock(
-            _multiquery=False, _post_filters=mock.Mock(return_value=False),
+            _multiquery=False,
+            _post_filters=mock.Mock(return_value=False),
         )
         results, cursor, more = query.fetch_page(5)
         assert results == [0, 1, 2, 3, 4]
@@ -2321,7 +2274,8 @@ class TestQuery:
         _datastore_query.iterate.return_value = DummyQueryIterator()
         query = query_module.Query()
         query.filters = mock.Mock(
-            _multiquery=False, _post_filters=mock.Mock(return_value=False),
+            _multiquery=False,
+            _post_filters=mock.Mock(return_value=False),
         )
         results, cursor, more = query.fetch_page(5)
         assert results == []

--- a/tests/unit/test_stats.py
+++ b/tests/unit/test_stats.py
@@ -154,9 +154,7 @@ class TestPropertyTypeStat:
 
     @staticmethod
     def test_constructor():
-        stat = stats.PropertyTypeStat(
-            property_type="test_property", **DEFAULTS
-        )
+        stat = stats.PropertyTypeStat(property_type="test_property", **DEFAULTS)
         assert stat.bytes == 4
         assert stat.count == 2
         assert stat.property_type == "test_property"
@@ -289,9 +287,7 @@ class TestNamespaceKindNonRootEntityStat:
 
     @staticmethod
     def test_constructor():
-        stat = stats.NamespaceKindNonRootEntityStat(
-            kind_name="test_stat", **DEFAULTS
-        )
+        stat = stats.NamespaceKindNonRootEntityStat(kind_name="test_stat", **DEFAULTS)
         assert stat.bytes == 4
         assert stat.count == 2
         assert stat.kind_name == "test_stat"
@@ -302,9 +298,7 @@ class TestNamespaceKindPropertyNamePropertyTypeStat:
     @staticmethod
     def test_get_kind():
         kind = stats.NamespaceKindPropertyNamePropertyTypeStat.STORED_KIND_NAME
-        assert (
-            stats.NamespaceKindPropertyNamePropertyTypeStat._get_kind() == kind
-        )
+        assert stats.NamespaceKindPropertyNamePropertyTypeStat._get_kind() == kind
 
     @staticmethod
     def test_constructor():
@@ -372,9 +366,7 @@ class TestNamespaceKindRootEntityStat:
 
     @staticmethod
     def test_constructor():
-        stat = stats.NamespaceKindRootEntityStat(
-            kind_name="test_stat", **DEFAULTS
-        )
+        stat = stats.NamespaceKindRootEntityStat(kind_name="test_stat", **DEFAULTS)
         assert stat.bytes == 4
         assert stat.count == 2
         assert stat.kind_name == "test_stat"

--- a/tests/unit/test_tasklets.py
+++ b/tests/unit/test_tasklets.py
@@ -303,9 +303,7 @@ class Test_TaskletFuture:
     @staticmethod
     def test___repr__():
         future = tasklets._TaskletFuture(None, None, info="Female")
-        assert repr(future) == "_TaskletFuture('Female') <{}>".format(
-            id(future)
-        )
+        assert repr(future) == "_TaskletFuture('Female') <{}>".format(id(future))
 
     @staticmethod
     def test__advance_tasklet_return(in_context):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -80,18 +80,14 @@ class Test_logging_debug:
     @mock.patch("google.cloud.ndb.utils.DEBUG", False)
     def test_noop():
         log = mock.Mock(spec=("debug",))
-        utils.logging_debug(
-            log, "hello dad! {} {where}", "I'm", where="in jail"
-        )
+        utils.logging_debug(log, "hello dad! {} {where}", "I'm", where="in jail")
         log.debug.assert_not_called()
 
     @staticmethod
     @mock.patch("google.cloud.ndb.utils.DEBUG", True)
     def test_log_it():
         log = mock.Mock(spec=("debug",))
-        utils.logging_debug(
-            log, "hello dad! {} {where}", "I'm", where="in jail"
-        )
+        utils.logging_debug(log, "hello dad! {} {where}", "I'm", where="in jail")
         log.debug.assert_called_once_with("hello dad! I'm in jail")
 
 


### PR DESCRIPTION
* Upgrade to the latest version of black.

* Stop passing "--line-length" argument to black, to use default, like
other Google API libraries.

* Add some errors for flake8 to ignore, consistent with other Google API
Libraries.