### PR TITLE
chore(CONTRIBUTING): Fix Redis URL scheme

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -81,7 +81,7 @@ We use `nox <https://nox.readthedocs.io/en/latest/>`__ to instrument our tests.
 - To run unit tests that use Memcached or Redis, you must have them running and set the appropriate environment variables:
 
     $ export MEMCACHED_HOSTS=localhost:11211
-    $ export REDIS_CACHE_URL=http://localhost:6379
+    $ export REDIS_CACHE_URL=redis://localhost:6379
 
 
 Note on Editable Installs / Develop Mode


### PR DESCRIPTION
redis://, rediss://, and unix:// are the only supported URL schemes, although not every version of the Python Redis client enforces this.