### PR TITLE
chore: Fix api_shortname in .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -10,5 +10,5 @@
     "distribution_name": "google-cloud-ndb",
     "default_version": "",
     "codeowner_team": "@googleapis/firestore-dpe @googleapis/cloud-storage-dpe",
-    "api_shortname": "python-ndb"
+    "api_shortname": "datastore"
 }


### PR DESCRIPTION
Fix #754

Per that issue, for gRPC libraries `api_shortname` should match the subdomain of an API's hostName.