### PR TITLE
chore: upgrade enchant packages in (Owlbot-controlled) docs Docker image

### DIFF
--- a/.kokoro/docker/docs/Dockerfile
+++ b/.kokoro/docker/docs/Dockerfile
@@ -22,7 +22,7 @@ ENV PATH /usr/local/bin:$PATH
 # Install dependencies.
 # Spell check related
 RUN apt-get update && apt-get install -y dictionaries-common aspell aspell-en \
-  hunspell-en-us libenchant1c2a enchant
+  hunspell-en-us libenchant-2-2 enchant-2
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     apt-transport-https \

--- a/owlbot.py
+++ b/owlbot.py
@@ -60,7 +60,7 @@ s.replace(
     "# Install dependencies.\n",
     """\g<0># Spell check related
 RUN apt-get update && apt-get install -y dictionaries-common aspell aspell-en \\
-  hunspell-en-us libenchant1c2a enchant
+  hunspell-en-us libenchant-2-2 enchant-2
 """
 )
 


### PR DESCRIPTION
Ubuntu Jammy doesn't have the enchant and libenchant1c2a packages. So, after https://github.com/googleapis/synthtool/pull/1422 was merged, which switched the base image of the Dockerfile, it's been unable to install these packages.