### PR TITLE
chore: revert owlbot main branch templates

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -54,7 +54,7 @@ python3 -m pip install --upgrade --quiet nox
 python3 -m nox --version
 
 # If this is a continuous build, send the test log to the FlakyBot.
-# See https://github.com/googleapis/repo-automation-bots/tree/main/packages/flakybot.
+# See https://github.com/googleapis/repo-automation-bots/tree/master/packages/flakybot.
 if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]]; then
   cleanup() {
     chmod +x $KOKORO_GFILE_DIR/linux_amd64/flakybot

--- a/.kokoro/test-samples-impl.sh
+++ b/.kokoro/test-samples-impl.sh
@@ -80,7 +80,7 @@ for file in samples/**/requirements.txt; do
     EXIT=$?
 
     # If this is a periodic build, send the test log to the FlakyBot.
-    # See https://github.com/googleapis/repo-automation-bots/tree/main/packages/flakybot.
+    # See https://github.com/googleapis/repo-automation-bots/tree/master/packages/flakybot.
     if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"periodic"* ]]; then
       chmod +x $KOKORO_GFILE_DIR/linux_amd64/flakybot
       $KOKORO_GFILE_DIR/linux_amd64/flakybot

--- a/owlbot.py
+++ b/owlbot.py
@@ -53,31 +53,3 @@ RUN apt-get update && apt-get install -y dictionaries-common aspell aspell-en \\
 
 s.shell.run(["nox", "-s", "blacken"], hide_output=False)
 
-# ----------------------------------------------------------------------------
-# Main Branch migration
-# ----------------------------------------------------------------------------
-
-s.replace(
-  "*.rst",
-  "master",
-  "main"
-)
-
-s.replace(
-  "*.rst",
-  "google-cloud-python/blob/main",
-  "google-cloud-python/blob/master"
-)
-
-s.replace(
-  "CONTRIBUTING.rst",
-  "kubernetes/community/blob/main",
-  "kubernetes/community/blob/master"
-)
-
-s.replace(
-  ".kokoro/*",
-  "master",
-  "main"
-)
-


### PR DESCRIPTION
Reverts main branch template for OwlBot that were included for the main branch integration.