### PR TITLE
fix: support sub-meanings for datastore v2.20.3

### DIFF
--- a/google/cloud/ndb/key.py
+++ b/google/cloud/ndb/key.py
@@ -716,13 +716,13 @@ class Key(object):
             >>> key = ndb.Key("Trampoline", 88, project="xy", database="wv", namespace="zt")
             >>> key.reference()
             app: "xy"
-            name_space: "zt"
             path {
               element {
                 type: "Trampoline"
                 id: 88
               }
             }
+            name_space: "zt"
             database_id: "wv"
             <BLANKLINE>
         """

--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -2698,14 +2698,26 @@ class BlobProperty(Property):
         Need to check the ds_entity for a compressed meaning that would
         indicate we are getting a compressed value.
         """
-        if self._name in ds_entity._meanings:
-            meaning = ds_entity._meanings[self._name][0]
-            if meaning == _MEANING_COMPRESSED and not self._compressed:
-                if self._repeated:
-                    for sub_value in value:
+        if self._name in ds_entity._meanings and not self._compressed:
+            root_meaning = ds_entity._meanings[self._name][0]
+            sub_meanings = None
+            # meaning may be a tuple. Attempt unwrap
+            if isinstance(root_meaning, tuple):
+                root_meaning, sub_meanings = root_meaning
+            # decompress values if needed
+            if root_meaning == _MEANING_COMPRESSED and not self._repeated:
+                value.b_val = zlib.decompress(value.b_val)
+            elif root_meaning == _MEANING_COMPRESSED and self._repeated:
+                for sub_value in value:
+                    sub_value.b_val = zlib.decompress(sub_value.b_val)
+            elif sub_meanings and self._repeated:
+                for idx, sub_value in enumerate(value):
+                    try:
+                        sub_value_meaning = sub_meanings[idx]
+                    except IndexError: 
+                        sub_value_meaning = None
+                    if sub_value_meaning == _MEANING_COMPRESSED:
                         sub_value.b_val = zlib.decompress(sub_value.b_val)
-                else:
-                    value.b_val = zlib.decompress(value.b_val)
         return value
 
     def _db_set_compressed_meaning(self, p):

--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -2710,7 +2710,7 @@ class BlobProperty(Property):
             elif root_meaning == _MEANING_COMPRESSED and self._repeated:
                 for sub_value in value:
                     sub_value.b_val = zlib.decompress(sub_value.b_val)
-            elif sub_meanings and isinstance(sub_meanings, list) and self._repeated:
+            elif isinstance(sub_meanings, list) and self._repeated:
                 for idx, sub_value in enumerate(value):
                     try:
                         if sub_meanings[idx] == _MEANING_COMPRESSED:

--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -2714,7 +2714,7 @@ class BlobProperty(Property):
                 for idx, sub_value in enumerate(value):
                     try:
                         sub_value_meaning = sub_meanings[idx]
-                    except IndexError: 
+                    except IndexError:
                         sub_value_meaning = None
                     if sub_value_meaning == _MEANING_COMPRESSED:
                         sub_value.b_val = zlib.decompress(sub_value.b_val)

--- a/google/cloud/ndb/model.py
+++ b/google/cloud/ndb/model.py
@@ -2710,14 +2710,14 @@ class BlobProperty(Property):
             elif root_meaning == _MEANING_COMPRESSED and self._repeated:
                 for sub_value in value:
                     sub_value.b_val = zlib.decompress(sub_value.b_val)
-            elif sub_meanings and self._repeated:
+            elif sub_meanings and isinstance(sub_meanings, list) and self._repeated:
                 for idx, sub_value in enumerate(value):
                     try:
-                        sub_value_meaning = sub_meanings[idx]
+                        if sub_meanings[idx] == _MEANING_COMPRESSED:
+                            sub_value.b_val = zlib.decompress(sub_value.b_val)
                     except IndexError:
-                        sub_value_meaning = None
-                    if sub_value_meaning == _MEANING_COMPRESSED:
-                        sub_value.b_val = zlib.decompress(sub_value.b_val)
+                        # value list size exceeds sub_meanings list
+                        break
         return value
 
     def _db_set_compressed_meaning(self, p):

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def main():
         readme = readme_file.read()
     dependencies = [
         "google-api-core[grpc] >= 1.34.0, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
-        "google-cloud-datastore >= 2.16.0, < 3.0.0dev",
+        "google-cloud-datastore >= 2.16.0, != 2.20.2, < 3.0.0dev",
         "protobuf >= 3.20.2, <6.0.0dev,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
         "pymemcache >= 2.1.0, < 5.0.0dev",
         "pytz >= 2018.3",

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -1968,7 +1968,9 @@ class TestBlobProperty:
         ],
     )
     @pytest.mark.usefixtures("in_context")
