### PR TITLE
fix: correct inconsistent behavior with regards to namespaces

### DIFF
--- a/google/cloud/ndb/key.py
+++ b/google/cloud/ndb/key.py
@@ -1367,6 +1367,9 @@ def _parse_from_args(
         # Offload verification of parent to ``google.cloud.datastore.Key()``.
         parent_ds_key = parent._key
 
+    if namespace == "":
+        namespace = None
+
     return google.cloud.datastore.Key(
         *flat, parent=parent_ds_key, project=project, namespace=namespace
     )

--- a/google/cloud/ndb/query.py
+++ b/google/cloud/ndb/query.py
@@ -1267,7 +1267,10 @@ class QueryOptions(_options.ReadOptions):
                 self.project = context.client.project
 
             if self.namespace is None:
-                self.namespace = context.get_namespace()
+                if self.ancestor is None:
+                    self.namespace = context.get_namespace()
+                else:
+                    self.namespace = self.ancestor.namespace()
 
 
 class Query(object):

--- a/tests/system/test_misc.py
+++ b/tests/system/test_misc.py
@@ -501,3 +501,27 @@ def test_legacy_local_structured_property_with_boolean(ds_entity):
     assert entity.children[1].bar is False
     assert entity.children[2].foo == "i'm in jail!"
     assert entity.children[2].bar is False
+
+
+@pytest.mark.usefixtures("client_context")
+def test_parent_and_child_in_default_namespace(dispose_of):
+    """Regression test for #661
+
+    https://github.com/googleapis/python-ndb/issues/661
+    """
+
+    class SomeKind(ndb.Model):
+        pass
+
+    class OtherKind(ndb.Model):
+        foo = ndb.IntegerProperty()
+
+    parent = SomeKind(namespace="")
+    parent_key = parent.put()
+    dispose_of(parent_key._key)
+
+    child = OtherKind(parent=parent_key, namespace="", foo=42)
+    child_key = child.put()
+    dispose_of(child_key._key)
+
+    assert OtherKind.query(ancestor=parent_key).get().foo == 42

--- a/tests/unit/test_key.py
+++ b/tests/unit/test_key.py
@@ -210,7 +210,7 @@ class TestKey:
         assert key._key == google.cloud.datastore.Key(
             "Kind", 1337, project="testing", namespace="foo"
         )
-        assert key._reference is None
+        assert key.namespace() == "foo"
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
@@ -219,7 +219,7 @@ class TestKey:
         key = key_module.Key("Kind", 1337, namespace="")
 
         assert key._key == google.cloud.datastore.Key("Kind", 1337, project="testing")
-        assert key._reference is None
+        assert key.namespace() is None
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
@@ -228,7 +228,7 @@ class TestKey:
         key = key_module.Key("Kind", 1337, namespace=None)
 
         assert key._key == google.cloud.datastore.Key("Kind", 1337, project="testing")
-        assert key._reference is None
+        assert key.namespace() is None
 
     @pytest.mark.usefixtures("in_context")
     def test_constructor_with_parent(self):

--- a/tests/unit/test_key.py
+++ b/tests/unit/test_key.py
@@ -212,6 +212,24 @@ class TestKey:
         )
         assert key._reference is None
 
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test_constructor_with_default_namespace_as_empty_string(context):
+        context.client.namespace = "DiffNamespace"
+        key = key_module.Key("Kind", 1337, namespace="")
+
+        assert key._key == google.cloud.datastore.Key("Kind", 1337, project="testing")
+        assert key._reference is None
+
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test_constructor_with_default_namespace_as_None(context):
+        context.client.namespace = "DiffNamespace"
+        key = key_module.Key("Kind", 1337, namespace=None)
+
+        assert key._key == google.cloud.datastore.Key("Kind", 1337, project="testing")
+        assert key._reference is None
+
     @pytest.mark.usefixtures("in_context")
     def test_constructor_with_parent(self):
         parent = key_module.Key(urlsafe=self.URLSAFE)


### PR DESCRIPTION
In the constructor for `Key`, `None` and the empty string `""` were
being treated as distinct namespaces, despite both being synonyms for
the default namespace.

In ancestor queries, the namespace for the query is now taken properly
from the ancestor key.

Fixes #661