### PR TITLE
chore(nox): Remove Py2-only condition

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -68,8 +68,7 @@ def unit(session):
     run_args.append(get_path("tests", "unit"))
     session.run(*run_args)
 
-    # Do not run cover session for Python 2, or it will fail
-    if not session.posargs and session.python[0] != "2":
+    if not session.posargs:
         session.notify("cover")
 
 


### PR DESCRIPTION
We only support Python 3.x now, so this condition is now always true