### PR TITLE
feat(dependencies)!: Upgrade to google-cloud-datastore 2.x

### DIFF
--- a/google/cloud/ndb/_cache.py
+++ b/google/cloud/ndb/_cache.py
@@ -738,4 +738,4 @@ def global_cache_key(key):
     Returns:
         bytes: The cache key.
     """
-    return _PREFIX + key.to_protobuf().SerializeToString()
+    return _PREFIX + key.to_protobuf()._pb.SerializeToString()

--- a/google/cloud/ndb/_datastore_api.py
+++ b/google/cloud/ndb/_datastore_api.py
@@ -20,8 +20,8 @@ import logging
 
 from google.api_core import exceptions as core_exceptions
 from google.cloud.datastore import helpers
-from google.cloud.datastore_v1.proto import datastore_pb2
-from google.cloud.datastore_v1.proto import entity_pb2
+from google.cloud.datastore_v1.types import datastore as datastore_pb2
+from google.cloud.datastore_v1.types import entity as entity_pb2
 
 from google.cloud.ndb import context as context_module
 from google.cloud.ndb import _batch

--- a/google/cloud/ndb/_datastore_api.py
+++ b/google/cloud/ndb/_datastore_api.py
@@ -221,7 +221,7 @@ class _LookupBatch(object):
         keys = []
         for todo_key in self.todo.keys():
             key_pb = entity_pb2.Key()
-            key_pb.ParseFromString(todo_key)
+            key_pb._pb.ParseFromString(todo_key)
             keys.append(key_pb)
 
         read_options = get_read_options(self.options)
@@ -306,7 +306,7 @@ def _datastore_lookup(keys, read_options, retries=None, timeout=None):
         read_options=read_options,
     )
 
-    return make_call("Lookup", request, retries=retries, timeout=timeout)
+    return make_call("lookup", request, retries=retries, timeout=timeout)
 
 
 def get_read_options(options, default_read_consistency=None):
@@ -875,7 +875,7 @@ def _datastore_commit(mutations, transaction, retries=None, timeout=None):
         transaction=transaction,
     )
 
-    return make_call("Commit", request, retries=retries, timeout=timeout)
+    return make_call("commit", request, retries=retries, timeout=timeout)
 
 
 def allocate(keys, options):
@@ -992,7 +992,7 @@ def _datastore_allocate_ids(keys, retries=None, timeout=None):
     client = context_module.get_context().client
     request = datastore_pb2.AllocateIdsRequest(project_id=client.project, keys=keys)
 
-    return make_call("AllocateIds", request, retries=retries, timeout=timeout)
+    return make_call("allocate_ids", request, retries=retries, timeout=timeout)
 
 
 @tasklets.tasklet
@@ -1048,7 +1048,7 @@ def _datastore_begin_transaction(read_only, retries=None, timeout=None):
         project_id=client.project, transaction_options=options
     )
 
-    return make_call("BeginTransaction", request, retries=retries, timeout=timeout)
+    return make_call("begin_transaction", request, retries=retries, timeout=timeout)
 
 
 @tasklets.tasklet
@@ -1089,4 +1089,4 @@ def _datastore_rollback(transaction, retries=None, timeout=None):
         project_id=client.project, transaction=transaction
     )
 
-    return make_call("Rollback", request, retries=retries, timeout=timeout)
+    return make_call("rollback", request, retries=retries, timeout=timeout)

--- a/google/cloud/ndb/_datastore_api.py
+++ b/google/cloud/ndb/_datastore_api.py
@@ -33,9 +33,9 @@ from google.cloud.ndb import _retry
 from google.cloud.ndb import tasklets
 from google.cloud.ndb import utils
 
-EVENTUAL = datastore_pb2.ReadOptions.EVENTUAL
+EVENTUAL = datastore_pb2.ReadOptions.ReadConsistency.EVENTUAL
 EVENTUAL_CONSISTENCY = EVENTUAL  # Legacy NDB
-STRONG = datastore_pb2.ReadOptions.STRONG
+STRONG = datastore_pb2.ReadOptions.ReadConsistency.STRONG
 
 _DEFAULT_TIMEOUT = None
 _NOT_FOUND = object()
@@ -863,9 +863,9 @@ def _datastore_commit(mutations, transaction, retries=None, timeout=None):
             :class:`google.cloud.datastore_v1.datastore_pb2.CommitResponse`
     """
     if transaction is None:
-        mode = datastore_pb2.CommitRequest.NON_TRANSACTIONAL
+        mode = datastore_pb2.CommitRequest.Mode.NON_TRANSACTIONAL
     else:
-        mode = datastore_pb2.CommitRequest.TRANSACTIONAL
+        mode = datastore_pb2.CommitRequest.Mode.TRANSACTIONAL
 
     client = context_module.get_context().client
     request = datastore_pb2.CommitRequest(

--- a/google/cloud/ndb/_datastore_query.py
+++ b/google/cloud/ndb/_datastore_query.py
@@ -77,7 +77,7 @@ def make_filter(name, op, value):
         property=query_pb2.PropertyReference(name=name),
         op=FILTER_OPERATORS[op],
     )
-    helpers._set_protobuf_value(filter_pb.value, value)
+    helpers._set_protobuf_value(filter_pb.value._pb, value)
     return filter_pb
 
 
@@ -811,9 +811,9 @@ class _Result(object):
                 ).flat_path
             else:
                 this_value_pb = self.result_pb.entity.properties[order.name]
