### PR TITLE
fix: support empty not_finished messages that cause query.count() to return early

### DIFF
--- a/google/cloud/ndb/_datastore_query.py
+++ b/google/cloud/ndb/_datastore_query.py
@@ -169,7 +169,7 @@ def _count_by_skipping(query):
         # so for a workaround, just bail as soon as we neither skip nor retrieve any
         # results
         new_count = batch.skipped_results + len(batch.entity_results)
-        if new_count == 0:
+        if new_count == 0 and more_results != NOT_FINISHED:
             break
 
         count += new_count

--- a/tests/unit/test__datastore_query.py
+++ b/tests/unit/test__datastore_query.py
@@ -165,6 +165,22 @@ class Test_count:
             ),
             mock.Mock(
                 batch=mock.Mock(
+                    more_results=_datastore_query.NOT_FINISHED,
+                    skipped_results=0,
+                    entity_results=[],
+                    end_cursor=b"secondCursor",
+                    skipped_cursor=b"skiptomylou",
+                    spec=(
+                        "more_results",
+                        "skipped_results",
+                        "entity_results",
+                        "end_cursor",
+                    ),
+                ),
+                spec=("batch",),
+            ),
+            mock.Mock(
+                batch=mock.Mock(
                     more_results=_datastore_query.NO_MORE_RESULTS,
                     skipped_results=99,
                     entity_results=[object()],
@@ -201,6 +217,17 @@ class Test_count:
                         offset=10000,
                         projection=["__key__"],
                         start_cursor=_datastore_query.Cursor(b"himom"),
+                    ),
+                ),
+                {},
+            ),
+            (
+                (
+                    query_module.QueryOptions(
+                        limit=1,
+                        offset=10000,
+                        projection=["__key__"],
+                        start_cursor=_datastore_query.Cursor(b"skiptomylou"),
                     ),
                 ),
                 {},


### PR DESCRIPTION
fixes #575