### PR TITLE
chore: replace old python teams with cloud-sdk-python-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # These are the default owners
-*                     @googleapis/api-datastore-sdk @googleapis/yoshi-python
+*                     @googleapis/api-datastore-sdk @googleapis/cloud-sdk-python-team


### PR DESCRIPTION
Bug ID: b/479543683