### PR TITLE
docs: add note in Django middleware documentation that it is unimplemented

### DIFF
--- a/google/cloud/ndb/django_middleware.py
+++ b/google/cloud/ndb/django_middleware.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Django middleware for ``ndb``."""
+"""Django middleware for ``ndb``.
+
+This class is not implemented and is no longer necessary.
+
+To use Django middleware with NDB, follow the steps in
+https://cloud.google.com/appengine/docs/standard/python3/migrating-to-cloud-ndb#using_a_runtime_context_with_django
+"""
 
 
 __all__ = ["NdbDjangoMiddleware"]


### PR DESCRIPTION
This should clarify to users that they don't need to (and cannot) use the old Django middleware in Cloud NDB.