### PR TITLE
fix: pin grpcio / googleapis-common-protos under Python2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,8 @@ def main():
         readme = readme_file.read()
     dependencies = [
         "google-cloud-datastore >= 1.7.0, < 2.0.0dev",
+        "googleapis-common-protos < 1.53.0; python_version<'3.0'",
+        "grpcio < 1.40dev; python_version<'3.0'",
         "pymemcache",
         "redis",
         "pytz"

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ def main():
         "google-cloud-datastore >= 1.7.0, < 2.0.0dev",
         "googleapis-common-protos < 1.53.0; python_version<'3.0'",
         "grpcio < 1.40dev; python_version<'3.0'",
+        "protobuf < 3.18dev; python_version<'3.0'",
         "pymemcache",
         "redis",
         "pytz"


### PR DESCRIPTION
Both dropped Python2 support in a minor release.  grpcio does not declare
'python_requires'.