### PR TITLE
feat: add support for custom key/data formats in global cache

### DIFF
--- a/google/cloud/ndb/_cache.py
+++ b/google/cloud/ndb/_cache.py
@@ -19,11 +19,14 @@ import uuid
 import warnings
 
 from google.api_core import retry as core_retry
+from google.cloud.datastore import entity
 
 from google.cloud.ndb import _batch
 from google.cloud.ndb import context as context_module
 from google.cloud.ndb import tasklets
 from google.cloud.ndb import utils
+
+from google.cloud.ndb.global_cache import GlobalCache
 
 _LOCKED_FOR_READ = b"0-"
 _LOCKED_FOR_WRITE = b"00"
@@ -738,4 +741,17 @@ def global_cache_key(key):
     Returns:
         bytes: The cache key.
     """
-    return _PREFIX + key.to_protobuf().SerializeToString()
+    cache = _global_cache()
+    if cache is None:
+        return GlobalCache.cache_key(key, _PREFIX)
+    return cache.cache_key(key, _PREFIX)
+
+
+def from_global_cache_value(key, result):
+    cache = _global_cache()
+    return cache.from_cache_value(key, result)
+
+
+def to_global_cache_value(entity_pb):
+    cache = _global_cache()
+    return cache.to_cache_value(entity_pb)

--- a/google/cloud/ndb/_datastore_api.py
+++ b/google/cloud/ndb/_datastore_api.py
@@ -143,8 +143,7 @@ def lookup(key, options):
         key_locked = _cache.is_locked_value(result)
         if not key_locked:
             if result:
-                entity_pb = entity_pb2.Entity()
-                entity_pb.MergeFromString(result)
+                entity_pb = _cache.from_global_cache_value(key, result)
 
             elif use_datastore:
                 lock = yield _cache.global_lock_for_read(cache_key, result)
@@ -375,7 +374,7 @@ def put(entity, options):
             lock = yield _cache.global_lock_for_write(cache_key)
         else:
             expires = context._global_cache_timeout(entity.key, options)
-            cache_value = entity_pb.SerializeToString()
+            cache_value = _cache.to_global_cache_value(entity_pb)
             yield _cache.global_set(cache_key, cache_value, expires=expires)
 
     if use_datastore:

--- a/tests/unit/test__cache.py
+++ b/tests/unit/test__cache.py
@@ -1132,13 +1132,24 @@ def test_is_locked_value():
     assert not _cache.is_locked_value(None)
 
 
-def test_global_cache_key():
+@pytest.mark.usefixtures("in_context")
+@mock.patch("google.cloud.ndb._cache._global_cache")
+def test_global_cache_key_default(_global_cache):
+    _global_cache.return_value = None
     key = mock.Mock()
     key.to_protobuf.return_value.SerializeToString.return_value = b"himom!"
     assert _cache.global_cache_key(key) == _cache._PREFIX + b"himom!"
     key.to_protobuf.assert_called_once_with()
     key.to_protobuf.return_value.SerializeToString.assert_called_once_with()
 
+
+@pytest.mark.usefixtures("in_context")
+@mock.patch("google.cloud.ndb._cache._global_cache")
+def test_global_cache_key_custom(_global_cache):
+    _global_cache.return_value.cache_key.return_value = b"himom!"
+    key = mock.Mock()
+    assert _cache.global_cache_key(key) == b"himom!"
+    _global_cache.return_value.cache_key.assert_called_once_with(key, _cache._PREFIX)
 
 def _future_result(result):
     future = tasklets.Future()


### PR DESCRIPTION
This diff abstracts out the specifics of data format in the global cache. This lets advanced customers define their own key/data format, while maintaining the current default behavior.

The "why?" is elaborated on in the linked issue, but in short, this lets people make the migration to this library and the py3 runtime in a way that avoids breaking data format changes, because this library stores data differently than the legacy runtime.

Closes https://github.com/googleapis/python-ndb/issues/749