### PR TITLE
fix: get_by_id and get_or_insert should use default namespace

### DIFF
--- a/google/cloud/ndb/metadata.py
+++ b/google/cloud/ndb/metadata.py
@@ -102,7 +102,7 @@ class Namespace(_BaseMetadata):
         Returns:
             key.Key: The Key for the namespace.
         """
-        if namespace:
+        if namespace is not None:
             return model.Key(cls.KIND_NAME, namespace)
         else:
             return model.Key(cls.KIND_NAME, cls.EMPTY_NAMESPACE_ID)

--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -5603,7 +5603,7 @@ class Model(_NotEqualMixin):
         if project:
             key_args["app"] = project
 
-        if namespace:
+        if namespace is not None:
             key_args["namespace"] = namespace
 
         key = key_module.Key(cls._get_kind(), id, parent=parent, **key_args)
@@ -5805,7 +5805,7 @@ class Model(_NotEqualMixin):
         if project:
             key_args["app"] = project
 
-        if namespace:
+        if namespace is not None:
             key_args["namespace"] = namespace
 
         key = key_module.Key(cls._get_kind(), name, parent=parent, **key_args)

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -100,11 +100,17 @@ class TestNamespace:
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
+    def test_key_for_namespace_default():
+        key = key_module.Key(metadata.Namespace.KIND_NAME, "")
+        assert key == metadata.Namespace.key_for_namespace("")
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
     def test_key_for_namespace_empty():
         key = key_module.Key(
             metadata.Namespace.KIND_NAME, metadata.Namespace.EMPTY_NAMESPACE_ID
         )
-        assert key == metadata.Namespace.key_for_namespace("")
+        assert key == metadata.Namespace.key_for_namespace(None)
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -4899,6 +4899,23 @@ class TestModel:
     @staticmethod
     @pytest.mark.usefixtures("in_context")
     @mock.patch("google.cloud.ndb.model.key_module")
+    def test_get_by_id_w_default_namespace(key_module):
+        entity = object()
+        key = key_module.Key.return_value
+        key.get_async.return_value = utils.future_result(entity)
+
+        class Simple(model.Model):
+            pass
+
+        assert Simple.get_by_id(1, namespace="") is entity
+
+        key_module.Key.assert_called_once_with("Simple", 1, namespace="", parent=None)
+
+        key.get_async.assert_called_once_with(_options=_options.ReadOptions())
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    @mock.patch("google.cloud.ndb.model.key_module")
     def test_get_by_id_w_app(key_module):
         entity = object()
         key = key_module.Key.return_value
@@ -4991,6 +5008,25 @@ class TestModel:
 
         key_module.Key.assert_called_once_with(
             "Simple", "one", parent=None, namespace="himom"
+        )
+
+        key.get_async.assert_called_once_with(_options=_options.ReadOptions())
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    @mock.patch("google.cloud.ndb.model.key_module")
+    def test_get_or_insert_get_w_default_namespace(key_module):
+        entity = object()
+        key = key_module.Key.return_value
+        key.get_async.return_value = utils.future_result(entity)
+
+        class Simple(model.Model):
+            foo = model.IntegerProperty()
+
+        assert Simple.get_or_insert("one", foo=0, namespace="") is entity
+
+        key_module.Key.assert_called_once_with(
+            "Simple", "one", parent=None, namespace=""
         )
 
         key.get_async.assert_called_once_with(_options=_options.ReadOptions())


### PR DESCRIPTION
when passed in when context is using another namespace.

refs #535