### PR TITLE
fix: Query options were not respecting use_cache

### DIFF
--- a/tests/system/test_query.py
+++ b/tests/system/test_query.py
@@ -2010,3 +2010,29 @@ def test_query_updates_cache(dispose_of, client_context):
 
         # If there is a cache hit, we'll get back the same object, not just a copy
         assert key.get() is retrieved
+
+
+def test_query_with_explicit_use_cache_updates_cache(dispose_of, client_context):
+    class SomeKind(ndb.Model):
+        foo = ndb.IntegerProperty()
+
+    entity = SomeKind(foo=42)
+    key = entity.put(use_cache=False)
+    dispose_of(key._key)
+    assert len(client_context.cache) == 0
+
+    eventually(lambda: SomeKind.query().fetch(use_cache=True), length_equals(1))
+    assert len(client_context.cache) == 1
+
+
+def test_query_with_use_cache_false_does_not_update_cache(dispose_of, client_context):
+    class SomeKind(ndb.Model):
+        foo = ndb.IntegerProperty()
+
+    entity = SomeKind(foo=42)
+    key = entity.put(use_cache=False)
+    dispose_of(key._key)
+    assert len(client_context.cache) == 0
+
+    eventually(lambda: SomeKind.query().fetch(use_cache=False), length_equals(1))
+    assert len(client_context.cache) == 0


### PR DESCRIPTION
In certain circumstances, we were not respecting use_cache for queries, unlike legacy NDB, which is quite emphatic about supporting them.
(See https://github.com/GoogleCloudPlatform/datastore-ndb-python/blob/59cb209ed95480025d26531fc91397575438d2fe/ndb/query.py#L186-L187)

In #613 we tried to match legacy NDB behavior by updating the cache using the results of queries. We still do that, but now we respect use_cache, which was a valid keyword argument for Query.fetch() and friends, but was not passed down to the context cache when needed.

As a result, the cache could mysteriously accumulate lots of memory usage and perhaps even cause you to hit memory limits, even if it was seemingly disabled and it didn't look like there were any objects holding references to your query results.
This is a problem for certain batch-style workloads where you know you're only interested in processing a certain entity once.

Fixes #752