### PR TITLE
fix: handle negatives in protobuf deserialization

### DIFF
--- a/google/cloud/ndb/_legacy_protocol_buffer.py
+++ b/google/cloud/ndb/_legacy_protocol_buffer.py
@@ -160,12 +160,17 @@ class Decoder:
                 raise ProtocolBufferDecodeError("corrupted")
             b = self.get8()
 
+        if result >= 0x8000000000000000:
+            result -= 0x10000000000000000
+
         if result >= 0x80000000 or result < -0x80000000:
             raise ProtocolBufferDecodeError("corrupted")
         return result
 
     def getVarInt64(self):
         result = self.getVarUint64()
+        if result >= (1 << 63):
+            result -= 1 << 64
         return result
 
     def getVarUint64(self):

--- a/tests/unit/test__legacy_entity_pb.py
+++ b/tests/unit/test__legacy_entity_pb.py
@@ -431,6 +431,11 @@ class TestDecoder:
         assert d.get32() == 1
 
     @staticmethod
+    def test_getVarInt32_negative():
+        d = _get_decoder(b"\xc7\xf5\xff\xff\xff\xff\xff\xff\xff\x01")
+        assert d.getVarInt32() == -1337
+
+    @staticmethod
     def test_get32_truncated():
         d = _get_decoder(b"\x10")
         with pytest.raises(pb_module.ProtocolBufferDecodeError):
@@ -440,6 +445,11 @@ class TestDecoder:
     def test_get64():
         d = _get_decoder(b"\x01\x00\x00\x00\x00\x00\x00\x00")
         assert d.get64() == 1
+
+    @staticmethod
+    def test_getVarInt64_negative():
+        d = _get_decoder(b"\xc7\xf5\xff\xff\xff\xff\xff\xff\xff\x01")
+        assert d.getVarInt64() == -1337
 
     @staticmethod
     def test_get64_truncated():
@@ -512,3 +522,4 @@ class TestDecoder:
         d = _get_decoder(b"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff")
         with pytest.raises(pb_module.ProtocolBufferDecodeError):
             d.getVarInt64()
+

--- a/tests/unit/test__legacy_entity_pb.py
+++ b/tests/unit/test__legacy_entity_pb.py
@@ -522,4 +522,3 @@ class TestDecoder:
         d = _get_decoder(b"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff")
         with pytest.raises(pb_module.ProtocolBufferDecodeError):
             d.getVarInt64()
-


### PR DESCRIPTION
The code in this library does not match that of the original GAE
runtime, which will do 2's complemenet math when deserializing signed
integers.

Legacy code reference: https://github.com/GoogleCloudPlatform/python-compat-runtime/blob/743ade7e1350c790c4aaa48dd2c0893d06d80cee/appengine-compat/exported_appengine_sdk/google/net/proto/ProtocolBuffer.py#L743-L747

Fixes #590