### PR TITLE
chore(deps): Specify minimum versions of pymemcache, redis, and pytz

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,9 @@ def main():
         readme = readme_file.read()
     dependencies = [
         "google-cloud-datastore >= 1.7.0, < 2.0.0dev",
-        "pymemcache",
-        "redis",
-        "pytz"
+        "pymemcache >= 2.1.0, < 5.0.0dev",
+        "redis >= 3.0.0, < 5.0.0dev",
+        "pytz >= 2018.3"
     ]
 
     if sys.version_info.major == 3 and sys.version_info.minor < 7:

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -1,0 +1,11 @@
+# This constraints file is used to check that lower bounds
+# are correct in setup.py
+# List *all* library dependencies and extras in this file.
+# Pin the version to the lower bound.
+#
+# e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
+# Then this file should have foo==1.14.0
+google-cloud-datastore==1.7.0
+pymemcache==2.1.0
+redis==3.0.0
+pytz==2018.3


### PR DESCRIPTION
These are _very_ lenient minimums; they represent the oldest versions I could find on pypi for which the tests all pass.

Include them in the constraints file for 3.7 as well for testing purposes.