### PR TITLE
chore(deps): Drop dependencies that were only used for Python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,6 @@ def main():
         readme = readme_file.read()
     dependencies = [
         "google-cloud-datastore >= 1.7.0, < 2.0.0dev",
-        "googleapis-common-protos < 1.53.0; python_version<'3.0'",
-        "grpcio < 1.40dev; python_version<'3.0'",
-        "protobuf < 3.18dev; python_version<'3.0'",
         "pymemcache",
         "redis",
         "pytz"


### PR DESCRIPTION
These were first added in https://github.com/googleapis/python-ndb/pull/725

Note that we're still _implicitly_ [depending on them](https://github.com/googleapis/python-datastore/blob/v1.15.5/setup.py#L32-L34). This just gets rid of the now-moot Python 2-only version pins.