### PR TITLE
fix: Remove usage of google.cloud.datastore.constants.DEFAULT_DATABASE

### DIFF
--- a/google/cloud/ndb/client.py
+++ b/google/cloud/ndb/client.py
@@ -25,7 +25,6 @@ from google.api_core.gapic_v1 import client_info
 from google.cloud import environment_vars
 from google.cloud import _helpers
 from google.cloud import client as google_client
-from google.cloud.datastore.constants import DEFAULT_DATABASE
 from google.cloud.datastore_v1.services.datastore.transports import (
     grpc as datastore_grpc,
 )
@@ -106,7 +105,7 @@ class Client(google_client.ClientWithProject):
         credentials=None,
         client_options=None,
         *,
-        database: str = DEFAULT_DATABASE
+        database: str = ""
     ):
         self.namespace = namespace
         self.host = os.environ.get(environment_vars.GCD_HOST, DATASTORE_API_HOST)

--- a/google/cloud/ndb/key.py
+++ b/google/cloud/ndb/key.py
@@ -144,10 +144,9 @@ class Key(object):
 
         from unittest import mock
         from google.cloud.ndb import context as context_module
-        from google.cloud.datastore.constants import DEFAULT_DATABASE
         client = mock.Mock(
             project="testing",
-            database=DEFAULT_DATABASE,
+            database="",
             namespace=None,
             stub=mock.Mock(spec=()),
             spec=("project", "database", "namespace", "stub"),
@@ -465,7 +464,7 @@ class Key(object):
         _clean_flat_path(flat)
         project = _project_from_app(kwargs["app"])
 
-        database = google.cloud.datastore.constants.DEFAULT_DATABASE
+        database = ""
         if "database" in kwargs:
             database = kwargs["database"]
 
@@ -600,7 +599,7 @@ class Key(object):
            >>> key.database()
            'mydb'
         """
-        db = self._key.database or google.cloud.datastore.constants.DEFAULT_DATABASE
+        db = self._key.database or ""
         return db
 
     def id(self):
@@ -1454,7 +1453,7 @@ def _parse_from_args(
         namespace = None
 
     if database is None:
-        database = google.cloud.datastore.constants.DEFAULT_DATABASE
+        database = ""
 
     return google.cloud.datastore.Key(
         *flat,

--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -18,12 +18,11 @@
 
     from unittest import mock
     from google.cloud import ndb
-    from google.cloud.datastore.constants import DEFAULT_DATABASE
     from google.cloud.ndb import context as context_module
 
     client = mock.Mock(
         project="testing",
-        database=DEFAULT_DATABASE,
+        database="",
         namespace=None,
         stub=mock.Mock(spec=()),
         spec=("project", "namespace", "database", "stub"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,6 @@ modules.
 import os
 
 from google.cloud import environment_vars
-from google.cloud.datastore.constants import DEFAULT_DATABASE
 from google.cloud.ndb import context as context_module
 from google.cloud.ndb import _eventloop
 from google.cloud.ndb import global_cache as global_cache_module
@@ -89,7 +88,7 @@ def context_factory():
     def context(**kwargs):
         client = mock.Mock(
             project="testing",
-            database=DEFAULT_DATABASE,
+            database="",
             namespace=None,
             spec=("project", "database", "namespace"),
             stub=mock.Mock(spec=()),

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -8,7 +8,6 @@ import requests
 
 from google.cloud import datastore
 from google.cloud import ndb
-from google.cloud.datastore.constants import DEFAULT_DATABASE
 
 from google.cloud.ndb import global_cache as global_cache_module
 
@@ -133,7 +132,7 @@ def database():
 
 
 def _get_database():
-    db = DEFAULT_DATABASE
+    db = ""
     if TEST_DATABASE is not None:
         db = TEST_DATABASE
     return db

--- a/tests/unit/test__datastore_api.py
+++ b/tests/unit/test__datastore_api.py
@@ -22,7 +22,6 @@ from google.api_core import exceptions as core_exceptions
 from google.cloud.datastore import entity
 from google.cloud.datastore import helpers
 from google.cloud.datastore import key as ds_key_module
-from google.cloud.datastore.constants import DEFAULT_DATABASE
 from google.cloud.datastore_v1.types import datastore as datastore_pb2
 from google.cloud.datastore_v1.types import entity as entity_pb2
 from google.cloud.ndb import _batch
@@ -1247,7 +1246,7 @@ class Test_datastore_commit:
 
         datastore_pb2.CommitRequest.assert_called_once_with(
             project_id="testing",
-            database_id=DEFAULT_DATABASE,
+            database_id="",
             mode=datastore_pb2.CommitRequest.Mode.NON_TRANSACTIONAL,
             mutations=mutations,
             transaction=None,
@@ -1270,7 +1269,7 @@ class Test_datastore_commit:
 
         datastore_pb2.CommitRequest.assert_called_once_with(
             project_id="testing",
-            database_id=DEFAULT_DATABASE,
+            database_id="",
             mode=datastore_pb2.CommitRequest.Mode.TRANSACTIONAL,
             mutations=mutations,
             transaction=b"tx123",
@@ -1362,7 +1361,7 @@ def test__datastore_allocate_ids(stub, datastore_pb2):
     assert _api._datastore_allocate_ids(keys).result() == "response"
 
     datastore_pb2.AllocateIdsRequest.assert_called_once_with(
-        project_id="testing", database_id=DEFAULT_DATABASE, keys=keys
+        project_id="testing", database_id="", keys=keys
     )
 
     request = datastore_pb2.AllocateIdsRequest.return_value
@@ -1403,7 +1402,7 @@ class Test_datastore_begin_transaction:
         transaction_options = datastore_pb2.TransactionOptions.return_value
         datastore_pb2.BeginTransactionRequest.assert_called_once_with(
             project_id="testing",
-            database_id=DEFAULT_DATABASE,
+            database_id="",
             transaction_options=transaction_options,
         )
 
@@ -1428,7 +1427,7 @@ class Test_datastore_begin_transaction:
         transaction_options = datastore_pb2.TransactionOptions.return_value
         datastore_pb2.BeginTransactionRequest.assert_called_once_with(
             project_id="testing",
-            database_id=DEFAULT_DATABASE,
+            database_id="",
             transaction_options=transaction_options,
         )
 
@@ -1460,7 +1459,7 @@ def test__datastore_rollback(stub, datastore_pb2):
     assert _api._datastore_rollback(b"tx123").result() == "response"
 
     datastore_pb2.RollbackRequest.assert_called_once_with(
-        project_id="testing", database_id=DEFAULT_DATABASE, transaction=b"tx123"
+        project_id="testing", database_id="", transaction=b"tx123"
     )
 
     request = datastore_pb2.RollbackRequest.return_value

--- a/tests/unit/test_key.py
+++ b/tests/unit/test_key.py
@@ -21,7 +21,6 @@ from google.cloud.datastore import _app_engine_key_pb2
 import google.cloud.datastore
 import pytest
 
-from google.cloud.datastore.constants import DEFAULT_DATABASE
 from google.cloud.ndb import exceptions
 from google.cloud.ndb import key as key_module
 from google.cloud.ndb import model
@@ -233,12 +232,12 @@ class TestKey:
     @staticmethod
     @pytest.mark.usefixtures("in_context")
     def test_constructor_with_default_database():
-        key = key_module.Key("Kind", 1337, database=DEFAULT_DATABASE)
+        key = key_module.Key("Kind", 1337, database="")
 
         assert key._key == google.cloud.datastore.Key(
-            "Kind", 1337, project="testing", database=DEFAULT_DATABASE
+            "Kind", 1337, project="testing", database=""
         )
-        assert key.database() == DEFAULT_DATABASE
+        assert key.database() == ""
 
     @staticmethod
     @pytest.mark.usefixtures("in_context")
@@ -520,9 +519,7 @@ class TestKey:
     @staticmethod
     @pytest.mark.usefixtures("in_context")
     def test_pickling_with_default_database():
-        key = key_module.Key(
-            "a", "b", app="c", namespace="d", database=DEFAULT_DATABASE
-        )
+        key = key_module.Key("a", "b", app="c", namespace="d", database="")
         pickled = pickle.dumps(key)
         unpickled = pickle.loads(pickled)
         assert key == unpickled

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -24,7 +24,6 @@ from google.cloud import datastore
 from google.cloud.datastore import entity as entity_module
 from google.cloud.datastore import key as ds_key_module
 from google.cloud.datastore import helpers
-from google.cloud.datastore.constants import DEFAULT_DATABASE
 from google.cloud.datastore_v1 import types as ds_types
 from google.cloud.datastore_v1.types import entity as entity_pb2
 import pytest
@@ -2624,7 +2623,7 @@ class TestKeyProperty:
             k = model.KeyProperty()
 
         kptm1 = KeyPropTestModel(k=key_module.Key("k", 1))
-        kptm2 = KeyPropTestModel(k=key_module.Key("k", 1, database=DEFAULT_DATABASE))
+        kptm2 = KeyPropTestModel(k=key_module.Key("k", 1, database=""))
         assert kptm1 == kptm2
 
 
@@ -6125,7 +6124,7 @@ class Test__from_pb:
     def test_with_key():
         m = model.Model()
         pb = _legacy_entity_pb.EntityProto()
-        key = key_module.Key("a", "b", app="c", database=DEFAULT_DATABASE, namespace="")
+        key = key_module.Key("a", "b", app="c", database="", namespace="")
         ent = m._from_pb(pb, key=key)
         assert ent.key == key
 

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -20,7 +20,6 @@ import pytest
 
 from google.cloud.datastore import entity as datastore_entity
 from google.cloud.datastore import helpers
-from google.cloud.datastore.constants import DEFAULT_DATABASE
 
 from google.cloud.ndb import _datastore_api
 from google.cloud.ndb import _datastore_query
@@ -1706,9 +1705,7 @@ class TestQuery:
         response = _datastore_query.fetch.return_value
         assert query.fetch_async() is response
         _datastore_query.fetch.assert_called_once_with(
-            query_module.QueryOptions(
-                project="foo", database=DEFAULT_DATABASE, namespace="bar"
-            )
+            query_module.QueryOptions(project="foo", database="", namespace="bar")
         )
 
     @staticmethod
@@ -1720,7 +1717,7 @@ class TestQuery:
         assert query.fetch_async(keys_only=True) is response
         _datastore_query.fetch.assert_called_once_with(
             query_module.QueryOptions(
-                project="testing", database=DEFAULT_DATABASE, projection=["__key__"]
+                project="testing", database="", projection=["__key__"]
             )
         )
 
@@ -1733,9 +1730,7 @@ class TestQuery:
         response = _datastore_query.fetch.return_value
         assert query.fetch_async(options=options) is response
         _datastore_query.fetch.assert_called_once_with(
-            query_module.QueryOptions(
-                project="testing", database=DEFAULT_DATABASE, keys_only=True
-            )
+            query_module.QueryOptions(project="testing", database="", keys_only=True)
         )
 
     @staticmethod
@@ -1754,7 +1749,7 @@ class TestQuery:
         assert query.fetch_async(projection=("foo", "bar")) is response
         _datastore_query.fetch.assert_called_once_with(
             query_module.QueryOptions(
-                project="testing", database=DEFAULT_DATABASE, projection=["foo", "bar"]
+                project="testing", database="", projection=["foo", "bar"]
             )
         )
 
@@ -1771,7 +1766,7 @@ class TestQuery:
         assert query.fetch_async(projection=(foo, bar)) is response
         _datastore_query.fetch.assert_called_once_with(
             query_module.QueryOptions(
-                project="testing", database=DEFAULT_DATABASE, projection=["foo", "bar"]
+                project="testing", database="", projection=["foo", "bar"]
             )
         )
 
@@ -1785,7 +1780,7 @@ class TestQuery:
         assert query.fetch_async(options=options) is response
         _datastore_query.fetch.assert_called_once_with(
             query_module.QueryOptions(
-                project="testing", database=DEFAULT_DATABASE, projection=("foo", "bar")
+                project="testing", database="", projection=("foo", "bar")
             )
         )
 
@@ -1804,9 +1799,7 @@ class TestQuery:
         response = _datastore_query.fetch.return_value
         assert query.fetch_async(offset=20) is response
         _datastore_query.fetch.assert_called_once_with(
-            query_module.QueryOptions(
-                project="testing", database=DEFAULT_DATABASE, offset=20
-            )
+            query_module.QueryOptions(project="testing", database="", offset=20)
         )
 
     @staticmethod
@@ -1817,9 +1810,7 @@ class TestQuery:
         response = _datastore_query.fetch.return_value
         assert query.fetch_async(limit=20) is response
         _datastore_query.fetch.assert_called_once_with(
-            query_module.QueryOptions(
-                project="testing", database=DEFAULT_DATABASE, limit=20
-            )
+            query_module.QueryOptions(project="testing", database="", limit=20)
         )
 
     @staticmethod
@@ -1830,9 +1821,7 @@ class TestQuery:
         response = _datastore_query.fetch.return_value
         assert query.fetch_async(20) is response
         _datastore_query.fetch.assert_called_once_with(
-            query_module.QueryOptions(
-                project="testing", database=DEFAULT_DATABASE, limit=20
-            )
+            query_module.QueryOptions(project="testing", database="", limit=20)
         )
 
     @staticmethod
@@ -1864,7 +1853,7 @@ class TestQuery:
         response = _datastore_query.fetch.return_value
         assert query.fetch_async(produce_cursors=True) is response
         _datastore_query.fetch.assert_called_once_with(
-            query_module.QueryOptions(project="testing", database=DEFAULT_DATABASE)
+            query_module.QueryOptions(project="testing", database="")
         )
 
     @staticmethod
@@ -1876,7 +1865,7 @@ class TestQuery:
         assert query.fetch_async(start_cursor="cursor") is response
         _datastore_query.fetch.assert_called_once_with(
             query_module.QueryOptions(
-                project="testing", database=DEFAULT_DATABASE, start_cursor="cursor"
+                project="testing", database="", start_cursor="cursor"
             )
         )
 
@@ -1889,7 +1878,7 @@ class TestQuery:
         assert query.fetch_async(end_cursor="cursor") is response
         _datastore_query.fetch.assert_called_once_with(
             query_module.QueryOptions(
-                project="testing", database=DEFAULT_DATABASE, end_cursor="cursor"
+                project="testing", database="", end_cursor="cursor"
             )
         )
 
@@ -1901,9 +1890,7 @@ class TestQuery:
         response = _datastore_query.fetch.return_value
         assert query.fetch_async(deadline=20) is response
         _datastore_query.fetch.assert_called_once_with(
-            query_module.QueryOptions(
-                project="testing", database=DEFAULT_DATABASE, timeout=20
-            )
+            query_module.QueryOptions(project="testing", database="", timeout=20)
         )
 
     @staticmethod
@@ -1914,9 +1901,7 @@ class TestQuery:
         response = _datastore_query.fetch.return_value
         assert query.fetch_async(timeout=20) is response
         _datastore_query.fetch.assert_called_once_with(
-            query_module.QueryOptions(
-                project="testing", database=DEFAULT_DATABASE, timeout=20
-            )
+            query_module.QueryOptions(project="testing", database="", timeout=20)
         )
 
     @staticmethod
@@ -1928,7 +1913,7 @@ class TestQuery:
         assert query.fetch_async(read_policy="foo") is response
         _datastore_query.fetch.assert_called_once_with(
             query_module.QueryOptions(
-                project="testing", database=DEFAULT_DATABASE, read_consistency="foo"
+                project="testing", database="", read_consistency="foo"
             )
         )
 
@@ -1940,9 +1925,7 @@ class TestQuery:
         response = _datastore_query.fetch.return_value
         assert query.fetch_async(transaction="foo") is response
         _datastore_query.fetch.assert_called_once_with(
-            query_module.QueryOptions(
-                project="testing", database=DEFAULT_DATABASE, transaction="foo"
-            )
+            query_module.QueryOptions(project="testing", database="", transaction="foo")
         )
 
     @staticmethod
@@ -1990,9 +1973,7 @@ class TestQuery:
         query = query_module.Query()
         assert query.fetch(20) == "foo"
         _datastore_query.fetch.assert_called_once_with(
-            query_module.QueryOptions(
-                project="testing", database=DEFAULT_DATABASE, limit=20
-            )
+            query_module.QueryOptions(project="testing", database="", limit=20)
         )
 
     @staticmethod
@@ -2039,7 +2020,7 @@ class TestQuery:
         iterator = query.iter()
         assert isinstance(iterator, _datastore_query.QueryIterator)
         assert iterator._query == query_module.QueryOptions(
-            project="testing", database=DEFAULT_DATABASE
+            project="testing", database=""
         )
 
     @staticmethod
@@ -2051,7 +2032,7 @@ class TestQuery:
         iterator = query.iter(projection=(foo,))
         assert isinstance(iterator, _datastore_query.QueryIterator)
         assert iterator._query == query_module.QueryOptions(
-            project="testing", database=DEFAULT_DATABASE, projection=["foo"]
+            project="testing", database="", projection=["foo"]
         )
 
     @staticmethod
@@ -2061,7 +2042,7 @@ class TestQuery:
         iterator = iter(query)
         assert isinstance(iterator, _datastore_query.QueryIterator)
         assert iterator._query == query_module.QueryOptions(
-            project="testing", database=DEFAULT_DATABASE
+            project="testing", database=""
         )
 
     @staticmethod
@@ -2150,9 +2131,7 @@ class TestQuery:
         _datastore_query.fetch.return_value = utils.future_result(["foo", "bar"])
         assert query.get() == "foo"
         _datastore_query.fetch.assert_called_once_with(
-            query_module.QueryOptions(
-                project="testing", database=DEFAULT_DATABASE, limit=1
-            )
+            query_module.QueryOptions(project="testing", database="", limit=1)
         )
 
     @staticmethod
@@ -2215,7 +2194,7 @@ class TestQuery:
             query_module.QueryOptions(
                 filters=query.filters,
                 project="testing",
-                database=DEFAULT_DATABASE,
+                database="",
                 limit=5,
             ),
             raw=True,
@@ -2254,7 +2233,7 @@ class TestQuery:
         _datastore_query.iterate.assert_called_once_with(
             query_module.QueryOptions(
                 project="testing",
-                database=DEFAULT_DATABASE,
+                database="",
                 limit=5,
                 start_cursor="cursor000",
             ),
@@ -2284,7 +2263,7 @@ class TestQuery:
         _datastore_query.iterate.assert_called_once_with(
             query_module.QueryOptions(
                 project="testing",
-                database=DEFAULT_DATABASE,
+                database="",
                 limit=5,
                 start_cursor="cursor000",
             ),
@@ -2319,7 +2298,7 @@ class TestQuery:
             query_module.QueryOptions(
                 filters=query.filters,
                 project="testing",
-                database=DEFAULT_DATABASE,
+                database="",
                 limit=5,
             ),
             raw=True,
@@ -2354,9 +2333,7 @@ class TestQuery:
         assert more
 
         _datastore_query.iterate.assert_called_once_with(
-            query_module.QueryOptions(
-                project="testing", database=DEFAULT_DATABASE, limit=5
-            ),
+            query_module.QueryOptions(project="testing", database="", limit=5),
             raw=True,
         )
 


### PR DESCRIPTION
We did not end up creating that constant after all, so just use "" everywhere instead.