### PR TITLE
fix: support polymodels with equal names but different roots (#961)

### DIFF
--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -557,7 +557,11 @@ def _entity_from_ds_entity(ds_entity, model_class=None):
         if not isinstance(class_key, list):
             kind = class_key
         else:
-            kind = class_key[-1]
+            poly_model_class = Model._class_map.get(tuple(class_key))
+            if not model_class and poly_model_class:
+                model_class = poly_model_class
+            else:
+                kind = class_key[-1]
     else:
         kind = ds_entity.kind
 
@@ -4877,6 +4881,7 @@ class Model(_NotEqualMixin, metaclass=MetaModel):
     _properties = None
     _has_repeated = False
     _kind_map = {}  # Dict mapping {kind: Model subclass}
+    _class_map = {}  # Map class key -> suitable subclass (populated by PolyModel)
 
     # Defaults for instance variables.
     _entity_key = None

--- a/google/cloud/ndb/polymodel.py
+++ b/google/cloud/ndb/polymodel.py
@@ -184,8 +184,6 @@ class PolyModel(model.Model):
 
     class_ = _ClassKeyProperty()
 
-    _class_map = {}  # Map class key -> suitable subclass.
-
     @classmethod
     def _update_kind_map(cls):
         """Override; called by Model._fix_up_properties().
@@ -193,8 +191,7 @@ class PolyModel(model.Model):
         Update the kind map as well as the class map, except for PolyModel
         itself (its class key is empty).  Note that the kind map will
         contain entries for all classes in a PolyModel hierarchy; they all
-        have the same kind, but different class names.  PolyModel class
-        names, like regular Model class names, must be globally unique.
+        have the same kind, but different class names.
         """
         cls._kind_map[cls._class_name()] = cls
         class_key = cls._class_key()

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -5798,6 +5798,47 @@ class Test_entity_from_ds_entity:
         assert entity.bar == "himom!"
         assert entity.class_ == ["Cat"]
 
+    @staticmethod
+    @pytest.mark.usefixtures("in_context")
+    def test_polymodel_equal_names_different_bases():
+        def inherit_cat(base):
+            class Cat(base):
+                data = model.StringProperty()
+            return Cat
+        
+        class Animal(polymodel.PolyModel):
+            foo = model.IntegerProperty()
+
+        class Command(polymodel.PolyModel):
+            bar = model.StringProperty()
+
+        CatAnimal = inherit_cat(Animal)
+        CatCommand = inherit_cat(Command)
+
+        animal_key = datastore.Key("Animal", 123, project="testing")
+        datastore_entity = datastore.Entity(key=animal_key)
+        datastore_entity.update(
+            {"foo": 42, "data": "meow!", "class": ["Animal", "Cat"]}
+        )
+
+        entity = model._entity_from_ds_entity(datastore_entity)
+        assert isinstance(entity, CatAnimal)
+        assert entity.foo == 42
+        assert entity.data == "meow!"
+        assert entity.class_ == ["Animal", "Cat"]
+
+        command_key = datastore.Key("Command", 456, project="testing")
+        datastore_entity = datastore.Entity(key=command_key)
+        datastore_entity.update(
+            {"bar": "42", "data": "config.conf", "class": ["Command", "Cat"]}
+        )
+
+        entity = model._entity_from_ds_entity(datastore_entity)
+        assert isinstance(entity, CatCommand)
+        assert entity.bar == "42"
+        assert entity.data == "config.conf"
+        assert entity.class_ == ["Command", "Cat"]
+
 
 class Test_entity_to_protobuf:
     @staticmethod


### PR DESCRIPTION
In the new version of NDB a breaking requirement/implementation has been added requiring all the polymodel leaves to have unique names. There is no technical limitation for this requirement either on client or server side. So, by the introduction of this requirement we make it unable for the clients with legacy data to retrieve their models written by `appengine.ext.ndb`.
Interestingly enough, currently there is an unused class property `PolyModel._class_map` which is populated by it but is never read. On the other side we have `model._entity_from_ds_entity` that discards the rest of the `class_key` passed to it, taking just just the last element and looking it as if it were an ordinary model. These two shortcomings are as if calling for each other - an unused property and a client using incomplete data.
This PR fixes this inconsistency and re-enables the ability to read and write polymodels with equal names if their class_keys are different. For this purpose the `_class_map` property is moved to `Model` class so that it can read from it. I avoided introduction of a function for accessing it, because unlike `lookup_kind` this function should not raise an exception if the model is not found. Anyhow, it is requested during the review, I will add a wrapper function along with its tests or perform any other changes more persistent to the design of the library.  