### PR TITLE
docs: Fix a mistaken ID description

### DIFF
--- a/google/cloud/ndb/key.py
+++ b/google/cloud/ndb/key.py
@@ -636,7 +636,7 @@ class Key(object):
         return self._key.name
 
     def integer_id(self):
-        """The string ID in the last ``(kind, id)`` pair, if any.
+        """The integer ID in the last ``(kind, id)`` pair, if any.
 
         .. doctest:: key-integer-id
 


### PR DESCRIPTION
It appears that the initial line of the `integer_id()` docstring was not updated after being copied from the `string_id()` docstring.