### PR TITLE
feat: Support client_options for Clients

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ def main():
     with io.open(readme_filename, encoding="utf-8") as readme_file:
         readme = readme_file.read()
     dependencies = [
+        "google-api-core[grpc] >= 1.34.0, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
         "google-cloud-datastore >= 2.7.2, <3.0.0dev",
         "protobuf >= 3.19.5, <5.0.0dev,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
         "pymemcache >= 2.1.0, < 5.0.0dev",

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -6,6 +6,7 @@
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
 google-cloud-datastore==2.7.2
+google-api-core==1.34.0
 protobuf==3.19.5
 pymemcache==2.1.0
 redis==3.0.0

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -21,6 +21,7 @@ except ImportError:  # pragma: NO PY3 COVER
     import mock
 
 from google.auth import credentials
+from google.api_core.client_options import ClientOptions
 from google.cloud import environment_vars
 from google.cloud.datastore import _http
 
@@ -81,9 +82,42 @@ class TestClient:
                 project="test-project",
                 namespace="test-namespace",
                 credentials=creds,
+                client_options=ClientOptions(
+                    api_endpoint="alternate-endpoint.example.com"
+                ),
             )
         assert client.namespace == "test-namespace"
         assert client.project == "test-project"
+        assert client.host == "alternate-endpoint.example.com"
+        assert client.secure is True
+
+    @staticmethod
+    def test_constructor_client_options_as_dict():
+        with patch_credentials("testing") as creds:
+            client = client_module.Client(
+                project="test-project",
+                namespace="test-namespace",
+                credentials=creds,
+                client_options={"api_endpoint": "alternate-endpoint.example.com"},
+            )
+        assert client.namespace == "test-namespace"
+        assert client.project == "test-project"
+        assert client.host == "alternate-endpoint.example.com"
+        assert client.secure is True
+
+    @staticmethod
+    def test_constructor_client_options_no_api_endpoint():
+        with patch_credentials("testing") as creds:
+            client = client_module.Client(
+                project="test-project",
+                namespace="test-namespace",
+                credentials=creds,
+                client_options={"scopes": ["my_scope"]},
+            )
+        assert client.namespace == "test-namespace"
+        assert client.project == "test-project"
+        assert client.host == _http.DATASTORE_API_HOST
+        assert client.secure is True
 
     @staticmethod
     def test__determine_default():


### PR DESCRIPTION
Currently, NDB clients do not recognize `client_options` as a keyword argument. Furthermore, because they currently create a Datastore channel directly, we have to manually modify the host to ensure it is passed to the Datastore channel. Merely setting the API endpoint via environment variable is not sufficient, because that variable's presence is currently used to test whether or not we are using the datastore emulator.

Also, depend directly on the API lib v1.32.0 or later now to ensure that it recognizes `client_options`.