### PR TITLE
fix: return a tuple when empty result returned on query

### DIFF
--- a/google/cloud/ndb/query.py
+++ b/google/cloud/ndb/query.py
@@ -2010,7 +2010,7 @@ class Query(object):
         if futures:
             mapped_results = yield futures
         else:
-            mapped_results = []
+            mapped_results = ()
 
         raise tasklets.Return(mapped_results)
 

--- a/tests/system/test_query.py
+++ b/tests/system/test_query.py
@@ -1668,7 +1668,7 @@ def test_map_empty_result_set(dispose_of):
         raise Exception("Shouldn't be called.")
 
     query = SomeKind.query()
-    assert query.map(somefunc) == []
+    assert query.map(somefunc) == ()
 
 
 @pytest.mark.usefixtures("client_context")

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -2035,7 +2035,7 @@ class TestQuery:
             raise Exception("Shouldn't get called.")
 
         query = query_module.Query()
-        assert query.map(callback) == []
+        assert query.map(callback) == ()
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")


### PR DESCRIPTION
Fixes #578 