### PR TITLE
fix(model): Ensure repeated props have same kind when converting from ds

### DIFF
--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -543,6 +543,7 @@ def _entity_from_ds_entity(ds_entity, model_class=None):
     Args:
         ds_entity (google.cloud.datastore_v1.types.Entity): An entity to be
             deserialized.
+        model_class (class): Optional; ndb Model class type.
 
     Returns:
         .Model: The deserialized entity.
@@ -623,10 +624,14 @@ def _entity_from_ds_entity(ds_entity, model_class=None):
                         # different lengths for the subproperties, which was a
                         # bug. We work around this when reading out such values
                         # by making sure our repeated property is the same
-                        # length as the longest suproperty.
+                        # length as the longest subproperty.
+                        # Make sure to create a key of the same kind as
+                        # the other entries in the value list
                         while len(subvalue) > len(value):
                             # Need to make some more subentities
-                            value.append(new_entity(key._key))
+                            expando_kind = structprop._model_class._get_kind()
+                            expando_key = key_module.Key(expando_kind, None)
+                            value.append(new_entity(expando_key._key))
 
                         # Branch coverage bug,
                         # See: https://github.com/nedbat/coveragepy/issues/817


### PR DESCRIPTION
Legacy NDB had a bug where, with repeated Expando properties, it could end up writing arrays of different length if some entities had missing values for certain subproperties. When Cloud NDB read this out, it might have only loaded entities corresponding to the shorter array length. See issue #129 .

To fix this, with PR #176 , we made Cloud NDB check if there are length differences and pad out the array as necessary.

However, depending on the order properties are returned from Datastore in, we may have accidentally padded with subentities of the wrong kind, because it was possible to skip over updating the kind if we alternated between updating repeated properties.

(Eg: A.a with 2 elements, B.b with 3 elements, A.c with 3 elements -> A would end up with an element of B's kind)