### PR TITLE
fix: do not set read_consistency for queries

### DIFF
--- a/google/cloud/ndb/_datastore_query.py
+++ b/google/cloud/ndb/_datastore_query.py
@@ -1008,9 +1008,7 @@ def _datastore_run_query(query):
     partition_id = entity_pb2.PartitionId(
         project_id=query.project, namespace_id=query.namespace
     )
-    read_options = _datastore_api.get_read_options(
-        query, default_read_consistency=_datastore_api.EVENTUAL
-    )
+    read_options = _datastore_api.get_read_options(query)
     request = datastore_pb2.RunQueryRequest(
         project_id=query.project,
         partition_id=partition_id,

--- a/tests/unit/test__datastore_query.py
+++ b/tests/unit/test__datastore_query.py
@@ -1941,9 +1941,7 @@ class Test__datastore_run_query:
         _datastore_api.make_call.assert_called_once_with(
             "RunQuery", request, timeout=None
         )
-        _datastore_api.get_read_options.assert_called_once_with(
-            query, default_read_consistency=_datastore_api.EVENTUAL
-        )
+        _datastore_api.get_read_options.assert_called_once_with(query)
 
 
 class TestCursor:


### PR DESCRIPTION
In Cloud Datastore ancestor queries are intended to be strong by default
(https://cloud.google.com/datastore/docs/concepts/structuring_for_strong_consistency) .

In Cloud Firestore in Datastore mode, all queries should be strongly
consistent by default (https://cloud.google.com/datastore/docs/upgrade-to-firestore).

closes googleapis/python-ndb#666