### PR TITLE
docs(query): Fix Py2-style print statements

### DIFF
--- a/google/cloud/ndb/query.py
+++ b/google/cloud/ndb/query.py
@@ -37,7 +37,7 @@ For example::
           return cls.query(cls.rank == rank).order(cls.age)
 
     for emp in Employee.seniors(42, 5):
-        print emp.name, emp.age, emp.rank
+        print(emp.name, emp.age, emp.rank)
 
 The 'in' operator cannot be overloaded, but is supported through the IN()
 method. For example::
@@ -133,7 +133,7 @@ tasklet, properly yielding when appropriate::
     it = query1.iter()
     while (yield it.has_next_async()):
         emp = it.next()
-        print emp.name, emp.age
+        print(emp.name, emp.age)
 """
 
 import functools


### PR DESCRIPTION
This PR changes Python 2-style print statements to their Python 3 equivalents. As the package no longer supports Python 2, the docs shouldn't present its usage in the docs.