### PR TITLE
tests(coverage): Exclude test files from coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,3 +11,4 @@ exclude_lines =
 omit =
   */gapic/*.py
   */proto/*.py
+  tests/*/*.py


### PR DESCRIPTION
We were previously seeing coverage reports include lines like

```
tests/unit/test_query.py 1759 6 220 0 99% 19-20, 2310, 2336, 2362, 2389
```

This will ensure that only production code is counted when requiring
100% coverage.