### PR TITLE
fix: enable filtering on UserProperty fields

### DIFF
--- a/google/cloud/ndb/_datastore_query.py
+++ b/google/cloud/ndb/_datastore_query.py
@@ -81,6 +81,13 @@ def make_filter(name, op, value):
         op=FILTER_OPERATORS[op],
     )
     helpers._set_protobuf_value(filter_pb.value._pb, value)
+
+    # Handle UserProperty meanings which are stored at the entity's top level,
+    # not within individual property values. This ensures proper meaning propagation
+    # when filtering on UserProperty fields.
+    if hasattr(value, "_meanings"):
+        helpers._set_pb_meaning_from_entity(value, name, value, filter_pb.value._pb)
+
     return filter_pb
 
 

--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -3471,6 +3471,17 @@ class UserProperty(Property):
         if auto_current_user_add is not None:
             raise exceptions.NoLongerImplementedError()
 
+    def _comparison(self, op, value):
+        query = super(UserProperty, self)._comparison(op, value)
+        # Assign _MEANING_PREDEFINED_ENTITY_USER to the property's meaning dictionary
+        # This special meaning designation is crucial for enabling filter queries on userProperty
+        # Without this meaning, the datastore would not properly recognize user-related filters
+        # in queries. This ensures the outer layer of userProperty is correctly marked as a
+        # predefined user entity type for query operations
+        query._value._meanings = {self._name: (_MEANING_PREDEFINED_ENTITY_USER, query._value)}
+
+        return query
+
     def _validate(self, value):
         """Validate a ``value`` before setting it.
 


### PR DESCRIPTION
## Description

This PR fixes an issue where filtering queries on UserProperty fields was not working. The root cause was that the `_MEANING_PREDEFINED_ENTITY_USER` meaning was not being properly set at the entity's top level during query filter creation.

In the Google Datastore, UserProperty meanings are stored at the entity's top level rather than within individual property values. This PR adds the necessary handling to ensure the meaning is correctly propagated when creating filters for UserProperty fields.

## Changes

- Added `_comparison` method to `UserProperty` class to set the proper meaning during filter creation
- Added documentation to clarify the special handling of UserProperty meanings at the entity level

## Testing

To reproduce and verify the fix:

```python
import os
import sys
from google.appengine.api import users
from google.cloud import ndb

class TestModel(ndb.Model):
    owner = ndb.UserProperty()


def init_ndb():
    os.environ["AUTH_DOMAIN"] = "ikala.ai"
    
    ndb_client = ndb.Client(project="cloud-sa-sandbox-1")
    return ndb_client


def test_get_user_data():
    ndb_client = init_ndb()
    with ndb_client.context():
        user = users.User(email="test@test.com")
        test_model = TestModel(owner=user)
        test_model.put()

        # Before the fix: This query would not work properly
        # After the fix: This query correctly filters by user
        query = TestModel.query().filter(TestModel.owner == user)
        result = query.get()


if __name__ == "__main__":
    test_get_user_data()
```

