### PR TITLE
test: fix flaky system test

### DIFF
--- a/tests/system/test_query.py
+++ b/tests/system/test_query.py
@@ -367,7 +367,7 @@ def test_namespace_set_on_client_with_id(dispose_of, other_namespace):
 
 
 def test_query_default_namespace_when_context_namespace_is_other(
-    client_context, dispose_of, other_namespace
+    client_context, dispose_of, namespace, other_namespace
 ):
     """Regression test for #476.
 
@@ -377,6 +377,7 @@ def test_query_default_namespace_when_context_namespace_is_other(
     class SomeKind(ndb.Model):
         foo = ndb.IntegerProperty()
         bar = ndb.StringProperty()
+        discriminator = ndb.StringProperty(default=namespace)
 
     entity1 = SomeKind(foo=1, bar="a", id="x", namespace=other_namespace)
     entity1.put()
@@ -389,7 +390,7 @@ def test_query_default_namespace_when_context_namespace_is_other(
     eventually(SomeKind.query(namespace=other_namespace).fetch, length_equals(1))
 
     with client_context.new(namespace=other_namespace).use():
-        query = SomeKind.query(namespace="")
+        query = SomeKind.query(namespace="").filter(SomeKind.discriminator == namespace)
         results = eventually(query.fetch, length_equals(1))
 
     assert results[0].foo == 2

--- a/tests/system/test_query.py
+++ b/tests/system/test_query.py
@@ -19,6 +19,7 @@ System tests for queries.
 import datetime
 import functools
 import operator
+import uuid
 
 import pytest
 import pytz
@@ -373,11 +374,12 @@ def test_query_default_namespace_when_context_namespace_is_other(
 
     https://github.com/googleapis/python-ndb/issues/476
     """
+    unique_id = str(uuid.uuid4())
 
     class SomeKind(ndb.Model):
         foo = ndb.IntegerProperty()
         bar = ndb.StringProperty()
-        discriminator = ndb.StringProperty(default=namespace)
+        discriminator = ndb.StringProperty(default=unique_id)
 
     entity1 = SomeKind(foo=1, bar="a", id="x", namespace=other_namespace)
     entity1.put()
@@ -390,7 +392,7 @@ def test_query_default_namespace_when_context_namespace_is_other(
     eventually(SomeKind.query(namespace=other_namespace).fetch, length_equals(1))
 
     with client_context.new(namespace=other_namespace).use():
-        query = SomeKind.query(namespace="").filter(SomeKind.discriminator == namespace)
+        query = SomeKind.query(namespace="").filter(SomeKind.discriminator == unique_id)
         results = eventually(query.fetch, length_equals(1))
 
     assert results[0].foo == 2

--- a/tests/system/test_query.py
+++ b/tests/system/test_query.py
@@ -368,7 +368,7 @@ def test_namespace_set_on_client_with_id(dispose_of, other_namespace):
 
 
 def test_query_default_namespace_when_context_namespace_is_other(
-    client_context, dispose_of, namespace, other_namespace
+    client_context, dispose_of, other_namespace
 ):
     """Regression test for #476.
 


### PR DESCRIPTION
Normally a unique namespace per test run is used to prevent different
test runs from interfering with each other, but some tests are
specifically for the default namespace. A discriminator is added to this
test that allows us to naorrow the test query to only entities created
in the current test run.

Fixes #700