### PR TITLE
Clean up datastore emulator workarounds

### DIFF
--- a/google/cloud/ndb/client.py
+++ b/google/cloud/ndb/client.py
@@ -95,7 +95,7 @@ class Client(google_client.ClientWithProject):
 
         # Use insecure connection when using Datastore Emulator, otherwise
         # use secure connection
-        emulator = bool(os.environ.get("DATASTORE_EMULATOR_HOST"))
+        emulator = bool(os.environ.get(environment_vars.GCD_HOST))
         self.secure = not emulator
 
         if emulator:


### PR DESCRIPTION
This my proposed fix for: #584

The idea is to store a boolean to remember the type of the backend (emulator or real) during the whole life of the client. I am not super happy about this but I think it's still an improvement over the current way things work. There is already branching in the code based on the type of the backend, but it's basically a guesswork based on the behavior of the backend. And that seems to be fragile, just like my issues demonstrate. After this PR, the branching would be made explicit, based on the actual backend type. 

An interesting side-effect of this change is that the change in line 181 actually also fixes #575 on my data, because the backend in my case doesn't send back an empty batch if the correct cursor is used in the query. However, based on #386 the backend might still send empty batches in some legit cases, and anyways, better safe than sorry, so I've kept the change in line 172.

Unfortunately this breaks some tests, I think mostly because `conftest.in_context` always creates a non-emulator context, but in some cases we'd need an emulator context.

So if you like this PR, please give me some pointers on how to parameterize `conftest.in_context`, or just feel free to take it over.

In any case, I think it would be a good idea to test the final PR on my data.