### PR TITLE
feat: Add support for google.cloud.ndb.__version__

### DIFF
--- a/google/cloud/ndb/__init__.py
+++ b/google/cloud/ndb/__init__.py
@@ -21,9 +21,9 @@ version of the ``db`` API (hence ``ndb``).
 .. autodata:: __all__
 """
 
-from pkg_resources import get_distribution
+from google.cloud.ndb import version
 
-__version__ = get_distribution("google-cloud-ndb").version
+__version__ = version.__version__
 
 from google.cloud.ndb.client import Client
 from google.cloud.ndb.context import AutoBatcher
@@ -131,6 +131,7 @@ from google.cloud.ndb._transaction import transactional_tasklet
 from google.cloud.ndb._transaction import non_transactional
 
 __all__ = [
+    "__version__",
     "AutoBatcher",
     "Client",
     "Context",

--- a/google/cloud/ndb/version.py
+++ b/google/cloud/ndb/version.py
@@ -1,0 +1,15 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+__version__ = "2.2.2"

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,19 @@
 
 import io
 import os
+import re
 
 import setuptools
 
+
+PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))
+
+version = None
+
+with open(os.path.join(PACKAGE_ROOT, "google/cloud/ndb/version.py")) as fp:
+    version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
+    assert len(version_candidates) == 1
+    version = version_candidates[0]
 
 def main():
     package_root = os.path.abspath(os.path.dirname(__file__))
@@ -36,7 +46,7 @@ def main():
 
     setuptools.setup(
         name="google-cloud-ndb",
-        version = "2.2.2",
+        version = version,
         description="NDB library for Google Cloud Datastore",
         long_description=readme,
         long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR migrates from using a hardcoded version in `setup.py` to a version module to make it easy to query the current version of `google-cloud-ndb`

```
(py39) partheniou@partheniou-vm-3:~/git/python-ndb$ python3
Python 3.9.16 (main, Mar  2 2023, 17:52:22) 
[GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import google.cloud.ndb
>>> google.cloud.ndb.__version__
'2.2.2'
```