-                this_value = helpers._get_value_from_value_pb(this_value_pb)
+                this_value = helpers._get_value_from_value_pb(this_value_pb._pb)
                 other_value_pb = other.result_pb.entity.properties[order.name]
-                other_value = helpers._get_value_from_value_pb(other_value_pb)
+                other_value = helpers._get_value_from_value_pb(other_value_pb._pb)
 
                 # Compare key paths if ordering by key property
                 if isinstance(this_value, Key):
@@ -943,7 +943,7 @@ def _query_to_protobuf(query):
             filter_pb = ancestor_filter_pb
 
         elif isinstance(filter_pb, query_pb2.CompositeFilter):
-            filter_pb.filters.add(property_filter=ancestor_filter_pb)
+            filter_pb.filters._pb.add(property_filter=ancestor_filter_pb._pb)
 
         else:
             filter_pb = query_pb2.CompositeFilter(
@@ -969,7 +969,7 @@ def _query_to_protobuf(query):
         query_pb.offset = query.offset
 
     if query.limit:
-        query_pb.limit.value = query.limit
+        query_pb._pb.limit.value = query.limit
 
     return query_pb
 

--- a/google/cloud/ndb/_datastore_query.py
+++ b/google/cloud/ndb/_datastore_query.py
@@ -683,7 +683,7 @@ class _MultiQueryIteratorImpl(QueryIterator):
                 next_result = result_sets[0].next()
 
             # Check to see if it's a duplicate
-            hash_key = next_result.result_pb.entity.key.SerializeToString()
+            hash_key = next_result.result_pb.entity.key._pb.SerializeToString()
             if hash_key in self._seen_keys:
                 continue
 
@@ -937,7 +937,7 @@ def _query_to_protobuf(query):
             property=query_pb2.PropertyReference(name="__key__"),
             op=query_pb2.PropertyFilter.Operator.HAS_ANCESTOR,
         )
-        ancestor_filter_pb.value.key_value.CopyFrom(ancestor_pb)
+        ancestor_filter_pb.value.key_value._pb.CopyFrom(ancestor_pb._pb)
 
         if filter_pb is None:
             filter_pb = ancestor_filter_pb

--- a/google/cloud/ndb/_datastore_query.py
+++ b/google/cloud/ndb/_datastore_query.py
@@ -1016,7 +1016,7 @@ def _datastore_run_query(query):
         read_options=read_options,
     )
     response = yield _datastore_api.make_call(
-        "RunQuery", request, timeout=query.timeout
+        "run_query", request, timeout=query.timeout
     )
     utils.logging_debug(log, response)
     raise tasklets.Return(response)

--- a/google/cloud/ndb/_datastore_query.py
+++ b/google/cloud/ndb/_datastore_query.py
@@ -22,9 +22,9 @@ import os
 
 from google.cloud import environment_vars
 
-from google.cloud.datastore_v1.proto import datastore_pb2
-from google.cloud.datastore_v1.proto import entity_pb2
-from google.cloud.datastore_v1.proto import query_pb2
+from google.cloud.datastore_v1.types import datastore as datastore_pb2
+from google.cloud.datastore_v1.types import entity as entity_pb2
+from google.cloud.datastore_v1.types import query as query_pb2
 from google.cloud.datastore import helpers, Key
 
 from google.cloud.ndb import context as context_module

--- a/google/cloud/ndb/_datastore_query.py
+++ b/google/cloud/ndb/_datastore_query.py
@@ -38,24 +38,24 @@ from google.cloud.ndb import utils
 log = logging.getLogger(__name__)
 
 MoreResultsType = query_pb2.QueryResultBatch.MoreResultsType
-NO_MORE_RESULTS = MoreResultsType.Value("NO_MORE_RESULTS")
-NOT_FINISHED = MoreResultsType.Value("NOT_FINISHED")
-MORE_RESULTS_AFTER_LIMIT = MoreResultsType.Value("MORE_RESULTS_AFTER_LIMIT")
+NO_MORE_RESULTS = MoreResultsType.NO_MORE_RESULTS
+NOT_FINISHED = MoreResultsType.NOT_FINISHED
+MORE_RESULTS_AFTER_LIMIT = MoreResultsType.MORE_RESULTS_AFTER_LIMIT
 
 ResultType = query_pb2.EntityResult.ResultType
-RESULT_TYPE_FULL = ResultType.Value("FULL")
-RESULT_TYPE_KEY_ONLY = ResultType.Value("KEY_ONLY")
-RESULT_TYPE_PROJECTION = ResultType.Value("PROJECTION")
+RESULT_TYPE_FULL = ResultType.FULL
+RESULT_TYPE_KEY_ONLY = ResultType.KEY_ONLY
+RESULT_TYPE_PROJECTION = ResultType.PROJECTION
 
-DOWN = query_pb2.PropertyOrder.DESCENDING
-UP = query_pb2.PropertyOrder.ASCENDING
+DOWN = query_pb2.PropertyOrder.Direction.DESCENDING
+UP = query_pb2.PropertyOrder.Direction.ASCENDING
 
 FILTER_OPERATORS = {
-    "=": query_pb2.PropertyFilter.EQUAL,
-    "<": query_pb2.PropertyFilter.LESS_THAN,
-    "<=": query_pb2.PropertyFilter.LESS_THAN_OR_EQUAL,
-    ">": query_pb2.PropertyFilter.GREATER_THAN,
-    ">=": query_pb2.PropertyFilter.GREATER_THAN_OR_EQUAL,
+    "=": query_pb2.PropertyFilter.Operator.EQUAL,
+    "<": query_pb2.PropertyFilter.Operator.LESS_THAN,
+    "<=": query_pb2.PropertyFilter.Operator.LESS_THAN_OR_EQUAL,
+    ">": query_pb2.PropertyFilter.Operator.GREATER_THAN,
+    ">=": query_pb2.PropertyFilter.Operator.GREATER_THAN_OR_EQUAL,
 }
 
 _KEY_NOT_IN_CACHE = object()
