### PR TITLE
fix: Add routing header for multi-db

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -146,6 +146,7 @@ Running System Tests
 
 - To run system tests for a given package, you can execute::
 
+   $ export RUN_NAMED_DB_TESTS=true
    $ export SYSTEM_TESTS_DATABASE=system-tests-named-db
    $ nox -e system
 

--- a/google/cloud/ndb/_datastore_query.py
+++ b/google/cloud/ndb/_datastore_query.py
@@ -1018,8 +1018,10 @@ def _datastore_run_query(query):
         query=query_pb,
         read_options=read_options,
     )
+    metadata = _datastore_api._add_routing_info((), request)
+
     response = yield _datastore_api.make_call(
-        "run_query", request, timeout=query.timeout
+        "run_query", request, timeout=query.timeout, metadata=metadata
     )
     utils.logging_debug(log, response)
     raise tasklets.Return(response)

--- a/tests/unit/test__datastore_query.py
+++ b/tests/unit/test__datastore_query.py
@@ -1942,10 +1942,12 @@ class Test__datastore_run_query:
             query=query_pb,
             read_options=read_options,
         )
+        metadata = ("x-goog-request-params", "project_id=testing")
+        _datastore_api._add_routing_info.return_value = metadata
         _datastore_api.get_read_options.return_value = read_options
         assert _datastore_query._datastore_run_query(query).result() == "foo"
         _datastore_api.make_call.assert_called_once_with(
-            "run_query", request, timeout=None
+            "run_query", request, timeout=None, metadata=metadata
         )
         _datastore_api.get_read_options.assert_called_once_with(query)
 


### PR DESCRIPTION
NDB doesn't use the autogenerated Datastore client class, which is where the routing header info was added to python-datastore.

Instead, add it into _datastore_api