### PR TITLE
chore: librarian release pull request: 20251113T151712Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,8 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:97c3041de740f26b132d3c5d43f0097f990e8b0d1f2e6707054840024c20ab0c
 libraries:
   - id: google-cloud-ndb
-    version: 2.3.4
+    version: 2.4.0
+    last_generated_commit: ""
     apis: []
     source_roots:
       - .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/google-cloud-ndb/#history
 
+## [2.4.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-ndb-v2.3.4...google-cloud-ndb-v2.4.0) (2025-11-13)
+
+
+### Features
+
+* Add support for Python 3.14 (#1028) ([947ff9b73c516f18b0411b828d45eb4bd8b95d39](https://github.com/googleapis/google-cloud-python/commit/947ff9b73c516f18b0411b828d45eb4bd8b95d39))
+
 ## [2.3.4](https://github.com/googleapis/python-ndb/compare/v2.3.3...v2.3.4) (2025-06-11)
 
 

--- a/google/cloud/ndb/version.py
+++ b/google/cloud/ndb/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.3.4"
+__version__ = "2.4.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v1.0.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:97c3041de740f26b132d3c5d43f0097f990e8b0d1f2e6707054840024c20ab0c
<details><summary>google-cloud-ndb: 2.4.0</summary>

## [2.4.0](https://github.com/googleapis/python-ndb/compare/v2.3.4...v2.4.0) (2025-11-13)

### Features

* Add support for Python 3.14 (#1028) ([947ff9b7](https://github.com/googleapis/python-ndb/commit/947ff9b7))

</details>