@@ -92,7 +92,7 @@ def make_composite_and_filter(filter_pbs):
         query_pb2.CompositeFilter: The new composite filter.
     """
     return query_pb2.CompositeFilter(
-        op=query_pb2.CompositeFilter.AND,
+        op=query_pb2.CompositeFilter.Operator.AND,
         filters=[_filter_pb(filter_pb) for filter_pb in filter_pbs],
     )
 
@@ -935,7 +935,7 @@ def _query_to_protobuf(query):
         ancestor_pb = query.ancestor._key.to_protobuf()
         ancestor_filter_pb = query_pb2.PropertyFilter(
             property=query_pb2.PropertyReference(name="__key__"),
-            op=query_pb2.PropertyFilter.HAS_ANCESTOR,
+            op=query_pb2.PropertyFilter.Operator.HAS_ANCESTOR,
         )
         ancestor_filter_pb.value.key_value.CopyFrom(ancestor_pb)
 
@@ -947,7 +947,7 @@ def _query_to_protobuf(query):
 
         else:
             filter_pb = query_pb2.CompositeFilter(
-                op=query_pb2.CompositeFilter.AND,
+                op=query_pb2.CompositeFilter.Operator.AND,
                 filters=[
                     _filter_pb(filter_pb),
                     _filter_pb(ancestor_filter_pb),

--- a/google/cloud/ndb/client.py
+++ b/google/cloud/ndb/client.py
@@ -19,11 +19,13 @@ import grpc
 import os
 import requests
 
-from google.api_core import client_info
+from google.api_core.gapic_v1 import client_info
 from google.cloud import environment_vars
 from google.cloud import _helpers
 from google.cloud import client as google_client
-from google.cloud.datastore import client as datastore_client
+from google.cloud.datastore_v1.services.datastore.transports import (
+    grpc as datastore_grpc,
+)
 
 from google.cloud.ndb import __version__
 from google.cloud.ndb import context as context_module
@@ -113,14 +115,17 @@ class Client(google_client.ClientWithProject):
 
         if emulator:
             channel = grpc.insecure_channel(self.host)
-
         else:
-            user_agent = _CLIENT_INFO.to_user_agent()
+            user_agent = self.client_info.to_user_agent()
             channel = _helpers.make_secure_channel(
                 self._credentials, user_agent, self.host
             )
-
-        self.stub = datastore_pb2_grpc.DatastoreStub(channel)
+        self.stub = datastore_grpc.DatastoreGrpcTransport(
+            host=self.host,
+            credentials=credentials,
+            client_info=self.client_info,
+            channel=channel,
+        )
 
     @contextlib.contextmanager
     def context(

--- a/google/cloud/ndb/client.py
+++ b/google/cloud/ndb/client.py
@@ -23,8 +23,7 @@ from google.api_core import client_info
 from google.cloud import environment_vars
 from google.cloud import _helpers
 from google.cloud import client as google_client
-from google.cloud.datastore_v1.gapic import datastore_client
-from google.cloud.datastore_v1.proto import datastore_pb2_grpc
+from google.cloud.datastore import client as datastore_client
 
 from google.cloud.ndb import __version__
 from google.cloud.ndb import context as context_module
@@ -35,7 +34,7 @@ _CLIENT_INFO = client_info.ClientInfo(
     user_agent="google-cloud-ndb/{}".format(__version__)
 )
 
-DATASTORE_API_HOST = datastore_client.DatastoreClient.SERVICE_ADDRESS.rsplit(":", 1)[0]
+DATASTORE_API_HOST = "datastore.googleapis.com"
 
 
 def _get_gcd_project():

--- a/google/cloud/ndb/key.py
+++ b/google/cloud/ndb/key.py
@@ -204,7 +204,7 @@ class Key(object):
         >>> reference
         app: "example"
         path {
-          Element {
+          element {
             type: "Kind"
             id: 1337
           }
@@ -681,13 +681,13 @@ class Key(object):
             >>> key = ndb.Key("Trampoline", 88, project="xy", namespace="zt")
             >>> key.reference()
             app: "xy"
+            name_space: "zt"
             path {
-              Element {
+              element {
                 type: "Trampoline"
                 id: 88
               }
             }
-            name_space: "zt"
             <BLANKLINE>
         """
         if self._reference is None:

--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -263,7 +263,7 @@ import pytz
 
 from google.cloud.datastore import entity as ds_entity_module
 from google.cloud.datastore import helpers
-from google.cloud.datastore_v1.proto import entity_pb2
+from google.cloud.datastore_v1.types import entity as entity_pb2
 
 from google.cloud.ndb import _legacy_entity_pb
 from google.cloud.ndb import _datastore_types

--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -793,7 +793,8 @@ def _entity_to_protobuf(entity, set_key=True):
 
     Returns:
         google.cloud.datastore_v1.types.Entity: The protocol buffer