-    def test__from_datastore_compressed_repeated_to_compressed_tuple_meaning(self, meaning):
+    def test__from_datastore_compressed_repeated_to_compressed_tuple_meaning(
+        self, meaning
+    ):
         class ThisKind(model.Model):
             foo = model.BlobProperty(compressed=True, repeated=True)
 
@@ -2031,7 +2033,9 @@ class TestBlobProperty:
         ],
     )
     @pytest.mark.usefixtures("in_context")
-    def test__from_datastore_compressed_repeated_to_uncompressed_tuple_meaning(self, meaning):
+    def test__from_datastore_compressed_repeated_to_uncompressed_tuple_meaning(
+        self, meaning
+    ):
         class ThisKind(model.Model):
             foo = model.BlobProperty(compressed=False, repeated=True)
 

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -1929,12 +1929,8 @@ class TestBlobProperty:
         ds_entity = model._entity_to_ds_entity(entity)
         assert ds_entity["foo"] == compressed_value
 
-    @pytest.mark.skipif(
-        [int(v) for v in datastore.__version__.split(".")] >= [2, 20, 2],
-        reason="uses meanings semantics from datastore v2.20.1 and lower",
-    )
     @pytest.mark.usefixtures("in_context")
-    def test__from_datastore_compressed_repeated_to_compressed_legacy(self):
+    def test__from_datastore_compressed_repeated_to_compressed(self):
         class ThisKind(model.Model):
             foo = model.BlobProperty(compressed=True, repeated=True)
 
@@ -1972,7 +1968,7 @@ class TestBlobProperty:
         ],
     )
     @pytest.mark.usefixtures("in_context")
-    def test__from_datastore_compressed_repeated_to_compressed(self, meaning):
+    def test__from_datastore_compressed_repeated_to_compressed_tuple_meaning(self, meaning):
         class ThisKind(model.Model):
             foo = model.BlobProperty(compressed=True, repeated=True)
 
@@ -1996,12 +1992,8 @@ class TestBlobProperty:
         ds_entity = model._entity_to_ds_entity(entity)
         assert ds_entity["foo"] == [compressed_value_one, compressed_value_two]
 
-    @pytest.mark.skipif(
-        [int(v) for v in datastore.__version__.split(".")] >= [2, 20, 2],
-        reason="uses meanings semantics from datastore v2.20.1 and lower",
-    )
     @pytest.mark.usefixtures("in_context")
-    def test__from_datastore_compressed_repeated_to_uncompressed_legacy(self):
+    def test__from_datastore_compressed_repeated_to_uncompressed(self):
         class ThisKind(model.Model):
             foo = model.BlobProperty(compressed=False, repeated=True)
 
@@ -2039,7 +2031,7 @@ class TestBlobProperty:
         ],
     )
     @pytest.mark.usefixtures("in_context")
-    def test__from_datastore_compressed_repeated_to_uncompressed(self, meaning):
+    def test__from_datastore_compressed_repeated_to_uncompressed_tuple_meaning(self, meaning):
         class ThisKind(model.Model):
             foo = model.BlobProperty(compressed=False, repeated=True)
 

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -1930,12 +1930,11 @@ class TestBlobProperty:
         assert ds_entity["foo"] == compressed_value
 
     @pytest.mark.skipif(
-        [int(v) for v in datastore.__version__.split(".")] < [2, 20, 2],
+        [int(v) for v in datastore.__version__.split(".")] >= [2, 20, 2],
         reason="uses meanings semantics from datastore v2.20.1 and lower",
     )
-    @staticmethod
     @pytest.mark.usefixtures("in_context")
-    def test__from_datastore_compressed_repeated_to_compressed_legacy():
+    def test__from_datastore_compressed_repeated_to_compressed_legacy(self):
         class ThisKind(model.Model):
             foo = model.BlobProperty(compressed=True, repeated=True)
 
@@ -1960,22 +1959,18 @@ class TestBlobProperty:
         assert ds_entity["foo"] == [compressed_value_one, compressed_value_two]
 
     @pytest.mark.skipif(
-        [int(v) for v in datastore.__version__.split(".")] >= [2, 20, 2],
+        [int(v) for v in datastore.__version__.split(".")] < [2, 20, 2],
         reason="uses meanings semantics from datastore v2.20.2 and later",
     )
     @pytest.mark.parametrize(
         "meaning",
         [
             (model._MEANING_COMPRESSED, None),  # set root meaning
-            (
-                None,
-                [model._MEANING_COMPRESSED, model._MEANING_COMPRESSED],
-            ),  # set sub-meanings
+            (None, [model._MEANING_COMPRESSED] * 2),  # set sub-meanings
         ],
     )
-    @staticmethod
     @pytest.mark.usefixtures("in_context")
