### PR TITLE
chore(tests): Remove mock dependency and import

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -45,7 +45,6 @@ def unit(session):
     )
     # Install all dependencies.
     session.install("pytest", "pytest-cov")
-    session.install("mock")
     session.install("google-cloud-testutils", "-c", constraints_path)
     session.install("-e", ".", "-c", constraints_path)
     # This variable is used to skip coverage by Python version
@@ -190,7 +189,6 @@ def system(session):
     # Install all test dependencies, then install this package into the
     # virtualenv's dist-packages.
     session.install("pytest")
-    session.install("mock")
     session.install("google-cloud-testutils")
     for local_dep in LOCAL_DEPS:
         session.install(local_dep)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,11 +29,7 @@ from google.cloud.ndb import utils
 
 import pytest
 
-# In Python 2.7, mock is not part of unittest
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 utils.DEBUG = True
 

--- a/tests/system/test_crud.py
+++ b/tests/system/test_crud.py
@@ -23,10 +23,7 @@ import random
 import threading
 import zlib
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 import pytest
 

--- a/tests/system/test_misc.py
+++ b/tests/system/test_misc.py
@@ -23,10 +23,7 @@ import traceback
 
 import redis
 
-try:
-    from unittest import mock
-except ImportError:  # pragma: NO PY3 COVER
-    import mock
+from unittest import mock
 
 import pytest
 

--- a/tests/unit/test__cache.py
+++ b/tests/unit/test__cache.py
@@ -14,10 +14,7 @@
 
 import warnings
 
-try:
-    from unittest import mock
-except ImportError:  # pragma: NO PY3 COVER
-    import mock
+from unittest import mock
 
 import pytest
 

--- a/tests/unit/test__datastore_api.py
+++ b/tests/unit/test__datastore_api.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    from unittest import mock
-except ImportError:  # pragma: NO PY3 COVER
-    import mock
+from unittest import mock
 
 import grpc
 import pytest

--- a/tests/unit/test__datastore_query.py
+++ b/tests/unit/test__datastore_query.py
@@ -14,10 +14,7 @@
 
 import base64
 
-try:
-    from unittest import mock
-except ImportError:  # pragma: NO PY3 COVER
-    import mock
+from unittest import mock
 
 import pytest
 

--- a/tests/unit/test__datastore_types.py
+++ b/tests/unit/test__datastore_types.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    from unittest import mock
-except ImportError:  # pragma: NO PY3 COVER
-    import mock
+from unittest import mock
 
 import pytest
 

--- a/tests/unit/test__eventloop.py
+++ b/tests/unit/test__eventloop.py
@@ -14,10 +14,7 @@
 
 import collections
 
-try:
-    from unittest import mock
-except ImportError:  # pragma: NO PY3 COVER
-    import mock
+from unittest import mock
 
 import grpc
 import pytest

--- a/tests/unit/test__remote.py
+++ b/tests/unit/test__remote.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    from unittest import mock
-except ImportError:  # pragma: NO PY3 COVER
-    import mock
+from unittest import mock
 
 import grpc
 import pytest

--- a/tests/unit/test__retry.py
+++ b/tests/unit/test__retry.py
@@ -14,10 +14,7 @@
 
 import itertools
 
-try:
-    from unittest import mock
-except ImportError:  # pragma: NO PY3 COVER
-    import mock
+from unittest import mock
 
 import pytest
 

--- a/tests/unit/test__transaction.py
+++ b/tests/unit/test__transaction.py
@@ -15,10 +15,7 @@
 import itertools
 import logging
 
-try:
-    from unittest import mock
-except ImportError:  # pragma: NO PY3 COVER
-    import mock
+from unittest import mock
 
 import pytest
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -15,10 +15,7 @@
 import contextlib
 import pytest
 
-try:
-    from unittest import mock
-except ImportError:  # pragma: NO PY3 COVER
-    import mock
+from unittest import mock
 
 from google.auth import credentials
 from google.cloud import environment_vars

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -15,10 +15,7 @@
 import pytest
 import threading
 
-try:
-    from unittest import mock
-except ImportError:  # pragma: NO PY3 COVER
-    import mock
+from unittest import mock
 
 from google.cloud.ndb import context as context_module
 from google.cloud.ndb import _eventloop

--- a/tests/unit/test_global_cache.py
+++ b/tests/unit/test_global_cache.py
@@ -14,10 +14,7 @@
 
 import collections
 
-try:
-    from unittest import mock
-except ImportError:  # pragma: NO PY3 COVER
-    import mock
+from unittest import mock
 
 import pytest
 import redis as redis_module

--- a/tests/unit/test_key.py
+++ b/tests/unit/test_key.py
@@ -15,10 +15,7 @@
 import base64
 import pickle
 
-try:
-    from unittest import mock
-except ImportError:  # pragma: NO PY3 COVER
-    import mock
+from unittest import mock
 
 from google.cloud.datastore import _app_engine_key_pb2
 import google.cloud.datastore

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    from unittest import mock
-except ImportError:  # pragma: NO PY3 COVER
-    import mock
+from unittest import mock
 
 import pytest
 

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -19,10 +19,7 @@ import six
 import types
 import zlib
 
-try:
-    from unittest import mock
-except ImportError:  # pragma: NO PY3 COVER
-    import mock
+from unittest import mock
 
 from google.cloud import datastore
 from google.cloud.datastore import entity as entity_module

--- a/tests/unit/test_polymodel.py
+++ b/tests/unit/test_polymodel.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    from unittest import mock
-except ImportError:  # pragma: NO PY3 COVER
-    import mock
+from unittest import mock
 
 import pytest
 

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -14,10 +14,7 @@
 
 import pickle
 
-try:
-    from unittest import mock
-except ImportError:  # pragma: NO PY3 COVER
-    import mock
+from unittest import mock
 
 import pytest
 import six

--- a/tests/unit/test_tasklets.py
+++ b/tests/unit/test_tasklets.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    from unittest import mock
-except ImportError:  # pragma: NO PY3 COVER
-    import mock
+from unittest import mock
 
 import pytest
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -14,10 +14,7 @@
 
 import threading
 
-try:
-    from unittest import mock
-except ImportError:  # pragma: NO PY3 COVER
-    import mock
+from unittest import mock
 
 import pytest
 


### PR DESCRIPTION
This is available in unittest for Py3. We only needed to do this for Python 2, which is no longer supported.