-            representation.
+            representation. Note that some methods are now only
+            accessible via the `_pb` property.
     """
     ds_entity = _entity_to_ds_entity(entity, set_key=set_key)
     return helpers.entity_to_protobuf(ds_entity)
@@ -4418,8 +4419,9 @@ class LocalStructuredProperty(BlobProperty):
                 "Cannot convert to bytes expected {} value; "
                 "received {}".format(self._model_class.__name__, value)
             )
-        pb = _entity_to_protobuf(value, set_key=self._keep_keys)
-        return pb.SerializePartialToString()
+        return _entity_to_protobuf(
+            value, set_key=self._keep_keys
+        )._pb.SerializePartialToString()
 
     def _from_base_type(self, value):
         """Convert a value from the "base" value type for this property.
@@ -4431,7 +4433,7 @@ class LocalStructuredProperty(BlobProperty):
         """
         if isinstance(value, bytes):
             pb = entity_pb2.Entity()
-            pb.MergeFromString(value)
+            pb._pb.MergeFromString(value)
             entity_value = helpers.entity_from_protobuf(pb)
             if not entity_value.keys():
                 # No properties. Maybe dealing with legacy pb format.

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ def main():
     with io.open(readme_filename, encoding="utf-8") as readme_file:
         readme = readme_file.read()
     dependencies = [
-        "google-cloud-datastore >= 1.7.0, < 2.0.0dev",
+        "google-cloud-datastore >= 2.7.2, <3.0.0dev",
+        "protobuf >= 3.19.5, <5.0.0dev,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
         "pymemcache >= 2.1.0, < 5.0.0dev",
         "redis >= 3.0.0, < 5.0.0dev",
         "pytz >= 2018.3"

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -5,7 +5,8 @@
 #
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
-google-cloud-datastore==1.7.0
+google-cloud-datastore==2.7.2
+protobuf==3.19.5
 pymemcache==2.1.0
 redis==3.0.0
 pytz==2018.3

--- a/tests/unit/test__cache.py
+++ b/tests/unit/test__cache.py
@@ -1134,10 +1134,10 @@ def test_is_locked_value():
 
 def test_global_cache_key():
     key = mock.Mock()
-    key.to_protobuf.return_value.SerializeToString.return_value = b"himom!"
+    key.to_protobuf.return_value._pb.SerializeToString.return_value = b"himom!"
     assert _cache.global_cache_key(key) == _cache._PREFIX + b"himom!"
     key.to_protobuf.assert_called_once_with()
-    key.to_protobuf.return_value.SerializeToString.assert_called_once_with()
+    key.to_protobuf.return_value._pb.SerializeToString.assert_called_once_with()
 
 
 def _future_result(result):

--- a/tests/unit/test__datastore_api.py
+++ b/tests/unit/test__datastore_api.py
@@ -600,7 +600,7 @@ class Test_get_read_options:
             _options.ReadOptions(read_consistency=_api.EVENTUAL)
         )
         assert options == datastore_pb2.ReadOptions(
-            read_consistency=datastore_pb2.ReadOptions.EVENTUAL
+            read_consistency=datastore_pb2.ReadOptions.ReadConsistency.EVENTUAL
         )
 
     @staticmethod
@@ -1230,7 +1230,7 @@ class Test_datastore_commit:
 
         datastore_pb2.CommitRequest.assert_called_once_with(
             project_id="testing",
-            mode=datastore_pb2.CommitRequest.NON_TRANSACTIONAL,
+            mode=datastore_pb2.CommitRequest.Mode.NON_TRANSACTIONAL,
             mutations=mutations,
             transaction=None,
         )
@@ -1252,7 +1252,7 @@ class Test_datastore_commit:
 
         datastore_pb2.CommitRequest.assert_called_once_with(
             project_id="testing",
-            mode=datastore_pb2.CommitRequest.TRANSACTIONAL,
+            mode=datastore_pb2.CommitRequest.Mode.TRANSACTIONAL,
             mutations=mutations,
             transaction=b"tx123",
         )

--- a/tests/unit/test__datastore_api.py
+++ b/tests/unit/test__datastore_api.py
@@ -382,12 +382,19 @@ class Test_LookupBatch:
     @mock.patch("google.cloud.ndb._datastore_api.entity_pb2")
     @mock.patch("google.cloud.ndb._datastore_api._datastore_lookup")
     def test_idle_callback(_datastore_lookup, entity_pb2, context):
-        class MockKey:
-            def __init__(self, key=None):
+        class MockKeyPb:
+            def __init__(self, key=None, parent=None):
                 self.key = key
+                self.parent = parent
 
             def ParseFromString(self, key):
                 self.key = key
+                self.parent.key = key
+
+        class MockKey:
+            def __init__(self, key=None):
+                self.key = key
+                self._pb = MockKeyPb(key, self)
 
         rpc = tasklets.Future("_datastore_lookup")
         _datastore_lookup.return_value = rpc

--- a/tests/unit/test__datastore_api.py
+++ b/tests/unit/test__datastore_api.py
@@ -554,20 +554,20 @@ class Test_LookupBatch:
 def test__datastore_lookup(datastore_pb2, context):
     client = mock.Mock(
         project="theproject",
-        stub=mock.Mock(spec=("Lookup",)),
+        stub=mock.Mock(spec=("lookup",)),
         spec=("project", "stub"),
     )
     with context.new(client=client).use() as context:
-        client.stub.Lookup = Lookup = mock.Mock(spec=("future",))
+        client.stub.lookup = lookup = mock.Mock(spec=("future",))
         future = tasklets.Future()
         future.set_result("response")
-        Lookup.future.return_value = future
+        lookup.future.return_value = future
         assert _api._datastore_lookup(["foo", "bar"], None).result() == "response"
 
         datastore_pb2.LookupRequest.assert_called_once_with(
             project_id="theproject", keys=["foo", "bar"], read_options=None
         )
-        client.stub.Lookup.future.assert_called_once_with(
+        client.stub.lookup.future.assert_called_once_with(
             datastore_pb2.LookupRequest.return_value,
             timeout=_api._DEFAULT_TIMEOUT,
         )
@@ -1225,7 +1225,7 @@ class Test_datastore_commit:
         api = stub.return_value
         future = tasklets.Future()
         future.set_result("response")
-        api.Commit.future.return_value = future
+        api.commit.future.return_value = future
         assert _api._datastore_commit(mutations, None).result() == "response"
 
         datastore_pb2.CommitRequest.assert_called_once_with(
@@ -1236,7 +1236,7 @@ class Test_datastore_commit:
         )
 
         request = datastore_pb2.CommitRequest.return_value
-        assert api.Commit.future.called_once_with(request)
+        assert api.commit.future.called_once_with(request)
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
@@ -1247,7 +1247,7 @@ class Test_datastore_commit:
         api = stub.return_value
         future = tasklets.Future()
         future.set_result("response")
-        api.Commit.future.return_value = future
+        api.commit.future.return_value = future
         assert _api._datastore_commit(mutations, b"tx123").result() == "response"
 
         datastore_pb2.CommitRequest.assert_called_once_with(
@@ -1258,7 +1258,7 @@ class Test_datastore_commit:
         )
 
         request = datastore_pb2.CommitRequest.return_value
-        assert api.Commit.future.called_once_with(request)
+        assert api.commit.future.called_once_with(request)
 
 
 @pytest.mark.usefixtures("in_context")
@@ -1339,7 +1339,7 @@ def test__datastore_allocate_ids(stub, datastore_pb2):
     api = stub.return_value
     future = tasklets.Future()
     future.set_result("response")
-    api.AllocateIds.future.return_value = future
+    api.allocate_ids.future.return_value = future
     assert _api._datastore_allocate_ids(keys).result() == "response"
 
     datastore_pb2.AllocateIdsRequest.assert_called_once_with(
@@ -1347,7 +1347,7 @@ def test__datastore_allocate_ids(stub, datastore_pb2):
     )
 
     request = datastore_pb2.AllocateIdsRequest.return_value
-    assert api.AllocateIds.future.called_once_with(request)
+    assert api.allocate_ids.future.called_once_with(request)
 
 
 @pytest.mark.usefixtures("in_context")
@@ -1374,7 +1374,7 @@ class Test_datastore_begin_transaction:
         api = stub.return_value
         future = tasklets.Future()
         future.set_result("response")
-        api.BeginTransaction.future.return_value = future
+        api.begin_transaction.future.return_value = future
         assert _api._datastore_begin_transaction(True).result() == "response"
 
         datastore_pb2.TransactionOptions.assert_called_once_with(
@@ -1387,7 +1387,7 @@ class Test_datastore_begin_transaction:
         )
 
         request = datastore_pb2.BeginTransactionRequest.return_value
-        assert api.BeginTransaction.future.called_once_with(request)
+        assert api.begin_transaction.future.called_once_with(request)
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
@@ -1397,7 +1397,7 @@ class Test_datastore_begin_transaction:
         api = stub.return_value
         future = tasklets.Future()
         future.set_result("response")
-        api.BeginTransaction.future.return_value = future
+        api.begin_transaction.future.return_value = future
         assert _api._datastore_begin_transaction(False).result() == "response"
 
         datastore_pb2.TransactionOptions.assert_called_once_with(
@@ -1410,7 +1410,7 @@ class Test_datastore_begin_transaction:
         )
 
         request = datastore_pb2.BeginTransactionRequest.return_value
-        assert api.BeginTransaction.future.called_once_with(request)
+        assert api.begin_transaction.future.called_once_with(request)
 
 
 @pytest.mark.usefixtures("in_context")
@@ -1433,7 +1433,7 @@ def test__datastore_rollback(stub, datastore_pb2):
     api = stub.return_value
     future = tasklets.Future()
     future.set_result("response")
-    api.Rollback.future.return_value = future
+    api.rollback.future.return_value = future
     assert _api._datastore_rollback(b"tx123").result() == "response"
 
     datastore_pb2.RollbackRequest.assert_called_once_with(
@@ -1441,7 +1441,7 @@ def test__datastore_rollback(stub, datastore_pb2):
     )
 
     request = datastore_pb2.RollbackRequest.return_value
-    assert api.Rollback.future.called_once_with(request)
+    assert api.rollback.future.called_once_with(request)
 
 
 def test__complete():

--- a/tests/unit/test__datastore_api.py
+++ b/tests/unit/test__datastore_api.py
@@ -25,8 +25,8 @@ from google.api_core import exceptions as core_exceptions
 from google.cloud.datastore import entity
 from google.cloud.datastore import helpers
 from google.cloud.datastore import key as ds_key_module
-from google.cloud.datastore_v1.proto import datastore_pb2
-from google.cloud.datastore_v1.proto import entity_pb2
+from google.cloud.datastore_v1.types import datastore as datastore_pb2
+from google.cloud.datastore_v1.types import entity as entity_pb2
 from google.cloud.ndb import _batch
 from google.cloud.ndb import _cache
 from google.cloud.ndb import context as context_module

--- a/tests/unit/test__datastore_query.py
+++ b/tests/unit/test__datastore_query.py
@@ -1942,7 +1942,7 @@ class Test__datastore_run_query:
         _datastore_api.get_read_options.return_value = read_options
         assert _datastore_query._datastore_run_query(query).result() == "foo"
         _datastore_api.make_call.assert_called_once_with(
-            "RunQuery", request, timeout=None
+            "run_query", request, timeout=None
         )
         _datastore_api.get_read_options.assert_called_once_with(query)
 

--- a/tests/unit/test__datastore_query.py
+++ b/tests/unit/test__datastore_query.py
@@ -21,9 +21,9 @@ except ImportError:  # pragma: NO PY3 COVER
 
 import pytest
 
-from google.cloud.datastore_v1.proto import datastore_pb2
-from google.cloud.datastore_v1.proto import entity_pb2
-from google.cloud.datastore_v1.proto import query_pb2
+from google.cloud.datastore_v1.types import datastore as datastore_pb2
+from google.cloud.datastore_v1.types import entity as entity_pb2
+from google.cloud.datastore_v1.types import query as query_pb2
 
 from google.cloud.ndb import _datastore_query
 from google.cloud.ndb import context as context_module

--- a/tests/unit/test__datastore_query.py
+++ b/tests/unit/test__datastore_query.py
@@ -39,7 +39,7 @@ from . import utils
 def test_make_filter():
     expected = query_pb2.PropertyFilter(
         property=query_pb2.PropertyReference(name="harry"),
-        op=query_pb2.PropertyFilter.EQUAL,
+        op=query_pb2.PropertyFilter.Operator.EQUAL,
         value=entity_pb2.Value(string_value="Harold"),
     )
     assert _datastore_query.make_filter("harry", "=", u"Harold") == expected
@@ -49,17 +49,17 @@ def test_make_composite_and_filter():
     filters = [
         query_pb2.PropertyFilter(
             property=query_pb2.PropertyReference(name="harry"),
-            op=query_pb2.PropertyFilter.EQUAL,
+            op=query_pb2.PropertyFilter.Operator.EQUAL,
             value=entity_pb2.Value(string_value="Harold"),
         ),
         query_pb2.PropertyFilter(
             property=query_pb2.PropertyReference(name="josie"),
-            op=query_pb2.PropertyFilter.EQUAL,
+            op=query_pb2.PropertyFilter.Operator.EQUAL,
             value=entity_pb2.Value(string_value="Josephine"),
         ),
     ]
     expected = query_pb2.CompositeFilter(
-        op=query_pb2.CompositeFilter.AND,
+        op=query_pb2.CompositeFilter.Operator.AND,
         filters=[
             query_pb2.Filter(property_filter=sub_filter) for sub_filter in filters
         ],
@@ -616,10 +616,10 @@ class Test_QueryIteratorImpl:
         _datastore_run_query.return_value = utils.future_result(
             mock.Mock(
                 batch=mock.Mock(
-                    entity_result_type=query_pb2.EntityResult.FULL,
+                    entity_result_type=query_pb2.EntityResult.ResultType.FULL,
                     entity_results=entity_results,
                     end_cursor=b"abc",
-                    more_results=query_pb2.QueryResultBatch.NO_MORE_RESULTS,
+                    more_results=query_pb2.QueryResultBatch.MoreResultsType.NO_MORE_RESULTS,
                 )
             )
         )
@@ -630,7 +630,7 @@ class Test_QueryIteratorImpl:
         assert iterator._index == 0
         assert len(iterator._batch) == 3
         assert iterator._batch[0].result_pb.entity == entity1
-        assert iterator._batch[0].result_type == query_pb2.EntityResult.FULL
+        assert iterator._batch[0].result_type == query_pb2.EntityResult.ResultType.FULL
         assert iterator._batch[0].order_by is None
         assert not iterator._has_next_batch
 
@@ -664,10 +664,10 @@ class Test_QueryIteratorImpl:
         _datastore_run_query.return_value = utils.future_result(
             mock.Mock(
                 batch=mock.Mock(
-                    entity_result_type=query_pb2.EntityResult.FULL,
+                    entity_result_type=query_pb2.EntityResult.ResultType.FULL,
                     entity_results=entity_results,
                     end_cursor=b"abc",
-                    more_results=query_pb2.QueryResultBatch.NO_MORE_RESULTS,
+                    more_results=query_pb2.QueryResultBatch.MoreResultsType.NO_MORE_RESULTS,
                 )
             )
         )
@@ -678,7 +678,7 @@ class Test_QueryIteratorImpl:
         assert iterator._index == 0
         assert len(iterator._batch) == 2
         assert iterator._batch[0].result_pb.entity == entity1
-        assert iterator._batch[0].result_type == query_pb2.EntityResult.FULL
+        assert iterator._batch[0].result_type == query_pb2.EntityResult.ResultType.FULL
         assert iterator._batch[0].order_by is None
         assert iterator._batch[1].result_pb.entity == entity3
         assert not iterator._has_next_batch
@@ -713,10 +713,10 @@ class Test_QueryIteratorImpl:
         _datastore_run_query.return_value = utils.future_result(
             mock.Mock(
                 batch=mock.Mock(
-                    entity_result_type=query_pb2.EntityResult.PROJECTION,
+                    entity_result_type=query_pb2.EntityResult.ResultType.PROJECTION,
                     entity_results=entity_results,
                     end_cursor=b"abc",
-                    more_results=query_pb2.QueryResultBatch.NOT_FINISHED,
+                    more_results=query_pb2.QueryResultBatch.MoreResultsType.NOT_FINISHED,
                 )
             )
         )
@@ -727,7 +727,10 @@ class Test_QueryIteratorImpl:
         assert iterator._index == 0
         assert len(iterator._batch) == 3
         assert iterator._batch[0].result_pb.entity == entity1
-        assert iterator._batch[0].result_type == query_pb2.EntityResult.PROJECTION
+        assert (
+            iterator._batch[0].result_type
+            == query_pb2.EntityResult.ResultType.PROJECTION
+        )
         assert iterator._batch[0].order_by is None
         assert iterator._has_next_batch
         assert iterator._query.start_cursor.cursor == b"abc"
@@ -766,11 +769,11 @@ class Test_QueryIteratorImpl:
         _datastore_run_query.return_value = utils.future_result(
             mock.Mock(
                 batch=mock.Mock(
-                    entity_result_type=query_pb2.EntityResult.FULL,
+                    entity_result_type=query_pb2.EntityResult.ResultType.FULL,
                     entity_results=entity_results,
                     end_cursor=b"abc",
                     skipped_results=5,
-                    more_results=query_pb2.QueryResultBatch.NOT_FINISHED,
+                    more_results=query_pb2.QueryResultBatch.MoreResultsType.NOT_FINISHED,
                 )
             )
         )
@@ -781,7 +784,7 @@ class Test_QueryIteratorImpl:
         assert iterator._index == 0
         assert len(iterator._batch) == 3
         assert iterator._batch[0].result_pb.entity == entity1
-        assert iterator._batch[0].result_type == query_pb2.EntityResult.FULL
+        assert iterator._batch[0].result_type == query_pb2.EntityResult.ResultType.FULL
         assert iterator._batch[0].order_by is None
         assert iterator._has_next_batch
         assert iterator._query.start_cursor.cursor == b"abc"
@@ -1754,7 +1757,7 @@ class Test__query_to_protobuf:
             filter=query_pb2.Filter(
                 property_filter=query_pb2.PropertyFilter(
                     property=query_pb2.PropertyReference(name="__key__"),
-                    op=query_pb2.PropertyFilter.HAS_ANCESTOR,
+                    op=query_pb2.PropertyFilter.Operator.HAS_ANCESTOR,
                 )
             )
         )
@@ -1772,18 +1775,18 @@ class Test__query_to_protobuf:
 
         filter_pb = query_pb2.PropertyFilter(
             property=query_pb2.PropertyReference(name="foo"),
-            op=query_pb2.PropertyFilter.EQUAL,
+            op=query_pb2.PropertyFilter.Operator.EQUAL,
             value=entity_pb2.Value(string_value="bar"),
         )
         ancestor_pb = query_pb2.PropertyFilter(
             property=query_pb2.PropertyReference(name="__key__"),
-            op=query_pb2.PropertyFilter.HAS_ANCESTOR,
+            op=query_pb2.PropertyFilter.Operator.HAS_ANCESTOR,
         )
         ancestor_pb.value.key_value.CopyFrom(key._key.to_protobuf())
         expected_pb = query_pb2.Query(
             filter=query_pb2.Filter(
                 composite_filter=query_pb2.CompositeFilter(
-                    op=query_pb2.CompositeFilter.AND,
+                    op=query_pb2.CompositeFilter.Operator.AND,
                     filters=[
                         query_pb2.Filter(property_filter=filter_pb),
                         query_pb2.Filter(property_filter=ancestor_pb),
@@ -1806,23 +1809,23 @@ class Test__query_to_protobuf:
 
         filter_pb1 = query_pb2.PropertyFilter(
             property=query_pb2.PropertyReference(name="foo"),
-            op=query_pb2.PropertyFilter.EQUAL,
+            op=query_pb2.PropertyFilter.Operator.EQUAL,
             value=entity_pb2.Value(string_value="bar"),
         )
         filter_pb2 = query_pb2.PropertyFilter(
             property=query_pb2.PropertyReference(name="food"),
-            op=query_pb2.PropertyFilter.EQUAL,
+            op=query_pb2.PropertyFilter.Operator.EQUAL,
             value=entity_pb2.Value(string_value="barn"),
         )
         ancestor_pb = query_pb2.PropertyFilter(
             property=query_pb2.PropertyReference(name="__key__"),
-            op=query_pb2.PropertyFilter.HAS_ANCESTOR,
+            op=query_pb2.PropertyFilter.Operator.HAS_ANCESTOR,
         )
         ancestor_pb.value.key_value.CopyFrom(key._key.to_protobuf())
         expected_pb = query_pb2.Query(
             filter=query_pb2.Filter(
                 composite_filter=query_pb2.CompositeFilter(
-                    op=query_pb2.CompositeFilter.AND,
+                    op=query_pb2.CompositeFilter.Operator.AND,
                     filters=[
                         query_pb2.Filter(property_filter=filter_pb1),
                         query_pb2.Filter(property_filter=filter_pb2),
@@ -1867,11 +1870,11 @@ class Test__query_to_protobuf:
             order=[
                 query_pb2.PropertyOrder(
                     property=query_pb2.PropertyReference(name="a"),
-                    direction=query_pb2.PropertyOrder.ASCENDING,
+                    direction=query_pb2.PropertyOrder.Direction.ASCENDING,
                 ),
                 query_pb2.PropertyOrder(
                     property=query_pb2.PropertyReference(name="b"),
-                    direction=query_pb2.PropertyOrder.DESCENDING,
+                    direction=query_pb2.PropertyOrder.Direction.DESCENDING,
                 ),
             ]
         )
@@ -1885,7 +1888,7 @@ class Test__query_to_protobuf:
 
         filter_pb = query_pb2.PropertyFilter(
             property=query_pb2.PropertyReference(name="foo"),
-            op=query_pb2.PropertyFilter.EQUAL,
+            op=query_pb2.PropertyFilter.Operator.EQUAL,
             value=entity_pb2.Value(string_value="bar"),
         )
         expected_pb = query_pb2.Query(

--- a/tests/unit/test__datastore_query.py
+++ b/tests/unit/test__datastore_query.py
@@ -1470,6 +1470,12 @@ class MockResultPB:
         self.result = result
         self.entity = self
         self.key = self
+        self._pb = MockResultPB_pb(result)
+
+
+class MockResultPB_pb:
+    def __init__(self, result):
+        self.result = result
 
     def SerializeToString(self):
         return self.result
@@ -1761,8 +1767,8 @@ class Test__query_to_protobuf:
                 )
             )
         )
-        expected_pb.filter.property_filter.value.key_value.CopyFrom(
-            key._key.to_protobuf()
+        expected_pb.filter.property_filter.value.key_value._pb.CopyFrom(
+            key._key.to_protobuf()._pb
         )
         assert _datastore_query._query_to_protobuf(query) == expected_pb
 
@@ -1782,7 +1788,7 @@ class Test__query_to_protobuf:
             property=query_pb2.PropertyReference(name="__key__"),
             op=query_pb2.PropertyFilter.Operator.HAS_ANCESTOR,
         )
-        ancestor_pb.value.key_value.CopyFrom(key._key.to_protobuf())
+        ancestor_pb.value.key_value._pb.CopyFrom(key._key.to_protobuf()._pb)
         expected_pb = query_pb2.Query(
             filter=query_pb2.Filter(
                 composite_filter=query_pb2.CompositeFilter(
@@ -1821,7 +1827,7 @@ class Test__query_to_protobuf:
             property=query_pb2.PropertyReference(name="__key__"),
             op=query_pb2.PropertyFilter.Operator.HAS_ANCESTOR,
         )
-        ancestor_pb.value.key_value.CopyFrom(key._key.to_protobuf())
+        ancestor_pb.value.key_value._pb.CopyFrom(key._key.to_protobuf()._pb)
         expected_pb = query_pb2.Query(
             filter=query_pb2.Filter(
                 composite_filter=query_pb2.CompositeFilter(

--- a/tests/unit/test__datastore_query.py
+++ b/tests/unit/test__datastore_query.py
@@ -1912,7 +1912,7 @@ class Test__query_to_protobuf:
     def test_limit():
         query = query_module.QueryOptions(limit=20)
         expected_pb = query_pb2.Query()
-        expected_pb.limit.value = 20
+        expected_pb._pb.limit.value = 20
         assert _datastore_query._query_to_protobuf(query) == expected_pb
 
     @staticmethod

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -29,7 +29,7 @@ from google.cloud.datastore import entity as entity_module
 from google.cloud.datastore import key as ds_key_module
 from google.cloud.datastore import helpers
 from google.cloud.datastore_v1 import types as ds_types
-from google.cloud.datastore_v1.proto import entity_pb2
+from google.cloud.datastore_v1.types import entity as entity_pb2
 import pytest
 
 from google.cloud.ndb import _datastore_types

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -3627,7 +3627,7 @@ class TestLocalStructuredProperty:
         prop = model.LocalStructuredProperty(Simple, name="ent")
         value = Simple()
         entity = entity_module.Entity()
-        pb = helpers.entity_to_protobuf(entity)
+        pb = helpers.entity_to_protobuf(entity)._pb
         expected = pb.SerializePartialToString()
         assert prop._to_base_type(value) == expected
 
@@ -3657,7 +3657,7 @@ class TestLocalStructuredProperty:
             pass
 
         prop = model.LocalStructuredProperty(Simple, name="ent")
-        pb = helpers.entity_to_protobuf(entity_module.Entity())
+        pb = helpers.entity_to_protobuf(entity_module.Entity())._pb
         value = pb.SerializePartialToString()
         expected = Simple()
         assert prop._from_base_type(value) == expected
@@ -3722,7 +3722,7 @@ class TestLocalStructuredProperty:
 
         entity = SomeKind(foo=[SubKind(bar="baz")])
         data = {"_exclude_from_indexes": []}
-        protobuf = model._entity_to_protobuf(entity.foo[0], set_key=False)
+        protobuf = model._entity_to_protobuf(entity.foo[0], set_key=False)._pb
         protobuf = protobuf.SerializePartialToString()
         assert SomeKind.foo._to_datastore(entity, data, repeated=True) == ("foo",)
         assert data.pop("_exclude_from_indexes") == ["foo"]
@@ -3871,7 +3871,7 @@ class TestLocalStructuredProperty:
         assert child.foo == "bar"
 
         pb = entity_pb2.Entity()
-        pb.MergeFromString(value)
+        pb._pb.MergeFromString(value)
         value = helpers.entity_from_protobuf(pb)
         child = model._entity_from_ds_entity(value, model_class=Base)
         assert child._values["foo"].b_val == "bar"


### PR DESCRIPTION
Fixes #804

BEGIN_COMMIT_OVERRIDE
feat(dependencies)!: Upgrade to google-cloud-datastore >= 2.7.2
fix: Update module imports
fix: Fix enum namespaces 
fix: Update datastore stub creation
fix: Update API capitalization/casing
fix: Correct access to SerializeToString, CopyFrom, and MergeFromString 
test: Fix tests
END_COMMIT_OVERRIDE

See [the python-datastore upgrade guide](https://github.com/googleapis/python-datastore/blob/main/UPGRADING.md#200-migration-guide) for information on how to upgrade your own code that uses google-cloud-datastore 1.x