### PR TITLE
fix: fix bug with repeated structured properties with Expando values

### DIFF
--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -717,7 +717,8 @@ def _properties_of(*entities):
         if not hasattr(level, "_properties"):
             continue
 
-        for prop in level._properties.values():
+        level_properties = getattr(level, "_properties", {})
+        for prop in level_properties.values():
             if (
                 not isinstance(prop, Property)
                 or isinstance(prop, ModelKey)

--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -697,17 +697,18 @@ def _entity_from_protobuf(protobuf):
 
 
 def _properties_of(*entities):
-    """Get the model properties for an entity.
+    """Get the model properties for one or more entities.
 
-    After collecting any properties local to the given entity, will traverse the
-    entity's MRO (class hierarchy) up from the entity's class through all of its
-    ancestors, collecting an ``Property`` instances defined for those classes.
+    After collecting any properties local to the given entities, will traverse the
+    entities' MRO (class hierarchy) up from the entities' class through all of its
+    ancestors, collecting any ``Property`` instances defined for those classes.
 
     Args:
-        entity (model.Model): The entity to get properties for.
+        entities (Tuple[model.Model]): The entities to get properties for. All entities
+            are expected to be of the same class.
 
     Returns:
-        Iterator[Property]: Iterator over the entity's properties.
+        Iterator[Property]: Iterator over the entities' properties.
     """
     seen = set()
 

--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -696,7 +696,7 @@ def _entity_from_protobuf(protobuf):
     return _entity_from_ds_entity(ds_entity)
 
 
-def _properties_of(entity):
+def _properties_of(*entities):
     """Get the model properties for an entity.
 
     After collecting any properties local to the given entity, will traverse the
@@ -711,7 +711,8 @@ def _properties_of(entity):
     """
     seen = set()
 
-    for level in (entity,) + tuple(type(entity).mro()):
+    entity_type = type(entities[0])  # assume all entities are same type
+    for level in entities + tuple(entity_type.mro()):
         if not hasattr(level, "_properties"):
             continue
 
@@ -4299,6 +4300,8 @@ class StructuredProperty(Property):
         if not self._repeated:
             values = (values,)
 
+        props = tuple(_properties_of(*values))
+
         for value in values:
             if value is None:
                 keys.extend(
@@ -4308,7 +4311,7 @@ class StructuredProperty(Property):
                 )
                 continue
 
-            for prop in _properties_of(value):
+            for prop in props:
                 keys.extend(
                     prop._to_datastore(
                         value, data, prefix=next_prefix, repeated=next_repeated


### PR DESCRIPTION
In the legacy data format, the dotted properties stored in Datastore
were not properly padded for missing values.

Fixes #669