### PR TITLE
docs: Mark database argument for get_by_id and its async counterpart as ignored

### DIFF
--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -5850,7 +5850,7 @@ class Model(_NotEqualMixin):
                 ``global_cache_timeout``.
             max_memcache_items (int): No longer supported.
             force_writes (bool): No longer supported.
-            database (Optional[str]): Ignored. Please set the database on the Client instead.
+            database (Optional[str]): This parameter is ignored. Please set the database on the Client instead.
 
         Returns:
             tasklets.Future: Optional[Model]: The retrieved entity, if one is

--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -5764,8 +5764,7 @@ class Model(_NotEqualMixin):
                 ``global_cache_timeout``.
             max_memcache_items (int): No longer supported.
             force_writes (bool): No longer supported.
-            database (Optional[str]): Database for the entity to load. If not
-                passed, uses the client's value.
+            database (Optional[str]): Ignored. Please set the database on the Client instead.
 
         Returns:
             Optional[Model]: The retrieved entity, if one is found.
@@ -5851,6 +5850,7 @@ class Model(_NotEqualMixin):
                 ``global_cache_timeout``.
             max_memcache_items (int): No longer supported.
             force_writes (bool): No longer supported.
+            database (Optional[str]): Ignored. Please set the database on the Client instead.
 
         Returns:
             tasklets.Future: Optional[Model]: The retrieved entity, if one is

--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -5764,7 +5764,7 @@ class Model(_NotEqualMixin):
                 ``global_cache_timeout``.
             max_memcache_items (int): No longer supported.
             force_writes (bool): No longer supported.
-            database (Optional[str]): Ignored. Please set the database on the Client instead.
+            database (Optional[str]): This parameter is ignored. Please set the database on the Client instead.
 
         Returns:
             Optional[Model]: The retrieved entity, if one is found.


### PR DESCRIPTION
The Client class should be used to set the database instead.