### PR TITLE
Set grpc override limits for emulator channel.

### DIFF
--- a/google/cloud/ndb/client.py
+++ b/google/cloud/ndb/client.py
@@ -20,8 +20,8 @@ import os
 import requests
 
 import google.api_core.client_options
-
 from google.api_core.gapic_v1 import client_info
+from google.auth.credentials import AnonymousCredentials  # type: ignore
 from google.cloud import environment_vars
 from google.cloud import _helpers
 from google.cloud import client as google_client
@@ -147,7 +147,13 @@ class Client(google_client.ClientWithProject):
             )
 
         if emulator:
-            channel = grpc.insecure_channel(self.host)
+            channel = grpc.insecure_channel(
+                self.host,
+                options=[
+                    # Default options provided in DatastoreGrpcTransport, but not when we override the channel.
+                    ("grpc.max_send_message_length", -1),
+                    ("grpc.max_receive_message_length", -1),
+                ])
         else:
             user_agent = self.client_info.to_user_agent()
             channel = _helpers.make_secure_channel(

--- a/tests/system/test_crud.py
+++ b/tests/system/test_crud.py
@@ -402,6 +402,24 @@ def test_parallel_threads(dispose_of, database_id, namespace):
 
 
 @pytest.mark.usefixtures("client_context")
+def test_large_rpc_lookup(dispose_of, ds_client):
+    class SomeKind(ndb.Model):
+        foo = ndb.TextProperty()
+
+    foo = 'a' * (500*1024)
+
+    keys = []
+    for i in range(15):
+        key = SomeKind(foo=foo).put()
+        dispose_of(key._key)
+        keys.append(key)
+
+    retrieved = ndb.get_multi(keys)
+    for entity in retrieved:
+        assert entity.foo == foo
+
+
+@pytest.mark.usefixtures("client_context")
 def test_large_json_property(dispose_of, ds_client):
     class SomeKind(ndb.Model):
         foo = ndb.JsonProperty()


### PR DESCRIPTION
The production path uses a channel builder which overrides the send/message length limits.

This applies the same options for the channel created for the emulator.