### PR TITLE
chore: Fix datastore system test index creation command

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -187,7 +187,7 @@ Running System Tests
    > --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
 
    # Create the indexes
-   $ gcloud datastore create-indexes system_tests/data/index.yaml
+   $ gcloud datastore indexes create tests/system/index.yaml
 
 - For datastore query tests, you'll need stored data in your dataset.
   To populate this data, run::


### PR DESCRIPTION
See https://cloud.google.com/sdk/gcloud/reference/datastore/indexes/create for the proper syntax.

Also, the path to the index file was wrong.