### PR TITLE
fix: remove unnecessary code

### DIFF
--- a/google/cloud/ndb/_transaction.py
+++ b/google/cloud/ndb/_transaction.py
@@ -301,7 +301,6 @@ def _transaction_async(context, callback, read_only=False):
             yield _datastore_api.rollback(transaction_id)
             raise e
 
-        tx_context._clear_global_cache()
         for callback in on_commit_callbacks:
             callback()
 

--- a/google/cloud/ndb/context.py
+++ b/google/cloud/ndb/context.py
@@ -23,7 +23,6 @@ import threading
 from google.cloud.ndb import _eventloop
 from google.cloud.ndb import exceptions
 from google.cloud.ndb import key as key_module
-from google.cloud.ndb import tasklets
 
 
 try:  # pragma: NO PY2 COVER
@@ -326,25 +325,6 @@ class _Context(_ContextTuple):
             else:
                 _state.toplevel_context = None
             _state.context = prev_context
-
-    @tasklets.tasklet
-    def _clear_global_cache(self):
-        """Clears the global cache.
-
-        Clears keys from the global cache that appear in the local context
-        cache. In this way, only keys that were touched in the current context
-        are affected.
-        """
-        # Prevent circular import in Python 2.7
-        from google.cloud.ndb import _cache
-
-        keys = [
-            _cache.global_cache_key(key._key)
-            for key in self.cache.keys()
-            if self._use_global_cache(key)
-        ]
-        if keys:
-            yield [_cache.global_delete(key) for key in keys]
 
     def _use_cache(self, key, options=None):
         """Return whether to use the context cache for this key."""

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -19,11 +19,9 @@ try:
 except ImportError:  # pragma: NO PY3 COVER
     import mock
 
-from google.cloud.ndb import _cache
 from google.cloud.ndb import context as context_module
 from google.cloud.ndb import _eventloop
 from google.cloud.ndb import exceptions
-from google.cloud.ndb import global_cache
 from google.cloud.ndb import key as key_module
 from google.cloud.ndb import model
 from google.cloud.ndb import _options
@@ -127,26 +125,6 @@ class TestContext:
         context.cache["testkey"] = "testdata"
         context.clear_cache()
         assert not context.cache
-
-    def test__clear_global_cache(self):
-        context = self._make_one(global_cache=global_cache._InProcessGlobalCache())
-        with context.use():
-            key = key_module.Key("SomeKind", 1)
-            cache_key = _cache.global_cache_key(key._key)
-            context.cache[key] = "testdata"
-            context.global_cache.cache[cache_key] = "testdata"
-            context.global_cache.cache["anotherkey"] = "otherdata"
-            context._clear_global_cache().result()
-
-        assert context.global_cache.cache == {"anotherkey": "otherdata"}
-
-    def test__clear_global_cache_nothing_to_do(self):
-        context = self._make_one(global_cache=global_cache._InProcessGlobalCache())
-        with context.use():
-            context.global_cache.cache["anotherkey"] = "otherdata"
-            context._clear_global_cache().result()
-
-        assert context.global_cache.cache == {"anotherkey": "otherdata"}
 
     def test_flush(self):
         eventloop = mock.Mock(spec=("run",))


### PR DESCRIPTION
Code that cleared the global cache at the end of a transaction was found
to be unnecessary.

Fixes #657