### PR TITLE
fix(dependencies): Pin to less than 2.0.0 for google-cloud-datastore

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def main():
     with io.open(readme_filename, encoding="utf-8") as readme_file:
         readme = readme_file.read()
     dependencies = [
-        "google-cloud-datastore >= 1.7.0, < 2.0.0dev"
+        "google-cloud-datastore >= 1.7.0, < 2.0.0dev",
         "pymemcache",
         "redis",
     ]

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def main():
     with io.open(readme_filename, encoding="utf-8") as readme_file:
         readme = readme_file.read()
     dependencies = [
-        "google-cloud-datastore >= 1.7.0",
+        "google-cloud-datastore >= 1.7.0, < 2.0.0dev"
         "pymemcache",
         "redis",
     ]


### PR DESCRIPTION
there are breaking changes in the next major version of datastore and pinning below 2.0.0 will stop those changes from breaking ndb.

Fixes #568 