### PR TITLE
fix: fix bug with compressed blob property

### DIFF
--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -2611,10 +2611,11 @@ class BlobProperty(Property):
             entity, data, prefix=prefix, repeated=repeated
         )
         if self._compressed:
-            value = data[self._name]
+            key = prefix + self._name
+            value = data[key]
             if isinstance(value, _CompressedValue):
                 value = value.z_val
-                data[self._name] = value
+                data[key] = value
 
             if self._repeated:
                 compressed_value = []
@@ -2623,14 +2624,14 @@ class BlobProperty(Property):
                         rval = zlib.compress(rval)
                     compressed_value.append(rval)
                 value = compressed_value
-                data[self._name] = value
+                data[key] = value
             if not self._repeated:
                 if value and not value.startswith(_ZLIB_COMPRESSION_MARKER):
                     value = zlib.compress(value)
-                    data[self._name] = value
+                    data[key] = value
 
             if value:
-                data.setdefault("_meanings", {})[self._name] = (
+                data.setdefault("_meanings", {})[key] = (
                     _MEANING_COMPRESSED,
                     value,
                 )

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -1765,6 +1765,28 @@ class TestBlobProperty:
         assert ds_entity._meanings["foo"][1] == compressed_value
 
     @staticmethod
+    def test__to_datastore_legacy_compressed_with_prefix(in_context):
+        """Regression test for #602
+
+        https://github.com/googleapis/python-ndb/issues/602
+        """
+
+        class ThisKind(model.Model):
+            bar = model.BlobProperty(compressed=True)
+
+        class ParentKind(model.Model):
+            foo = model.StructuredProperty(ThisKind)
+
+        with in_context.new(legacy_data=True).use():
+            uncompressed_value = b"abc" * 1000
+            compressed_value = zlib.compress(uncompressed_value)
+            entity = ParentKind(foo=ThisKind(bar=uncompressed_value))
+            ds_entity = model._entity_to_ds_entity(entity)
+            assert "foo.bar" in ds_entity._meanings
+            assert ds_entity._meanings["foo.bar"][0] == model._MEANING_COMPRESSED
+            assert ds_entity._meanings["foo.bar"][1] == compressed_value
+
+    @staticmethod
     @pytest.mark.usefixtures("in_context")
     def test__to_datastore_compressed_repeated():
         class ThisKind(model.Model):


### PR DESCRIPTION
There was a bug when using a compressed blob property as a child of a structured
property while using the legacy data format for structured properties.

Fixes #602