-    def test__from_datastore_compressed_repeated_to_compressed(meaning):
+    def test__from_datastore_compressed_repeated_to_compressed(self, meaning):
         class ThisKind(model.Model):
             foo = model.BlobProperty(compressed=True, repeated=True)
 
@@ -2000,12 +1995,11 @@ class TestBlobProperty:
         assert ds_entity["foo"] == [compressed_value_one, compressed_value_two]
 
     @pytest.mark.skipif(
-        [int(v) for v in datastore.__version__.split(".")] < [2, 20, 2],
+        [int(v) for v in datastore.__version__.split(".")] >= [2, 20, 2],
         reason="uses meanings semantics from datastore v2.20.1 and lower",
     )
-    @staticmethod
     @pytest.mark.usefixtures("in_context")
-    def test__from_datastore_compressed_repeated_to_uncompressed_legacy(meaning):
+    def test__from_datastore_compressed_repeated_to_uncompressed_legacy(self):
         class ThisKind(model.Model):
             foo = model.BlobProperty(compressed=False, repeated=True)
 
@@ -2030,22 +2024,18 @@ class TestBlobProperty:
         assert ds_entity["foo"] == [uncompressed_value_one, uncompressed_value_two]
 
     @pytest.mark.skipif(
-        [int(v) for v in datastore.__version__.split(".")] >= [2, 20, 2],
+        [int(v) for v in datastore.__version__.split(".")] < [2, 20, 2],
         reason="uses meanings semantics from datastore v2.20.2 and later",
     )
     @pytest.mark.parametrize(
         "meaning",
         [
             (model._MEANING_COMPRESSED, None),  # set root meaning
-            (
-                None,
-                [model._MEANING_COMPRESSED, model._MEANING_COMPRESSED],
-            ),  # set sub-meanings
+            (None, [model._MEANING_COMPRESSED] * 2),  # set sub-meanings
         ],
     )
-    @staticmethod
     @pytest.mark.usefixtures("in_context")
-    def test__from_datastore_compressed_repeated_to_uncompressed(meaning):
+    def test__from_datastore_compressed_repeated_to_uncompressed(self, meaning):
         class ThisKind(model.Model):
             foo = model.BlobProperty(compressed=False, repeated=True)
 
@@ -2070,15 +2060,15 @@ class TestBlobProperty:
         assert ds_entity["foo"] == [uncompressed_value_one, uncompressed_value_two]
 
     @pytest.mark.skipif(
-        [int(v) for v in datastore.__version__.split(".")] >= [2, 20, 2],
-        reason="uses meanings semantics from datastore v2.20.2 and later"
+        [int(v) for v in datastore.__version__.split(".")] < [2, 20, 2],
+        reason="uses meanings semantics from datastore v2.20.2 and later",
     )
-    @staticmethod
     @pytest.mark.usefixtures("in_context")
-    def test__from_datastore_compressed_repeated_to_uncompressed_mixed_meaning():
+    def test__from_datastore_compressed_repeated_to_uncompressed_mixed_meaning(self):
         """
         One item is compressed, one uncompressed
         """
+
         class ThisKind(model.Model):
             foo = model.BlobProperty(compressed=False, repeated=True)
 

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -2155,8 +2155,7 @@ class TestBlobProperty:
         try calling _from_datastore with a meaning list smaller than the value list
         """
 
-        prop = model.BlobProperty(compressed=False, repeated=True)
-        prop._name = "foo"
+        prop = model.BlobProperty(compressed=False, repeated=True, name="foo")
 
         key = datastore.Key("ThisKind", 123, project="testing")
         datastore_entity = datastore.Entity(key=key)
@@ -2164,7 +2163,10 @@ class TestBlobProperty:
         compressed_value_one = zlib.compress(uncompressed_value_one)
         uncompressed_value_two = b"xyz" * 1000
         compressed_value_two = zlib.compress(uncompressed_value_two)
-        compressed_value = [model._BaseValue(compressed_value_one), model._BaseValue(compressed_value_two)]
+        compressed_value = [
+            model._BaseValue(compressed_value_one),
+            model._BaseValue(compressed_value_two),
+        ]
         datastore_entity.update({"foo": compressed_value})
         meanings = {
             "foo": (


### PR DESCRIPTION
[Datastore v2.20.2](https://github.com/googleapis/python-datastore/releases/tag/v2.20.2) made a change to how the meaning field for lists is recorded. Previously, the meaning field was saved for each element in the array, but the array itself wouldn't have a root meaning recorded. After v2.20.2, the meaning was stored as a tuple of `(root_meaning, sub_meaning_list)`

This PR fixed the ndb library's meaning parser to support both the new and old formats, and adds tests for both formats

Fixes https://github.com/googleapis/python-ndb/issues/1006, https://github.com/googleapis/python-ndb/issues/1005